### PR TITLE
Fix #30

### DIFF
--- a/producer/src/test/kotlin/streams/serialization/JacksonUtilTest.kt
+++ b/producer/src/test/kotlin/streams/serialization/JacksonUtilTest.kt
@@ -1,27 +1,30 @@
 package streams.serialization
 
-import org.apache.commons.lang3.StringUtils
 import org.junit.Test
 import org.neo4j.values.storable.CoordinateReferenceSystem.*
-import org.neo4j.values.storable.DateTimeValue.*
-import org.neo4j.values.storable.DateValue.*
-import org.neo4j.values.storable.TimeValue.*
-import org.neo4j.values.storable.Values.*
-import java.time.ZoneOffset.*
+import org.neo4j.values.storable.DateTimeValue.datetime
+import org.neo4j.values.storable.DateValue.date
+import org.neo4j.values.storable.TimeValue.time
+import org.neo4j.values.storable.Values.pointValue
+import java.time.ZoneOffset.UTC
 import kotlin.test.assertEquals
 
-class JacksoUtilTest {
+class JacksonUtilTest {
 
     @Test
     fun shouldSerializeGeometryAndTemporalDataTypes() {
         // Given
-        val expected = "{\"point2d\":{\"coordinates\":[1.0,2.0],\"crs\":{\"name\":\"cartesian\",\"table\":\"SR_ORG\",\"code\":7203,\"href\":\"http://spatialreference.org/ref/sr-org/7203/\",\"dimension\":2,\"geographic\":false,\"calculator\":{},\"type\":\"cartesian\"}}," +
-                "\"point3d\":{\"coordinates\":[1.0,2.0,3.0],\"crs\":{\"name\":\"cartesian-3d\",\"table\":\"SR_ORG\",\"code\":9157,\"href\":\"http://spatialreference.org/ref/sr-org/9157/\",\"dimension\":3,\"geographic\":false,\"calculator\":{},\"type\":\"cartesian-3d\"}}," +
+        val expected = "{\"point2dCartesian\":{\"crs\":\"cartesian\",\"x\":1.0,\"y\":2.0,\"z\":null}," +
+                "\"point3dCartesian\":{\"crs\":\"cartesian-3d\",\"x\":1.0,\"y\":2.0,\"z\":3.0}," +
+                "\"point2dWgs84\":{\"crs\":\"wgs-84\",\"latitude\":1.0,\"longitude\":2.0,\"height\":null}," +
+                "\"point3dWgs84\":{\"crs\":\"wgs-84-3d\",\"latitude\":1.0,\"longitude\":2.0,\"height\":3.0}," +
                 "\"time\":\"14:00:00Z\",\"dateTime\":\"2017-12-17T17:14:35.123456789Z\"}"
-        val map = linkedMapOf<String, Any>("point2d" to pointValue(Cartesian, 1.0, 2.0 ),
-                "point3d" to pointValue(Cartesian_3D, 1.0, 2.0, 3.0 ),
-                "time" to time( 14, 0, 0, 0, UTC ),
-                "dateTime" to datetime(date( 2017, 12, 17 ), time( 17, 14, 35, 123456789, UTC)))
+        val map = linkedMapOf<String, Any>("point2dCartesian" to pointValue(Cartesian, 1.0, 2.0),
+                "point3dCartesian" to pointValue(Cartesian_3D, 1.0, 2.0, 3.0),
+                "point2dWgs84" to pointValue(WGS84, 1.0, 2.0),
+                "point3dWgs84" to pointValue(WGS84_3D, 1.0, 2.0, 3.0),
+                "time" to time( 14, 0, 0, 0, UTC),
+                "dateTime" to datetime(date( 2017, 12, 17), time( 17, 14, 35, 123456789, UTC)))
 
         // When
         val jsonString = JacksonUtil.getMapper().writeValueAsString(map)


### PR DESCRIPTION
We manage 2 different data structures for point type:

```
{"crs": "cartesian|cartesian-3d", "x": 1.1, "y": 13.4, "z": 3.1}
{"crs": "wgs-84|wgs-84-3d", "latitude": 13.1, "longitude": 13.4, "height": 1.1}
```