### PR TITLE
fixes #84: Add a stream.publish(topic, payload) procedure

### DIFF
--- a/consumer/src/main/kotlin/streams/StreamsEventSinkQueryExecution.kt
+++ b/consumer/src/main/kotlin/streams/StreamsEventSinkQueryExecution.kt
@@ -13,7 +13,6 @@ class StreamsEventSinkQueryExecution(private val streamsTopicService: StreamsTop
             return
         }
         if(log.isDebugEnabled){
-
             log.debug("Processing ${params.size} events from Kafka")
         }
         db.execute("$UNWIND $cypherQuery", mapOf("events" to params)).close()

--- a/consumer/src/main/kotlin/streams/kafka/KafkaEventSink.kt
+++ b/consumer/src/main/kotlin/streams/kafka/KafkaEventSink.kt
@@ -27,7 +27,7 @@ class KafkaEventSink: StreamsEventSink {
 
     private lateinit var job: Job
     private lateinit var queryExecution: StreamsEventSinkQueryExecution
-    private lateinit var kafkaConsumer: KafkaConsumer<Long, ByteArray>
+    private lateinit var kafkaConsumer: KafkaConsumer<String, ByteArray>
 
     override var streamsTopicService: StreamsTopicService? = null
 
@@ -84,7 +84,7 @@ class KafkaEventSink: StreamsEventSink {
         }
     }
 
-    private fun consume(records: ConsumerRecords<Long, ByteArray>) {
+    private fun consume(records: ConsumerRecords<String, ByteArray>) {
         streamsTopicService!!.getTopics().forEach {
             if (log.isDebugEnabled) {
                 log.debug("Reading data from topic $it")

--- a/consumer/src/main/kotlin/streams/kafka/KafkaSinkConfiguration.kt
+++ b/consumer/src/main/kotlin/streams/kafka/KafkaSinkConfiguration.kt
@@ -3,6 +3,7 @@ package streams.kafka
 import org.apache.kafka.clients.consumer.ConsumerConfig
 import org.apache.kafka.common.serialization.ByteArrayDeserializer
 import org.apache.kafka.common.serialization.LongDeserializer
+import org.apache.kafka.common.serialization.StringDeserializer
 import org.codehaus.jackson.map.ObjectMapper
 import org.neo4j.kernel.configuration.Config
 import streams.StreamsSinkConfiguration
@@ -67,7 +68,7 @@ data class KafkaSinkConfiguration(val zookeeperConnect: String = "localhost:2181
 
     private fun addDeserializers() : Properties {
         val props = Properties()
-        props[ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG] = LongDeserializer::class.java
+        props[ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG] = StringDeserializer::class.java
         props[ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG] = ByteArrayDeserializer::class.java
         return props
     }

--- a/doc/asciidoc/producer/index.adoc
+++ b/doc/asciidoc/producer/index.adoc
@@ -28,9 +28,9 @@ This procedure allows custom message streaming from Neo4j to the configured envi
 
 Uses:
 
-`CALL streams.publish('my-topic', 'Hello World from Neo4j!`')`
+`CALL streams.publish('my-topic', 'Hello World from Neo4j!')`
 
-The message retrived from the Consumer is the following:
+The message retrieved from the Consumer is the following:
 
 `{"payload":"Hello world from Neo4j!"}`
 
@@ -52,6 +52,7 @@ Input Parameters:
 
 |===
 
+You can send any kind of data in the payload, nodes, relationships, paths, lists, maps, scalar values and nested versions thereof.
 
 === Transaction Event Handler
 

--- a/doc/asciidoc/producer/index.adoc
+++ b/doc/asciidoc/producer/index.adoc
@@ -41,8 +41,7 @@ Input Parameters:
 |Variable Name
 |Type
 |Description
-`
-|`topic
+|`topic`
 |String
 |The topic where you want to publish the data
 

--- a/doc/asciidoc/producer/index.adoc
+++ b/doc/asciidoc/producer/index.adoc
@@ -22,7 +22,7 @@ If you are using them via Docker, pass this simple environment parameter:
  NEO4J_dbms_security_procedures_unrestricted: streams.*
 
 
-== streams.publish
+==== streams.publish
 
 This procedure allows custom message streaming from Neo4j to the configured environment
 

--- a/doc/asciidoc/producer/index.adoc
+++ b/doc/asciidoc/producer/index.adoc
@@ -10,7 +10,54 @@ include::configuration.adoc[]
 
 include::patterns.adoc[]
 
-=== Events
+=== Procedures
+
+The producer comes out with a list of procedures.
+Because of they use internal Neo4j API you must allow them with the following configuration paramater
+
+ dbms.security.procedures.unrestricted=streams.*
+
+If you are using them via Docker, pass this simple environment parameter:
+
+ NEO4J_dbms_security_procedures_unrestricted: streams.*
+
+
+== streams.publish
+
+This procedure allows custom message streaming from Neo4j to the configured environment
+
+Uses:
+
+`CALL streams.publish('my-topic', 'Hello World from Neo4j!`')`
+
+The message retrived from the Consumer is the following:
+
+`{"payload":"Hello world from Neo4j!"}`
+
+Input Parameters:
+
+[cols="3*",options="header"]
+|===
+|Variable Name
+|Type
+|Description
+`
+|`topic
+|String
+|The topic where you want to publish the data
+
+|`payload`
+|Object
+|The data that you want to stream
+
+|===
+
+
+=== Transaction Event Handler
+
+The transaction event handler is the core of the Stream Producer and allows to stream database changes.
+
+==== Events
 
 The Producer streams three kind of events:
 
@@ -18,7 +65,7 @@ The Producer streams three kind of events:
 * *updated*: when a node/relation/property is updated
 * *deleted*: when a node/relation/property is deleted
 
-==== Created
+===== Created
 
 Following an example of the node creation event:
 
@@ -30,7 +77,7 @@ include::data/node.created.json[]
 include::data/relationship.created.json[]
 ```
 
-==== Updated
+===== Updated
 
 Following an example of the node update event:
 
@@ -42,7 +89,7 @@ include::data/node.updated.json[]
 include::data/relationship.updated.json[]
 ```
 
-==== Deleted
+===== Deleted
 
 Following an example of the node creation event:
 
@@ -54,7 +101,7 @@ include::data/node.deleted.json[]
 include::data/relationship.deleted.json[]
 ```
 
-=== Meta
+==== Meta
 
 The *meta* field contains the metadata related to the transaction event:
 
@@ -93,7 +140,7 @@ The *meta* field contains the metadata related to the transaction event:
 |Contains the information about the source
 |===
 
-==== Source
+===== Source
 
 [cols="3*",options="header"]
 |===
@@ -107,7 +154,7 @@ The *meta* field contains the metadata related to the transaction event:
 |===
 
 
-=== Payload
+==== Payload
 
 The *payload* field contains the information about the the data related to the event
 
@@ -134,11 +181,11 @@ The *payload* field contains the information about the the data related to the e
 |The data after the transaction event
 |===
 
-==== Payload: before and after
+===== Payload: before and after
 
 We must distinguish two cases:
 
-===== Nodes
+====== Nodes
 
 [cols="3*",options="header"]
 |===
@@ -155,7 +202,7 @@ We must distinguish two cases:
 |List of properties attached to the node, the Key is the property name
 |===
 
-===== Relationships
+====== Relationships
 
 [cols="3*",options="header"]
 |===
@@ -198,7 +245,7 @@ We must distinguish two cases:
 |===
 
 
-=== Schema
+==== Schema
 
 [cols="3*",options="header"]
 |===
@@ -215,7 +262,7 @@ We must distinguish two cases:
 |The schema after the transaction event
 |===
 
-==== Schema: before and after
+===== Schema: before and after
 
 [cols="3*",options="header"]
 |===
@@ -234,7 +281,7 @@ We must distinguish two cases:
 
 We must distinguish two cases:
 
-===== Nodes
+====== Nodes
 
 [cols="3*",options="header"]
 |===
@@ -253,8 +300,9 @@ We must distinguish two cases:
 
 ====== Constraints
 
-A node can have a list of constraints attached to it:
+Nodes and Relationships can have a list of constraints attached to them:
 
+.Node Constraints
 [cols="3*",options="header"]
 |===
 |Field
@@ -274,8 +322,7 @@ A node can have a list of constraints attached to it:
 |List of node properties involved in the constraint
 |===
 
-===== Relationships
-
+.Relationship constraints
 [cols="3*",options="header"]
 |===
 |Field

--- a/performance/README.md
+++ b/performance/README.md
@@ -45,7 +45,7 @@ The  creation query used by the tester:
 The acquisition query:
 
 ```properties
-streams.sink.topic.cypher.neo4j=WITH event.value.payload AS payload, event.value.meta AS meta CALL apoc.do.case( [\
+streams.sink.topic.cypher.neo4j=WITH event.payload AS payload, event.meta AS meta CALL apoc.do.case( [\
 
 payload.type = 'node' AND meta.operation = 'created', \
 
@@ -100,10 +100,10 @@ nodes = 1000
 To check the coniguration or to get a fast result you can run the command
 
 ```shell
-python3.6 neo4j-streams-pt.py --start
+python3 neo4j-streams-pt.py --start
 ```
 
-The output is a windows that show you the distribution of the test. See result session to better understand the values. You can use the option `--plot-out file.png` to not show the result but save it on file. The details of the execution are dumped on standard output as CSV or you can redirect it on file using the option `--csv-file file.csv`
+The output is a windows that show you the distribution of the test. See result session to better understand the values. You can use the option `--plot-out file.png` to not show the result but save it on file. The details of the execution are dumped on standard output as CSV or you can redirect it on file using the option `--csv-out file.csv`
 
 ### baseline
 
@@ -114,13 +114,13 @@ ES: 3 = 3 * 1000 if 1000 is the value configured as *nodes* in the *[unit]* part
 To get the same result of *start*:
 
 ```shell
-python3.6 neo4j-streams-pt.py --baseline 1
+python3 neo4j-streams-pt.py --baseline 1
 ```
 
 The get more distribution (real case):
 
 ```shell
-python3.6 neo4j-streams-pt.py --baseline 1 10 100 1000 --plot-out results.png
+python3 neo4j-streams-pt.py --baseline 1 10 100 1000 --plot-out results.png
 ```
 
 This means the tester execute 5 (if *repeat = 5*) times each series. A series is comped by 1k, 10k, 100k, 1000k nodes (if *nodes = 1000*)

--- a/performance/docker-compose.yml
+++ b/performance/docker-compose.yml
@@ -12,8 +12,8 @@ services:
       - "8474:7474"
       - "8687:7687"
     volumes:
-      - $HOME/app/neo4-streams/neo4j-community-3.4.7-producer/data:/data
-      - $HOME/app/neo4-streams/neo4j-community-3.4.7-producer/plugins:/plugins
+      - $HOME/app/neo4j-streams/neo4j-community-3.4.7-producer/data:/data
+      - $HOME/app/neo4j-streams/neo4j-community-3.4.7-producer/plugins:/plugins
     environment:
       NEO4J_kafka_zookeeper_connect: zookeeper:2181
       NEO4J_kafka_bootstrap_servers: broker:9092
@@ -32,15 +32,15 @@ services:
       - "7474:7474"
       - "7687:7687"
     volumes:
-      - $HOME/app/neo4-streams/neo4j-community-3.4.7-consumer/data:/data
-      - $HOME/app/neo4-streams/neo4j-community-3.4.7-consumer/plugins:/plugins
+      - $HOME/app/neo4j-streams/neo4j-community-3.4.7-consumer/data:/data
+      - $HOME/app/neo4j-streams/neo4j-community-3.4.7-consumer/plugins:/plugins
     environment:
       NEO4J_kafka_zookeeper_connect: zookeeper:2181
       NEO4J_kafka_bootstrap_servers: broker:9092
       NEO4J_AUTH: neo4j/consumer
       NEO4J_dbms_memory_heap_max__size: 2G
       NEO4J_kafka_max_poll_records: 16384
-      NEO4J_streams_sink_topic_cypher_neo4j: "WITH event.value.payload AS payload, event.value.meta AS meta CALL apoc.do.case( [
+      NEO4J_streams_sink_topic_cypher_neo4j: "WITH event.payload AS payload, event.meta AS meta CALL apoc.do.case( [
       payload.type = 'node' AND meta.operation = 'created', \
       'CREATE (x:Performance {received_time: apoc.date.currentTimestamp()}) SET x+=props RETURN count(x)'] 
       ,'RETURN 0', 

--- a/producer/src/main/kotlin/streams/Extensions.kt
+++ b/producer/src/main/kotlin/streams/Extensions.kt
@@ -1,0 +1,19 @@
+package streams
+
+import org.neo4j.graphdb.Node
+import org.neo4j.graphdb.Relationship
+import streams.events.EntityType
+import streams.events.RelationshipNodeChange
+
+fun Map<String,String>.getInt(name:String, defaultValue: Int) = this.get(name)?.toInt() ?: defaultValue
+
+fun Node.toMap(): Map<String, Any?> {
+    return mapOf("id" to id.toString(), "properties" to allProperties, "labels" to labelNames(), "type" to EntityType.node)
+}
+
+fun Relationship.toMap(): Map<String, Any?> {
+    return mapOf("id" to id.toString(), "properties" to allProperties, "label" to type,
+            "start" to RelationshipNodeChange(startNode.id.toString(), startNode.labelNames()),
+            "end" to RelationshipNodeChange(endNode.id.toString(), endNode.labelNames()),
+            "type" to EntityType.relationship)
+}

--- a/producer/src/main/kotlin/streams/StreamsEventRouter.kt
+++ b/producer/src/main/kotlin/streams/StreamsEventRouter.kt
@@ -7,7 +7,11 @@ import streams.events.StreamsEvent
 
 abstract class StreamsEventRouter(val logService: LogService?, val config: Config?) {
 
-    abstract fun sendEvents(events : List<StreamsEvent>)
+    abstract fun sendEvents(topic: String, transactionEvents: List<out StreamsEvent>)
+
+    abstract fun start()
+
+    abstract fun stop()
 
 }
 

--- a/producer/src/main/kotlin/streams/StreamsEventRouterConfiguration.kt
+++ b/producer/src/main/kotlin/streams/StreamsEventRouterConfiguration.kt
@@ -1,0 +1,36 @@
+package streams
+
+import org.apache.commons.lang3.StringUtils
+import streams.events.EntityType
+
+
+private fun <T> filterMap(config: Map<String, String>, routingPrefix: String): List<T> {
+    return config
+            .filterKeys { it.startsWith(routingPrefix) }
+            .flatMap { RoutingConfigurationFactory.getRoutingConfiguration(it.key.replace(routingPrefix, StringUtils.EMPTY) , it.value, EntityType.node) as List<T> }
+}
+
+private object StreamsRoutingConfigurationConstants {
+    const val NODE_ROUTING_KEY_PREFIX: String = "streams.source.topic.nodes."
+    const val REL_ROUTING_KEY_PREFIX: String = "streams.source.topic.relationships."
+    const val ENABLED = "streams.produce.enabled"
+}
+
+data class StreamsEventRouterConfiguration(val enabled: Boolean = true,
+                                           val nodeRouting: List<NodeRoutingConfiguration> = listOf(NodeRoutingConfiguration()),
+                                           val relRouting: List<RelationshipRoutingConfiguration> = listOf(RelationshipRoutingConfiguration())) {
+    companion object {
+        fun from(config: Map<String, String>): StreamsEventRouterConfiguration {
+            val nodeRouting = filterMap<NodeRoutingConfiguration>(config = config,
+                    routingPrefix = StreamsRoutingConfigurationConstants.NODE_ROUTING_KEY_PREFIX)
+
+            val relRouting = filterMap<RelationshipRoutingConfiguration>(config = config,
+                    routingPrefix = StreamsRoutingConfigurationConstants.REL_ROUTING_KEY_PREFIX)
+
+            val default = StreamsEventRouterConfiguration()
+            return default.copy(enabled = config.getOrDefault(StreamsRoutingConfigurationConstants.ENABLED, default.enabled).toString().toBoolean(),
+                    nodeRouting = if (nodeRouting.isEmpty()) default.nodeRouting else nodeRouting,
+                    relRouting = if (relRouting.isEmpty()) default.relRouting else relRouting)
+        }
+    }
+}

--- a/producer/src/main/kotlin/streams/StreamsEventRouterConfiguration.kt
+++ b/producer/src/main/kotlin/streams/StreamsEventRouterConfiguration.kt
@@ -1,13 +1,12 @@
 package streams
 
-import org.apache.commons.lang3.StringUtils
 import streams.events.EntityType
 
 
 private fun <T> filterMap(config: Map<String, String>, routingPrefix: String): List<T> {
     return config
             .filterKeys { it.startsWith(routingPrefix) }
-            .flatMap { RoutingConfigurationFactory.getRoutingConfiguration(it.key.replace(routingPrefix, StringUtils.EMPTY) , it.value, EntityType.node) as List<T> }
+            .flatMap { RoutingConfigurationFactory.getRoutingConfiguration(it.key.replace(routingPrefix, "") , it.value, EntityType.node) as List<T> }
 }
 
 private object StreamsRoutingConfigurationConstants {

--- a/producer/src/main/kotlin/streams/StreamsExtensionFactory.kt
+++ b/producer/src/main/kotlin/streams/StreamsExtensionFactory.kt
@@ -1,48 +1,61 @@
 package streams
 
 import org.neo4j.graphdb.Node
-import org.neo4j.helpers.Service
 import org.neo4j.kernel.configuration.Config
 import org.neo4j.kernel.extension.KernelExtensionFactory
+import org.neo4j.kernel.impl.core.EmbeddedProxySPI
+import org.neo4j.kernel.impl.core.GraphProperties
 import org.neo4j.kernel.impl.logging.LogService
 import org.neo4j.kernel.impl.spi.KernelContext
 import org.neo4j.kernel.internal.GraphDatabaseAPI
 import org.neo4j.kernel.lifecycle.Lifecycle
 import org.neo4j.kernel.lifecycle.LifecycleAdapter
 
-@Service.Implementation(KernelExtensionFactory::class)
-class StreamsExtensionFactory : KernelExtensionFactory<StreamsExtensionFactory.Dependencies>("Streams") {
-    private var txHandler: StreamsTransactionEventHandler? = null
-
+class StreamsExtensionFactory : KernelExtensionFactory<StreamsExtensionFactory.Dependencies>("StreamsProcedures") {
     override fun newInstance(context: KernelContext, dependencies: Dependencies): Lifecycle {
         val db = dependencies.graphdatabaseAPI()
         val log = dependencies.log()
         val configuration = dependencies.config()
-
-        return object : LifecycleAdapter() {
-
-            override fun start() {
-                var streamsLog = log.getUserLog(StreamsExtensionFactory::class.java)
-                try {
-                    val streamHandler = StreamsEventRouterFactory.getStreamsEventRouter(log, configuration)
-                    txHandler = StreamsTransactionEventHandler(streamHandler)
-                    db.registerTransactionEventHandler(txHandler)
-                } catch (e: Exception) {
-                    streamsLog.error("Error initializing the streaming Connector", e)
-                }
-            }
-
-            override fun stop() {
-                txHandler?.let { db.unregisterTransactionEventHandler(it) }
-            }
-        }
-
+        val streamHandler = StreamsEventRouterFactory.getStreamsEventRouter(log, configuration)
+        val streamsEventRouterConfiguration = StreamsEventRouterConfiguration.from(configuration.raw)
+        return StreamsEventRouterLifecycle(db, streamHandler, streamsEventRouterConfiguration, log)
     }
 
     interface Dependencies {
         fun graphdatabaseAPI(): GraphDatabaseAPI
         fun log(): LogService
         fun config(): Config
+    }
+}
+
+class StreamsEventRouterLifecycle(val db: GraphDatabaseAPI, val streamHandler: StreamsEventRouter,
+                                  val streamsEventRouterConfiguration: StreamsEventRouterConfiguration,
+                                  private val log: LogService): LifecycleAdapter() {
+    private val streamsLog = log.getUserLog(StreamsExtensionFactory::class.java)
+    private lateinit var txHandler: StreamsTransactionEventHandler
+
+    override fun start() {
+        try {
+            streamHandler.start()
+            registerTransactionEventHandler()
+        } catch (e: Exception) {
+            e.printStackTrace()
+            streamsLog.error("Error initializing the streaming producer", e)
+        }
+    }
+
+    fun registerTransactionEventHandler() {
+        txHandler = StreamsTransactionEventHandler(streamHandler, streamsEventRouterConfiguration)
+        db.registerTransactionEventHandler(txHandler)
+    }
+
+    fun unregisterTransactionEventHandler() {
+        db.unregisterTransactionEventHandler(txHandler)
+    }
+
+    override fun stop() {
+        unregisterTransactionEventHandler()
+        streamHandler.stop()
     }
 }
 

--- a/producer/src/main/kotlin/streams/events/StreamsEvent.kt
+++ b/producer/src/main/kotlin/streams/events/StreamsEvent.kt
@@ -50,4 +50,5 @@ data class Constraint(val label: String?,
 data class Schema(val properties: List<String> = emptyList(),
                   val constraints: List<Constraint>? = null)
 
-data class StreamsEvent(val meta: Meta, val payload: Payload, val schema: Schema)
+open class StreamsEvent(open val payload: Any)
+data class StreamsTransactionEvent(val meta: Meta, override val payload: Payload, val schema: Schema): StreamsEvent(payload)

--- a/producer/src/main/kotlin/streams/events/StreamsEventBuilder.kt
+++ b/producer/src/main/kotlin/streams/events/StreamsEventBuilder.kt
@@ -189,7 +189,7 @@ class StreamsEventBuilder(){
         return this
     }
 
-    fun build() : StreamsEvent{
-        return StreamsEvent(meta!!, payload!!, schema!!)
+    fun build() : StreamsTransactionEvent{
+        return StreamsTransactionEvent(meta!!, payload!!, schema!!)
     }
 }

--- a/producer/src/main/kotlin/streams/kafka/KafkaConfiguration.kt
+++ b/producer/src/main/kotlin/streams/kafka/KafkaConfiguration.kt
@@ -4,6 +4,7 @@ import org.apache.commons.lang3.StringUtils
 import org.apache.kafka.clients.producer.ProducerConfig
 import org.apache.kafka.common.serialization.ByteArraySerializer
 import org.apache.kafka.common.serialization.LongSerializer
+import org.apache.kafka.common.serialization.StringSerializer
 import streams.getInt
 import streams.serialization.JacksonUtil
 import java.util.*
@@ -63,7 +64,7 @@ data class KafkaConfiguration(val zookeeperConnect: String = "localhost:2181",
 
     private fun addSerializers() : Properties {
         val props = Properties()
-        props[ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG] =  LongSerializer::class.java
+        props[ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG] =  StringSerializer::class.java
         props[ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG] = ByteArraySerializer::class.java
         return props
     }

--- a/producer/src/main/kotlin/streams/kafka/KafkaConfiguration.kt
+++ b/producer/src/main/kotlin/streams/kafka/KafkaConfiguration.kt
@@ -4,25 +4,11 @@ import org.apache.commons.lang3.StringUtils
 import org.apache.kafka.clients.producer.ProducerConfig
 import org.apache.kafka.common.serialization.ByteArraySerializer
 import org.apache.kafka.common.serialization.LongSerializer
-import streams.NodeRoutingConfiguration
-import streams.RelationshipRoutingConfiguration
-import streams.RoutingConfigurationFactory
-import streams.events.EntityType
+import streams.getInt
 import streams.serialization.JacksonUtil
 import java.util.*
 
-fun Map<String,String>.getInt(name:String, defaultValue: Int) = this.get(name)?.toInt() ?: defaultValue
-
-private fun <T> filterMap(config: Map<String, String>, routingPrefix: String, clazz: Class<T>): List<T> {
-    return config
-            .filterKeys { it.startsWith(routingPrefix) }
-            .flatMap { RoutingConfigurationFactory.getRoutingConfiguration(it.key.replace(routingPrefix, StringUtils.EMPTY) , it.value, EntityType.node) as List<T> }
-}
-
-private object StreamsRoutingConfigurationConstants { // TODO move to a StreamConfiguration class as we do in the Sink
-    const val NODE_ROUTING_KEY_PREFIX: String = "streams.source.topic.nodes."
-    const val REL_ROUTING_KEY_PREFIX: String = "streams.source.topic.relationships."
-}
+private val configPrefix = "kafka."
 
 data class KafkaConfiguration(val zookeeperConnect: String = "localhost:2181",
                               val bootstrapServers: String = "localhost:9092",
@@ -36,16 +22,10 @@ data class KafkaConfiguration(val zookeeperConnect: String = "localhost:2181",
                               val connectionTimeoutMs: Int = 10 * 1000,
                               val replication: Int = 1,
                               val transactionalId: String = StringUtils.EMPTY,
-                              val lingerMs: Int = 1,
-                              val nodeRouting : List<NodeRoutingConfiguration> = listOf(NodeRoutingConfiguration()),
-                              val relRouting : List<RelationshipRoutingConfiguration> = listOf(RelationshipRoutingConfiguration())){
+                              val lingerMs: Int = 1){
     companion object {
-        fun from(config: Map<String, String>) : KafkaConfiguration {
-            val nodeRouting = filterMap(config = config, routingPrefix = StreamsRoutingConfigurationConstants.NODE_ROUTING_KEY_PREFIX,
-                    clazz = NodeRoutingConfiguration::class.java)
-
-            val relRouting = filterMap(config = config, routingPrefix = StreamsRoutingConfigurationConstants.REL_ROUTING_KEY_PREFIX,
-                    clazz = RelationshipRoutingConfiguration::class.java)
+        fun from(cfg: Map<String, String>) : KafkaConfiguration {
+            val config = cfg.filterKeys { it.startsWith(configPrefix) }.mapKeys { it.key.substring(configPrefix.length) }
 
             val default = KafkaConfiguration()
             return default.copy(zookeeperConnect = config.getOrDefault("zookeeper.connect",default.zookeeperConnect),
@@ -60,9 +40,7 @@ data class KafkaConfiguration(val zookeeperConnect: String = "localhost:2181",
                     connectionTimeoutMs = config.getInt("connection.timeout.ms", default.connectionTimeoutMs),
                     replication = config.getInt("replication", default.replication),
                     transactionalId = config.getOrDefault("transactional.id", default.transactionalId),
-                    lingerMs = config.getInt("linger.ms", default.lingerMs),
-                    nodeRouting = if (nodeRouting.isEmpty()) default.nodeRouting else nodeRouting,
-                    relRouting = if (relRouting.isEmpty()) default.relRouting else relRouting
+                    lingerMs = config.getInt("linger.ms", default.lingerMs)
             )
         }
     }

--- a/producer/src/main/kotlin/streams/kafka/KafkaEventRouter.kt
+++ b/producer/src/main/kotlin/streams/kafka/KafkaEventRouter.kt
@@ -16,8 +16,10 @@ import org.neo4j.logging.Log
 import streams.NodeRoutingConfiguration
 import streams.RelationshipRoutingConfiguration
 import streams.StreamsEventRouter
+import streams.StreamsEventRouterConfiguration
 import streams.events.EntityType
 import streams.events.StreamsEvent
+import streams.events.StreamsTransactionEvent
 import streams.serialization.JacksonUtil
 import java.lang.Exception
 import java.util.*
@@ -27,47 +29,63 @@ import java.util.concurrent.ThreadLocalRandom
 
 class KafkaEventRouter: StreamsEventRouter {
     private val log: Log
-    private val producer: Producer<Long, ByteArray>
+    private lateinit var producer: Producer<Long, ByteArray>
     private val kafkaConfig: KafkaConfiguration
 
-    private val configPrefix = "kafka."
 
     constructor(logService: LogService, config: Config): super(logService, config) {
         log = logService.getUserLog(KafkaEventRouter::class.java)
         log.info("Initializing Kafka Connector")
-        kafkaConfig = KafkaConfiguration.from(config.raw.filterKeys { it.startsWith(configPrefix) }.mapKeys { it.key.substring(configPrefix.length) })
+        kafkaConfig = KafkaConfiguration.from(config.raw)
+    }
+
+    override fun start() {
         val props = kafkaConfig.asProperties()
         producer = Neo4jKafkaProducer<Long, ByteArray>(props)
         producer.initTransactions()
-        log.info("Kafka initialization successful")
-        val topics = kafkaConfig.nodeRouting.map { it.topic }.toMutableSet() + kafkaConfig.relRouting.map { it.topic }.toMutableSet()
-        AdminClient.create(props).use { client -> client.createTopics(
-                topics.map { topic -> NewTopic(topic, kafkaConfig.numPartitions, kafkaConfig.replication.toShort()) }) }
         log.info("Kafka Connector started")
     }
 
-    override fun sendEvents(events: List<StreamsEvent>) {
+    override fun stop() {
+        producer.close()
+    }
+
+    private fun send(producerRecord: ProducerRecord<Long, ByteArray>) {
+        producer.send(producerRecord,
+                { meta: RecordMetadata?, error: Exception? ->
+                    if (log.isDebugEnabled) {
+                        log.debug("Sent record in partition ${meta?.partition()} offset ${meta?.offset()} data ${meta?.topic()} key size ${meta?.serializedKeySize()}", error)
+                    }
+                })
+    }
+
+    private fun sendEvent(partition: Int, topic: String, event: StreamsEvent) {
+        if (log.isDebugEnabled) {
+            log.debug("Trying to send a simple event with payload ${event.payload} to kafka")
+        }
+        val producerRecord = ProducerRecord(topic, partition, System.currentTimeMillis(), event.hashCode().toLong(),
+                JacksonUtil.getMapper().writeValueAsBytes(event))
+        send(producerRecord)
+    }
+
+    private fun sendEvent(partition: Int, topic: String, event: StreamsTransactionEvent) {
+        if (log.isDebugEnabled) {
+            log.debug("Trying to send a transaction event with txId ${event.meta.txId} and txEventId ${event.meta.txEventId} to kafka")
+        }
+        val producerRecord = ProducerRecord(topic, partition, System.currentTimeMillis(), event.meta.txId + event.meta.txEventId,
+                JacksonUtil.getMapper().writeValueAsBytes(event))
+        send(producerRecord)
+    }
+
+    override fun sendEvents(topic: String, transactionEvents: List<out StreamsEvent>) {
         try {
             producer.beginTransaction()
-            events.forEach {
-                val event = it
-                val eventMap = when (event.payload.type) {
-                    EntityType.node -> NodeRoutingConfiguration.prepareEvent(event, kafkaConfig.nodeRouting)
-                    EntityType.relationship -> RelationshipRoutingConfiguration.prepareEvent(event, kafkaConfig.relRouting)
-                }
-                eventMap.forEach {
-                    val partition = ThreadLocalRandom.current().nextInt(kafkaConfig.numPartitions)
-                    if (log.isDebugEnabled) {
-                        log.debug("Trying to send the event with txId ${it.value.meta.txId} and txEventId ${it.value.meta.txEventId} to kafka")
-                    }
-                    val producerRecord = ProducerRecord(it.key, partition, System.currentTimeMillis(), it.value.meta.txId + it.value.meta.txEventId,
-                            JacksonUtil.getMapper().writeValueAsBytes(it))
-                    producer.send(producerRecord,
-                            { meta: RecordMetadata?, error: Exception? ->
-                                if (log.isDebugEnabled) {
-                                    log.debug("sending record in partition ${meta?.partition()} offset ${meta?.offset()} data ${meta?.topic()} key size ${meta?.serializedKeySize()}", error)
-                                }
-                            })
+            transactionEvents.forEach {
+                val partition = ThreadLocalRandom.current().nextInt(kafkaConfig.numPartitions)
+                if (it is StreamsTransactionEvent) {
+                    sendEvent(partition, topic, it)
+                } else {
+                    sendEvent(partition, topic, it)
                 }
             }
             producer.commitTransaction()

--- a/producer/src/main/kotlin/streams/procedures/StreamsProcedures.kt
+++ b/producer/src/main/kotlin/streams/procedures/StreamsProcedures.kt
@@ -58,7 +58,7 @@ class StreamsProcedures {
                 mapOf("length" to length, "rels" to rels, "nodes" to nodes)
             }
             is Map<*, *> -> {
-                payload.map { it.key to buildPayload(topic, it.value) }.toMap()
+                payload.mapValues { buildPayload(topic, it) }
             }
             is List<*> -> {
                 payload.map { buildPayload(topic, it) }

--- a/producer/src/main/kotlin/streams/procedures/StreamsProcedures.kt
+++ b/producer/src/main/kotlin/streams/procedures/StreamsProcedures.kt
@@ -58,7 +58,7 @@ class StreamsProcedures {
                 mapOf("length" to length, "rels" to rels, "nodes" to nodes)
             }
             is Map<*, *> -> {
-                payload.mapValues { buildPayload(topic, it) }
+                payload.mapValues { buildPayload(topic, it.value) }
             }
             is List<*> -> {
                 payload.map { buildPayload(topic, it) }

--- a/producer/src/main/kotlin/streams/procedures/StreamsProcedures.kt
+++ b/producer/src/main/kotlin/streams/procedures/StreamsProcedures.kt
@@ -1,0 +1,71 @@
+package streams.procedures
+
+import org.neo4j.graphdb.Node
+import org.neo4j.graphdb.Path
+import org.neo4j.graphdb.Relationship
+import org.neo4j.kernel.internal.GraphDatabaseAPI
+import org.neo4j.procedure.*
+import streams.StreamsEventRouterLifecycle
+import streams.events.StreamsEvent
+import streams.toMap
+
+class StreamsProcedures {
+
+    @JvmField @Context var db: GraphDatabaseAPI? = null
+
+
+    @Procedure(mode = Mode.SCHEMA, name = "streams.publish")
+    @Description("streams.publish(topic, config) - Allows custom streaming from Neo4j to the configured stream environment")
+    fun publish(@Name("topic") topic: String, @Name("payload") payload: Any,
+                @Name(value = "config", defaultValue = "{}") config: Map<String, Any>?) {
+        val newPayload = buildPayload(topic, payload)
+        val streamsEvent = StreamsEvent(newPayload!!)
+        getStreamsEventRouterLifecycle()?.streamHandler?.sendEvents(topic, listOf(streamsEvent))
+    }
+
+    private fun getStreamsEventRouterLifecycle() =
+            db?.dependencyResolver?.resolveDependency(StreamsEventRouterLifecycle::class.java)
+
+    fun buildPayload(topic: String, payload: Any?): Any? {
+        if (payload == null) {
+            return null
+        }
+        return when (payload) {
+            is Node -> {
+                val routingConfiguration = getStreamsEventRouterLifecycle()?.streamsEventRouterConfiguration?.nodeRouting
+                        ?.filter { it.topic == topic}
+                        ?.firstOrNull()
+                if (routingConfiguration != null) {
+                    routingConfiguration.filter(payload)
+                } else {
+                    payload.toMap()
+                }
+            }
+            is Relationship -> {
+                val routingConfiguration = getStreamsEventRouterLifecycle()?.streamsEventRouterConfiguration?.relRouting
+                        ?.filter { it.topic == topic}
+                        ?.firstOrNull()
+                if (routingConfiguration != null) {
+                    routingConfiguration.filter(payload)
+                } else {
+                    payload.toMap()
+                }
+            }
+            is Path -> {
+                val length = payload.length()
+                val rels = payload.relationships().map { buildPayload(topic, it) }
+                val nodes = payload.nodes().map { buildPayload(topic, it) }
+                mapOf("length" to length, "rels" to rels, "nodes" to nodes)
+            }
+            is Map<*, *> -> {
+                payload.map { it.key to buildPayload(topic, it.value) }.toMap()
+            }
+            is List<*> -> {
+                payload.map { buildPayload(topic, it) }
+            }
+            else -> {
+                payload
+            }
+        }
+    }
+}

--- a/producer/src/test/kotlin/streams/RoutingConfigurationTest.kt
+++ b/producer/src/test/kotlin/streams/RoutingConfigurationTest.kt
@@ -153,7 +153,7 @@ class RoutingConfigurationTest {
 
         //When
         val events = NodeRoutingConfiguration.prepareEvent(
-                streamsEvent = streamsEvent,
+                streamsTransactionEvent = streamsEvent,
                 routingConf = routingConf)
 
         // Then
@@ -218,7 +218,7 @@ class RoutingConfigurationTest {
 
         //When
         val events = RelationshipRoutingConfiguration.prepareEvent(
-                streamsEvent = streamsEvent,
+                streamsTransactionEvent = streamsEvent,
                 routingConf = routingConf)
 
         // Then

--- a/producer/src/test/kotlin/streams/StreamsTransactionEventHandlerRelTest.kt
+++ b/producer/src/test/kotlin/streams/StreamsTransactionEventHandlerRelTest.kt
@@ -15,7 +15,7 @@ import kotlin.test.assertNull
 
 class StreamsTransactionEventHandlerRelTest {
 
-    private val handler : StreamsTransactionEventHandler = StreamsTransactionEventHandler(MockStreamsEventRouter())
+    private val handler : StreamsTransactionEventHandler = StreamsTransactionEventHandler(MockStreamsEventRouter(), StreamsEventRouterConfiguration())
 
 
     @Before
@@ -29,8 +29,8 @@ class StreamsTransactionEventHandlerRelTest {
         val createdRels = mutableListOf<MockRelationship>(MockRelationship(
                 id=1,
                 type="REL",
-                startNode=MockNode(nodeId = 1, labels = mutableListOf(Label.label("Start"))),
-                endNode = MockNode(nodeId = 2, labels = mutableListOf(Label.label("End"))),
+                startNode=MockNode(id = 1, labels = mutableListOf(Label.label("Start"))),
+                endNode = MockNode(id = 2, labels = mutableListOf(Label.label("End"))),
                 properties = mutableMapOf("p1" to 1, "p2" to "2")))
         val txd = MockTransactionData(createdRelationships = createdRels)
         val previous = handler.beforeCommit(txd).relData
@@ -58,8 +58,8 @@ class StreamsTransactionEventHandlerRelTest {
         val delRel = MockRelationship(
                 id=1,
                 type="REL",
-                startNode=MockNode(nodeId = 1, labels = mutableListOf(Label.label("Start"))),
-                endNode = MockNode(nodeId = 2, labels = mutableListOf(Label.label("End"))))
+                startNode=MockNode(id = 1, labels = mutableListOf(Label.label("Start"))),
+                endNode = MockNode(id = 2, labels = mutableListOf(Label.label("End"))))
         val removedProps = mutableListOf<PropertyEntry<Relationship>>(MockPropertyEntry<Relationship>( delRel,"p1", null, 1),
                 MockPropertyEntry<Relationship>( delRel,"p2", null, "2"))
 
@@ -91,8 +91,8 @@ class StreamsTransactionEventHandlerRelTest {
         val createdRels = mutableListOf<MockRelationship>(MockRelationship(
                 id = 1,
                 type = "REL",
-                startNode = MockNode(nodeId = 1, labels = mutableListOf(Label.label("Start"))),
-                endNode = MockNode(nodeId = 2, labels = mutableListOf(Label.label("End"))),
+                startNode = MockNode(id = 1, labels = mutableListOf(Label.label("Start"))),
+                endNode = MockNode(id = 2, labels = mutableListOf(Label.label("End"))),
                 properties = mutableMapOf("p1" to 1, "p2" to "2")))
         val txd = MockTransactionData(createdRelationships = createdRels)
         val prev = handler.beforeCommit(txd)
@@ -112,8 +112,8 @@ class StreamsTransactionEventHandlerRelTest {
         val delRel = MockRelationship(
                 id=1,
                 type="REL",
-                startNode=MockNode(nodeId = 1, labels = mutableListOf(Label.label("Start"))),
-                endNode = MockNode(nodeId = 2, labels = mutableListOf(Label.label("End"))))
+                startNode=MockNode(id = 1, labels = mutableListOf(Label.label("Start"))),
+                endNode = MockNode(id = 2, labels = mutableListOf(Label.label("End"))))
         val removedProps = mutableListOf<PropertyEntry<Relationship>>(MockPropertyEntry<Relationship>( delRel,"p1", null, 1),
                 MockPropertyEntry<Relationship>( delRel,"p2", null, "2"))
 
@@ -136,8 +136,8 @@ class StreamsTransactionEventHandlerRelTest {
         val relation = MockRelationship(
                 id=1,
                 type="REL",
-                startNode=MockNode(nodeId = 1, labels = mutableListOf(Label.label("Start"))),
-                endNode = MockNode(nodeId = 2, labels = mutableListOf(Label.label("End"))),
+                startNode=MockNode(id = 1, labels = mutableListOf(Label.label("Start"))),
+                endNode = MockNode(id = 2, labels = mutableListOf(Label.label("End"))),
                 properties = mutableMapOf("p1" to 1, "p2" to "2"))
 
         val createdRels = mutableListOf<MockRelationship>(relation)

--- a/producer/src/test/kotlin/streams/StreamsTransactionEventHandlerTest.kt
+++ b/producer/src/test/kotlin/streams/StreamsTransactionEventHandlerTest.kt
@@ -17,7 +17,7 @@ import kotlin.test.assertTrue
 
 class StreamsTransactionEventHandlerTest {
 
-    private val handler : StreamsTransactionEventHandler = StreamsTransactionEventHandler(MockStreamsEventRouter())
+    private val handler : StreamsTransactionEventHandler = StreamsTransactionEventHandler(MockStreamsEventRouter(), StreamsEventRouterConfiguration())
 
 
     @Before
@@ -28,7 +28,7 @@ class StreamsTransactionEventHandlerTest {
     @Test
     fun afterCreatedNodes() {
 
-        val createdNodes = mutableListOf<Node>(MockNode(nodeId = 1))
+        val createdNodes = mutableListOf<Node>(MockNode(id = 1))
         val txd = MockTransactionData(createdNodes = createdNodes)
         val previous = handler.beforeCommit(txd)
         handler.afterCommit(txd, previous)
@@ -45,7 +45,7 @@ class StreamsTransactionEventHandlerTest {
     @Test
     fun afterCreatedNodesWithLabel() {
 
-        val node = MockNode(nodeId = 1, labels = mutableListOf(Label.label("Test")))
+        val node = MockNode(id = 1, labels = mutableListOf(Label.label("Test")))
         val createdNodes = mutableListOf<Node>(node)
 
         val labels = mapOf<String, List<String>>("1" to listOf("Test"))
@@ -67,7 +67,7 @@ class StreamsTransactionEventHandlerTest {
     @Test
     fun afterCreatedNodesWithProperties() {
 
-        val node = MockNode(nodeId = 1, properties = hashMapOf<String,Any>("name" to "Omar"))
+        val node = MockNode(id = 1, properties = hashMapOf<String,Any>("name" to "Omar"))
         val createdNodes = mutableListOf<Node>(node)
 
         val txd = MockTransactionData(createdNodes = createdNodes)
@@ -87,7 +87,7 @@ class StreamsTransactionEventHandlerTest {
     @Test
     fun afterDeletedNodes() {
 
-        val deletedNodes = mutableListOf<Node>(MockNode(nodeId = 1))
+        val deletedNodes = mutableListOf<Node>(MockNode(id = 1))
         val txd = MockTransactionData(deletedNodes = deletedNodes)
         val previous = handler.beforeCommit(txd)// PreviousTransactionData(nodeProperties = emptyMap(), nodeLabels = emptyMap(), createdPayload = emptyList(), deletedPayload = emptyList())
         handler.afterCommit(txd, previous)
@@ -104,7 +104,7 @@ class StreamsTransactionEventHandlerTest {
     @Test
     fun afterDeletedNodesWithLabel() {
 
-        val node = MockNode(nodeId = 1)
+        val node = MockNode(id = 1)
         val deletedNodes = mutableListOf<Node>(node)
 
         val labels = mapOf("1" to listOf("Test"))
@@ -131,7 +131,7 @@ class StreamsTransactionEventHandlerTest {
     fun afterDeletedNodesWithProperties() {
 
         val props = hashMapOf<String,Any>("name" to "Omar")
-        val node = MockNode(nodeId = 1)
+        val node = MockNode(id = 1)
         val deletedNodes = mutableListOf<Node>(node)
 
         val removedProps = mutableListOf<PropertyEntry<Node>>(MockPropertyEntry<Node>(node, "name", null, "Omar"))
@@ -153,7 +153,7 @@ class StreamsTransactionEventHandlerTest {
     @Test
     fun afterUpdateLabelNodes() {
 
-        val updateNodes = mutableListOf<Node>(MockNode(nodeId = 1,labels = mutableListOf(Label.label("PreTest"),Label.label("Test"))))
+        val updateNodes = mutableListOf<Node>(MockNode(id = 1,labels = mutableListOf(Label.label("PreTest"),Label.label("Test"))))
 
         val labels = mutableListOf<LabelEntry>(MockLabelEntry(
                 Label.label("Test"),
@@ -182,7 +182,7 @@ class StreamsTransactionEventHandlerTest {
     fun afterUpdatePropertiesNodes() {
         val prevProps = hashMapOf<String,Any>("name" to "Omar")
         val afterProps = hashMapOf<String,Any>("name" to "Andrea")
-        val updateNodes = mutableListOf<Node>(MockNode(nodeId = 1,properties = afterProps,labels = mutableListOf(Label.label("Test"))))
+        val updateNodes = mutableListOf<Node>(MockNode(id = 1,properties = afterProps,labels = mutableListOf(Label.label("Test"))))
 
 
         val txd = MockTransactionData(assignedNodeProperties = mutableListOf<PropertyEntry<Node>>(MockPropertyEntry<Node>(updateNodes[0], "name", "Andrea", "Omar")))
@@ -211,7 +211,7 @@ class StreamsTransactionEventHandlerTest {
     fun beforeCommitAddLabel() {
         val labels = mutableListOf<LabelEntry>(MockLabelEntry(
                 Label.label("Test"),
-                MockNode(nodeId = 1, labels = mutableListOf(Label.label("PreTest"),Label.label("Test")))))
+                MockNode(id = 1, labels = mutableListOf(Label.label("PreTest"),Label.label("Test")))))
 
         val txd = MockTransactionData(assignedLabels = labels)
         val previous = handler.beforeCommit(txd).nodeData
@@ -228,7 +228,7 @@ class StreamsTransactionEventHandlerTest {
     fun beforeCommitRemoveLabel() {
         val labels = mutableListOf<LabelEntry>(MockLabelEntry(
                 Label.label("Test"),
-                MockNode(nodeId = 1, labels = mutableListOf(Label.label("PreTest")))))
+                MockNode(id = 1, labels = mutableListOf(Label.label("PreTest")))))
 
         val txd = MockTransactionData(removedLabels = labels)
         val previous = handler.beforeCommit(txd).nodeData
@@ -259,7 +259,7 @@ class StreamsTransactionEventHandlerTest {
     @Test
     fun beforeCommitRemoveProperty() {
         val props = mutableListOf<PropertyEntry<Node>>()
-        val node = MockNode(nodeId = 1)
+        val node = MockNode(id = 1)
         props.add(MockPropertyEntry<Node>(node, "p1", "value0", "value0"))
         val txd = MockTransactionData(removedNodeProperties = props)
         val previous = handler.beforeCommit(txd).nodeData
@@ -273,7 +273,7 @@ class StreamsTransactionEventHandlerTest {
 
     @Test
     fun beforeCommitSetProperty() {
-        val node = MockNode(nodeId = 1, properties = mutableMapOf("p1" to "value1", "p2" to "value2", "p3" to "value4"))
+        val node = MockNode(id = 1, properties = mutableMapOf("p1" to "value1", "p2" to "value2", "p3" to "value4"))
         val props = mutableListOf<PropertyEntry<Node>>(
                 MockPropertyEntry<Node>(node, "p1", "value1", "value0"),
                 MockPropertyEntry<Node>(node, "p3", "value4", "value3")
@@ -293,12 +293,12 @@ class StreamsTransactionEventHandlerTest {
     @Test
     fun beforeCommitMultinodes() {
         val props = mutableListOf<PropertyEntry<Node>>()
-        val node = MockNode(nodeId = 1)
+        val node = MockNode(id = 1)
         props.add(MockPropertyEntry<Node>(node, "p1", "value1", "value0"))
 
         val labels = mutableListOf<LabelEntry>(MockLabelEntry(
                 Label.label("Test"),
-                MockNode(nodeId = 2, labels = mutableListOf(Label.label("PreTest"),Label.label("Test")))))
+                MockNode(id = 2, labels = mutableListOf(Label.label("PreTest"),Label.label("Test")))))
 
         val txd = MockTransactionData(assignedNodeProperties = props, assignedLabels = labels)
         val previous = handler.beforeCommit(txd).nodeData

--- a/producer/src/test/kotlin/streams/integrations/KafkaEventRouterIT.kt
+++ b/producer/src/test/kotlin/streams/integrations/KafkaEventRouterIT.kt
@@ -6,6 +6,7 @@ import org.apache.kafka.clients.consumer.ConsumerRecords
 import org.apache.kafka.clients.consumer.KafkaConsumer
 import org.apache.kafka.common.serialization.ByteArrayDeserializer
 import org.apache.kafka.common.serialization.LongDeserializer
+import org.apache.kafka.common.serialization.StringDeserializer
 import org.junit.After
 import org.junit.Before
 import org.junit.ClassRule
@@ -77,11 +78,11 @@ class KafkaEventRouterIT {
         consumer.close()
     }
 
-    private fun createConsumer(config: KafkaConfiguration): KafkaConsumer<Long, ByteArray> {
+    private fun createConsumer(config: KafkaConfiguration): KafkaConsumer<String, ByteArray> {
         val props = config.asProperties()
         props["group.id"] = "neo4j"
         props["enable.auto.commit"] = "true"
-        props[ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG] = LongDeserializer::class.java
+        props[ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG] = StringDeserializer::class.java
         props[ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG] = ByteArrayDeserializer::class.java
         props["auto.offset.reset"] = "earliest"
         return KafkaConsumer(props)

--- a/producer/src/test/kotlin/streams/kafka/KafkaConfigurationTest.kt
+++ b/producer/src/test/kotlin/streams/kafka/KafkaConfigurationTest.kt
@@ -7,17 +7,35 @@ import kotlin.test.assertTrue
 class KafkaConfigurationTest {
 
     @Test
-    fun shouldCreateDefaultConfiguration() {
-        val configuration = KafkaConfiguration.from(emptyMap())
+    fun shouldCreateConfiguration() {
+        val map = mapOf("kafka.zookeeper.connect" to "zookeeper:1234",
+                "kafka.bootstrap.servers" to "kafka:5678",
+                "kafka.acks" to "10",
+                "kafka.num.partitions" to 1,
+                "kafka.retries" to 1,
+                "kafka.batch.size" to 10,
+                "kafka.buffer.memory" to 1000,
+                "kafka.reindex.batch.size" to 1,
+                "kafka.session.timeout.ms" to 1,
+                "kafka.connection.timeout.ms" to 1,
+                "kafka.replication" to 2,
+                "kafka.transactional.id" to "foo",
+                "kafka.linger.ms" to 10)
 
-        assertEquals(1, configuration.nodeRouting.size)
-        assertEquals("neo4j", configuration.nodeRouting[0].topic)
-        assertTrue { configuration.nodeRouting[0].all }
-        assertTrue { configuration.nodeRouting[0].labels.isEmpty() }
+        val properties = KafkaConfiguration.from(map.mapValues { it.value.toString() }).asProperties()
 
-        assertEquals(1, configuration.relRouting.size)
-        assertEquals("neo4j", configuration.relRouting[0].topic)
-        assertTrue { configuration.relRouting[0].all }
-        assertTrue { configuration.relRouting[0].name == "" }
+        assertEquals(map["kafka.zookeeper.connect"], properties["zookeeper.connect"])
+        assertEquals(map["kafka.bootstrap.servers"], properties["bootstrap.servers"])
+        assertEquals(map["kafka.acks"], properties["acks"])
+        assertEquals(map["kafka.num.partitions"], properties["num.partitions"])
+        assertEquals(map["kafka.retries"], properties["retries"])
+        assertEquals(map["kafka.batch.size"], properties["batch.size"])
+        assertEquals(map["kafka.buffer.memory"], properties["buffer.memory"])
+        assertEquals(map["kafka.reindex.batch.size"], properties["reindex.batch.size"])
+        assertEquals(map["kafka.session.timeout.ms"], properties["session.timeout.ms"])
+        assertEquals(map["kafka.connection.timeout.ms"], properties["connection.timeout.ms"])
+        assertEquals(map["kafka.replication"], properties["replication"])
+        assertEquals(map["kafka.transactional.id"], properties["transactional.id"])
+        assertEquals(map["kafka.linger.ms"], properties["linger.ms"])
     }
 }

--- a/producer/src/test/kotlin/streams/mocks/MockGraphDatabaseAPI.kt
+++ b/producer/src/test/kotlin/streams/mocks/MockGraphDatabaseAPI.kt
@@ -25,139 +25,139 @@ import java.util.function.Supplier
 
 class MockGraphDatabaseAPI(private val dependencyResolver: MockDependencyResolver = MockDependencyResolver()) : GraphDatabaseAPI {
     override fun createNode(): Node {
-        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        TODO("not implemented")
     }
 
     override fun createNode(vararg labels: Label?): Node {
-        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        TODO("not implemented")
     }
 
     override fun <T : Any?> unregisterTransactionEventHandler(handler: TransactionEventHandler<T>?): TransactionEventHandler<T> {
-        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        TODO("not implemented")
     }
 
     override fun index(): IndexManager {
-        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        TODO("not implemented")
     }
 
     override fun bidirectionalTraversalDescription(): BidirectionalTraversalDescription {
-        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        TODO("not implemented")
     }
 
     override fun registerKernelEventHandler(handler: KernelEventHandler?): KernelEventHandler {
-        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        TODO("not implemented")
     }
 
     override fun getNodeById(id: Long): Node {
-        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        TODO("not implemented")
     }
 
     override fun beginTransaction(type: Transaction.Type?, loginContext: LoginContext?): InternalTransaction {
-        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        TODO("not implemented")
     }
 
     override fun beginTransaction(type: Transaction.Type?, loginContext: LoginContext?, timeout: Long, unit: TimeUnit?): InternalTransaction {
-        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        TODO("not implemented")
     }
 
     override fun getAllLabels(): ResourceIterable<Label> {
-        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        TODO("not implemented")
     }
 
     override fun beginTx(): org.neo4j.graphdb.Transaction {
-        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        TODO("not implemented")
     }
 
     override fun beginTx(timeout: Long, unit: TimeUnit?): org.neo4j.graphdb.Transaction {
-        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        TODO("not implemented")
     }
 
     override fun getAllNodes(): ResourceIterable<Node> {
-        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        TODO("not implemented")
     }
 
     override fun getAllLabelsInUse(): ResourceIterable<Label> {
-        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        TODO("not implemented")
     }
 
     override fun getAllRelationshipTypes(): ResourceIterable<RelationshipType> {
-        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        TODO("not implemented")
     }
 
     override fun getStoreDir(): File {
-        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        TODO("not implemented")
     }
 
     override fun getAllRelationships(): ResourceIterable<Relationship> {
-        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        TODO("not implemented")
     }
 
     override fun findNodes(label: Label?, key: String?, value: Any?): ResourceIterator<Node> {
-        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        TODO("not implemented")
     }
 
     override fun findNodes(label: Label?): ResourceIterator<Node> {
-        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        TODO("not implemented")
     }
 
     override fun <T : Any?> registerTransactionEventHandler(handler: TransactionEventHandler<T>?): TransactionEventHandler<T> {
-        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        TODO("not implemented")
     }
 
     override fun createNodeId(): Long {
-        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        TODO("not implemented")
     }
 
     override fun traversalDescription(): TraversalDescription {
-        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        TODO("not implemented")
     }
 
     override fun execute(query: String?): Result {
-        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        TODO("not implemented")
     }
 
     override fun execute(query: String?, timeout: Long, unit: TimeUnit?): Result {
-        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        TODO("not implemented")
     }
 
     override fun execute(query: String?, parameters: MutableMap<String, Any>?): Result {
-        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        TODO("not implemented")
     }
 
     override fun execute(query: String?, parameters: MutableMap<String, Any>?, timeout: Long, unit: TimeUnit?): Result {
-        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        TODO("not implemented")
     }
 
     override fun shutdown() {
-        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        TODO("not implemented")
     }
 
     override fun getRelationshipById(id: Long): Relationship {
-        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        TODO("not implemented")
     }
 
     override fun findNode(label: Label?, key: String?, value: Any?): Node {
-        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        TODO("not implemented")
     }
 
     override fun getAllPropertyKeys(): ResourceIterable<String> {
-        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        TODO("not implemented")
     }
 
     override fun validateURLAccess(url: URL?): URL {
-        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        TODO("not implemented")
     }
 
     override fun unregisterKernelEventHandler(handler: KernelEventHandler?): KernelEventHandler {
-        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        TODO("not implemented")
     }
 
     override fun schema(): Schema {
-        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        TODO("not implemented")
     }
 
     override fun isAvailable(timeout: Long): Boolean {
-        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        TODO("not implemented")
     }
 
     override fun getDependencyResolver(): DependencyResolver {
@@ -165,11 +165,11 @@ class MockGraphDatabaseAPI(private val dependencyResolver: MockDependencyResolve
     }
 
     override fun storeId(): StoreId {
-        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        TODO("not implemented")
     }
 
     override fun getAllRelationshipTypesInUse(): ResourceIterable<RelationshipType> {
-        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        TODO("not implemented")
     }
 
 }
@@ -188,15 +188,15 @@ class MockDependencyResolver(private val nodeRouting: List<NodeRoutingConfigurat
     }
 
     override fun <T : Any?> resolveDependency(type: Class<T>?, selector: DependencyResolver.SelectionStrategy?): T {
-        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        TODO("not implemented")
     }
 
     override fun <T : Any?> provideDependency(type: Class<T>?, selector: DependencyResolver.SelectionStrategy?): Supplier<T> {
-        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        TODO("not implemented")
     }
 
     override fun <T : Any?> provideDependency(type: Class<T>?): Supplier<T> {
-        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        TODO("not implemented")
     }
 
 }

--- a/producer/src/test/kotlin/streams/mocks/MockGraphDatabaseAPI.kt
+++ b/producer/src/test/kotlin/streams/mocks/MockGraphDatabaseAPI.kt
@@ -1,0 +1,217 @@
+package streams.mocks
+
+import org.neo4j.graphdb.*
+import org.neo4j.graphdb.event.KernelEventHandler
+import org.neo4j.graphdb.event.TransactionEventHandler
+import org.neo4j.graphdb.index.IndexManager
+import org.neo4j.graphdb.schema.Schema
+import org.neo4j.graphdb.traversal.BidirectionalTraversalDescription
+import org.neo4j.graphdb.traversal.TraversalDescription
+import org.neo4j.internal.kernel.api.Transaction
+import org.neo4j.internal.kernel.api.security.LoginContext
+import org.neo4j.kernel.configuration.Config
+import org.neo4j.kernel.impl.coreapi.InternalTransaction
+import org.neo4j.kernel.impl.logging.LogService
+import org.neo4j.kernel.impl.logging.NullLogService
+import org.neo4j.kernel.impl.store.StoreId
+import org.neo4j.kernel.internal.GraphDatabaseAPI
+import org.neo4j.logging.NullLog
+import streams.*
+import java.io.File
+import java.lang.IllegalArgumentException
+import java.net.URL
+import java.util.concurrent.TimeUnit
+import java.util.function.Supplier
+
+class MockGraphDatabaseAPI(private val dependencyResolver: MockDependencyResolver = MockDependencyResolver()) : GraphDatabaseAPI {
+    override fun createNode(): Node {
+        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+    }
+
+    override fun createNode(vararg labels: Label?): Node {
+        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+    }
+
+    override fun <T : Any?> unregisterTransactionEventHandler(handler: TransactionEventHandler<T>?): TransactionEventHandler<T> {
+        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+    }
+
+    override fun index(): IndexManager {
+        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+    }
+
+    override fun bidirectionalTraversalDescription(): BidirectionalTraversalDescription {
+        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+    }
+
+    override fun registerKernelEventHandler(handler: KernelEventHandler?): KernelEventHandler {
+        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+    }
+
+    override fun getNodeById(id: Long): Node {
+        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+    }
+
+    override fun beginTransaction(type: Transaction.Type?, loginContext: LoginContext?): InternalTransaction {
+        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+    }
+
+    override fun beginTransaction(type: Transaction.Type?, loginContext: LoginContext?, timeout: Long, unit: TimeUnit?): InternalTransaction {
+        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+    }
+
+    override fun getAllLabels(): ResourceIterable<Label> {
+        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+    }
+
+    override fun beginTx(): org.neo4j.graphdb.Transaction {
+        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+    }
+
+    override fun beginTx(timeout: Long, unit: TimeUnit?): org.neo4j.graphdb.Transaction {
+        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+    }
+
+    override fun getAllNodes(): ResourceIterable<Node> {
+        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+    }
+
+    override fun getAllLabelsInUse(): ResourceIterable<Label> {
+        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+    }
+
+    override fun getAllRelationshipTypes(): ResourceIterable<RelationshipType> {
+        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+    }
+
+    override fun getStoreDir(): File {
+        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+    }
+
+    override fun getAllRelationships(): ResourceIterable<Relationship> {
+        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+    }
+
+    override fun findNodes(label: Label?, key: String?, value: Any?): ResourceIterator<Node> {
+        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+    }
+
+    override fun findNodes(label: Label?): ResourceIterator<Node> {
+        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+    }
+
+    override fun <T : Any?> registerTransactionEventHandler(handler: TransactionEventHandler<T>?): TransactionEventHandler<T> {
+        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+    }
+
+    override fun createNodeId(): Long {
+        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+    }
+
+    override fun traversalDescription(): TraversalDescription {
+        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+    }
+
+    override fun execute(query: String?): Result {
+        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+    }
+
+    override fun execute(query: String?, timeout: Long, unit: TimeUnit?): Result {
+        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+    }
+
+    override fun execute(query: String?, parameters: MutableMap<String, Any>?): Result {
+        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+    }
+
+    override fun execute(query: String?, parameters: MutableMap<String, Any>?, timeout: Long, unit: TimeUnit?): Result {
+        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+    }
+
+    override fun shutdown() {
+        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+    }
+
+    override fun getRelationshipById(id: Long): Relationship {
+        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+    }
+
+    override fun findNode(label: Label?, key: String?, value: Any?): Node {
+        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+    }
+
+    override fun getAllPropertyKeys(): ResourceIterable<String> {
+        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+    }
+
+    override fun validateURLAccess(url: URL?): URL {
+        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+    }
+
+    override fun unregisterKernelEventHandler(handler: KernelEventHandler?): KernelEventHandler {
+        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+    }
+
+    override fun schema(): Schema {
+        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+    }
+
+    override fun isAvailable(timeout: Long): Boolean {
+        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+    }
+
+    override fun getDependencyResolver(): DependencyResolver {
+        return dependencyResolver
+    }
+
+    override fun storeId(): StoreId {
+        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+    }
+
+    override fun getAllRelationshipTypesInUse(): ResourceIterable<RelationshipType> {
+        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+    }
+
+}
+
+class MockDependencyResolver(private val nodeRouting: List<NodeRoutingConfiguration> = listOf(NodeRoutingConfiguration()),
+                             private val relRouting: List<RelationshipRoutingConfiguration> = listOf(RelationshipRoutingConfiguration())): DependencyResolver {
+    override fun <T : Any?> resolveDependency(type: Class<T>?): T {
+        if (type == StreamsEventRouterLifecycle::class.java) {
+            val dependencies = MockDependencies()
+            val lifecycle = StreamsEventRouterLifecycle(db = dependencies.graphdatabaseAPI(),
+                    log = dependencies.log(), streamHandler = MockStreamsEventRouter(),
+                    streamsEventRouterConfiguration = StreamsEventRouterConfiguration(nodeRouting = nodeRouting, relRouting = relRouting))
+            return lifecycle as T
+        }
+        throw IllegalArgumentException("mock")
+    }
+
+    override fun <T : Any?> resolveDependency(type: Class<T>?, selector: DependencyResolver.SelectionStrategy?): T {
+        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+    }
+
+    override fun <T : Any?> provideDependency(type: Class<T>?, selector: DependencyResolver.SelectionStrategy?): Supplier<T> {
+        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+    }
+
+    override fun <T : Any?> provideDependency(type: Class<T>?): Supplier<T> {
+        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+    }
+
+}
+
+class MockDependencies: StreamsExtensionFactory.Dependencies {
+    override fun graphdatabaseAPI(): GraphDatabaseAPI {
+        return MockGraphDatabaseAPI()
+    }
+
+    override fun log(): LogService {
+        return NullLogService.getInstance()
+    }
+
+    override fun config(): Config {
+        return Config.defaults()
+    }
+
+}

--- a/producer/src/test/kotlin/streams/mocks/MockStreamsEventRouter.kt
+++ b/producer/src/test/kotlin/streams/mocks/MockStreamsEventRouter.kt
@@ -4,15 +4,20 @@ import org.neo4j.kernel.configuration.Config
 import org.neo4j.kernel.impl.logging.LogService
 import streams.StreamsEventRouter
 import streams.events.StreamsEvent
+import streams.events.StreamsTransactionEvent
 
 class MockStreamsEventRouter(logService: LogService? = null, config: Config? = null): StreamsEventRouter(logService, config) {
 
-    override fun sendEvents(streamsEvents: List<StreamsEvent>) {
-        events.addAll(streamsEvents)
+    override fun sendEvents(topic: String, streamsTransactionEvents: List<out StreamsEvent>) {
+        events.addAll(streamsTransactionEvents as List<StreamsTransactionEvent>)
     }
 
+    override fun start() {}
+
+    override fun stop() {}
+
     companion object {
-        var events = mutableListOf<StreamsEvent>()
+        var events = mutableListOf<StreamsTransactionEvent>()
 
         fun reset() {
             events.clear()

--- a/producer/src/test/kotlin/streams/mocks/MockTransactionData.kt
+++ b/producer/src/test/kotlin/streams/mocks/MockTransactionData.kt
@@ -105,10 +105,10 @@ data class MockPropertyEntry<T : PropertyContainer>(val entity: T,
 
 }
 
-class MockNode(var nodeId : Long = 0, @JvmField var labels : MutableIterable<Label> = mutableListOf(), val properties:  MutableMap<String, Any> = mutableMapOf() ) : Node {
+class MockNode(private var id : Long = 0, @JvmField var labels : MutableIterable<Label> = mutableListOf(), val properties:  MutableMap<String, Any> = mutableMapOf() ) : Node {
 
     override fun getId(): Long {
-        return nodeId
+        return id
     }
 
     override fun hasProperty(key: String?): Boolean {
@@ -315,6 +315,45 @@ class MockRelationship(private val id: Long, private val type: String, private v
     }
 
     override fun delete() {
+        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+    }
+
+}
+
+class MockPath(private val startNode: Node, private val endNode: Node, private val relationship: Relationship): Path {
+    override fun length(): Int {
+        return 1
+    }
+
+    override fun endNode(): Node {
+        return endNode
+    }
+
+    override fun nodes(): MutableIterable<Node> {
+        return mutableListOf(startNode, endNode)
+    }
+
+    override fun startNode(): Node {
+        return startNode
+    }
+
+    override fun reverseRelationships(): MutableIterable<Relationship> {
+        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+    }
+
+    override fun iterator(): MutableIterator<PropertyContainer> {
+        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+    }
+
+    override fun lastRelationship(): Relationship {
+        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+    }
+
+    override fun relationships(): MutableIterable<Relationship> {
+        return mutableListOf(relationship)
+    }
+
+    override fun reverseNodes(): MutableIterable<Node> {
         TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
     }
 

--- a/producer/src/test/kotlin/streams/mocks/MockTransactionData.kt
+++ b/producer/src/test/kotlin/streams/mocks/MockTransactionData.kt
@@ -30,7 +30,7 @@ data class MockTransactionData(val assignedNodeProperties: MutableIterable<Prope
     }
 
     override fun isDeleted(relationship: Relationship?): Boolean {
-        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        TODO("not implemented")
     }
 
     override fun removedLabels(): MutableIterable<LabelEntry> {
@@ -58,7 +58,7 @@ data class MockTransactionData(val assignedNodeProperties: MutableIterable<Prope
     }
 
     override fun metaData(): MutableMap<String, Any> {
-        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        TODO("not implemented")
     }
 
     override fun deletedRelationships(): MutableIterable<Relationship> {
@@ -112,7 +112,7 @@ class MockNode(private var id : Long = 0, @JvmField var labels : MutableIterable
     }
 
     override fun hasProperty(key: String?): Boolean {
-        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        TODO("not implemented")
     }
 
     override fun getLabels(): MutableIterable<Label> {
@@ -124,115 +124,115 @@ class MockNode(private var id : Long = 0, @JvmField var labels : MutableIterable
     }
 
     override fun addLabel(label: Label?) {
-        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        TODO("not implemented")
     }
 
     override fun getGraphDatabase(): GraphDatabaseService {
-        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        TODO("not implemented")
     }
 
     override fun setProperty(key: String?, value: Any?) {
-        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        TODO("not implemented")
     }
 
     override fun hasLabel(label: Label?): Boolean {
-        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        TODO("not implemented")
     }
 
     override fun getDegree(): Int {
-        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        TODO("not implemented")
     }
 
     override fun getDegree(type: RelationshipType?): Int {
-        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        TODO("not implemented")
     }
 
     override fun getDegree(direction: Direction?): Int {
-        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        TODO("not implemented")
     }
 
     override fun getDegree(type: RelationshipType?, direction: Direction?): Int {
-        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        TODO("not implemented")
     }
 
     override fun getRelationships(): MutableIterable<Relationship> {
-        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        TODO("not implemented")
     }
 
     override fun getRelationships(vararg types: RelationshipType?): MutableIterable<Relationship> {
-        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        TODO("not implemented")
     }
 
     override fun getRelationships(direction: Direction?, vararg types: RelationshipType?): MutableIterable<Relationship> {
-        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        TODO("not implemented")
     }
 
     override fun getRelationships(dir: Direction?): MutableIterable<Relationship> {
-        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        TODO("not implemented")
     }
 
     override fun getRelationships(type: RelationshipType?, dir: Direction?): MutableIterable<Relationship> {
-        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        TODO("not implemented")
     }
 
     override fun removeLabel(label: Label?) {
-        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        TODO("not implemented")
     }
 
     override fun removeProperty(key: String?): Any {
-        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        TODO("not implemented")
     }
 
     override fun getProperties(vararg keys: String?): MutableMap<String, Any> {
-        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        TODO("not implemented")
     }
 
     override fun getProperty(key: String?): Any {
-        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        TODO("not implemented")
     }
 
     override fun getProperty(key: String?, defaultValue: Any?): Any {
-        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        TODO("not implemented")
     }
 
     override fun getSingleRelationship(type: RelationshipType?, dir: Direction?): Relationship {
-        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        TODO("not implemented")
     }
 
     override fun getRelationshipTypes(): MutableIterable<RelationshipType> {
-        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        TODO("not implemented")
     }
 
     override fun createRelationshipTo(otherNode: Node?, type: RelationshipType?): Relationship {
-        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        TODO("not implemented")
     }
 
     override fun getPropertyKeys(): MutableIterable<String> {
-        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        TODO("not implemented")
     }
 
     override fun hasRelationship(): Boolean {
-        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        TODO("not implemented")
     }
 
     override fun hasRelationship(vararg types: RelationshipType?): Boolean {
-        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        TODO("not implemented")
     }
 
     override fun hasRelationship(direction: Direction?, vararg types: RelationshipType?): Boolean {
-        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        TODO("not implemented")
     }
 
     override fun hasRelationship(dir: Direction?): Boolean {
-        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        TODO("not implemented")
     }
 
     override fun hasRelationship(type: RelationshipType?, dir: Direction?): Boolean {
-        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        TODO("not implemented")
     }
 
     override fun delete() {
-        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        TODO("not implemented")
     }
 
 }
@@ -251,7 +251,7 @@ class MockLabelEntry(val label:Label, val node:Node) : LabelEntry {
 class MockRelationship(private val id: Long, private val type: String, private val startNode: Node, private val endNode: Node,
                        val properties:  MutableMap<String, Any> = mutableMapOf()): Relationship {
     override fun hasProperty(p0: String?): Boolean {
-        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        TODO("not implemented")
     }
 
     override fun getAllProperties(): MutableMap<String, Any> {
@@ -259,11 +259,11 @@ class MockRelationship(private val id: Long, private val type: String, private v
     }
 
     override fun getGraphDatabase(): GraphDatabaseService {
-        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        TODO("not implemented")
     }
 
     override fun setProperty(p0: String?, p1: Any?) {
-        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        TODO("not implemented")
     }
 
     override fun getId(): Long {
@@ -275,27 +275,27 @@ class MockRelationship(private val id: Long, private val type: String, private v
     }
 
     override fun removeProperty(p0: String?): Any {
-        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        TODO("not implemented")
     }
 
     override fun getProperties(vararg p0: String?): MutableMap<String, Any> {
-        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        TODO("not implemented")
     }
 
     override fun getProperty(p0: String?): Any {
-        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        TODO("not implemented")
     }
 
     override fun getProperty(p0: String?, p1: Any?): Any {
-        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        TODO("not implemented")
     }
 
     override fun getNodes(): Array<Node> {
-        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        TODO("not implemented")
     }
 
     override fun getOtherNode(p0: Node?): Node {
-        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        TODO("not implemented")
     }
 
     override fun getStartNode(): Node {
@@ -303,7 +303,7 @@ class MockRelationship(private val id: Long, private val type: String, private v
     }
 
     override fun isType(p0: RelationshipType?): Boolean {
-        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        TODO("not implemented")
     }
 
     override fun getEndNode(): Node {
@@ -311,11 +311,11 @@ class MockRelationship(private val id: Long, private val type: String, private v
     }
 
     override fun getPropertyKeys(): MutableIterable<String> {
-        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        TODO("not implemented")
     }
 
     override fun delete() {
-        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        TODO("not implemented")
     }
 
 }
@@ -338,15 +338,15 @@ class MockPath(private val startNode: Node, private val endNode: Node, private v
     }
 
     override fun reverseRelationships(): MutableIterable<Relationship> {
-        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        TODO("not implemented")
     }
 
     override fun iterator(): MutableIterator<PropertyContainer> {
-        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        TODO("not implemented")
     }
 
     override fun lastRelationship(): Relationship {
-        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        TODO("not implemented")
     }
 
     override fun relationships(): MutableIterable<Relationship> {
@@ -354,7 +354,7 @@ class MockPath(private val startNode: Node, private val endNode: Node, private v
     }
 
     override fun reverseNodes(): MutableIterable<Node> {
-        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        TODO("not implemented")
     }
 
 }

--- a/producer/src/test/kotlin/streams/procedures/StreamsProceduresTest.kt
+++ b/producer/src/test/kotlin/streams/procedures/StreamsProceduresTest.kt
@@ -1,0 +1,307 @@
+package streams.procedures
+
+import org.junit.BeforeClass
+import org.junit.Test
+import org.neo4j.graphdb.Label
+import streams.events.RelationshipNodeChange
+import streams.labelNames
+import streams.mocks.*
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import streams.NodeRoutingConfiguration
+import streams.RelationshipRoutingConfiguration
+
+class StreamsProceduresTest {
+
+    companion object {
+        lateinit var streamsProcedures: StreamsProcedures
+
+        @BeforeClass
+        @JvmStatic
+        fun setup() {
+            streamsProcedures = StreamsProcedures()
+        }
+
+    }
+
+    @Test
+    fun shouldCreateSimpleTypes() {
+        streamsProcedures.db = MockGraphDatabaseAPI()
+        val str = "Test"
+        val strExpected = streamsProcedures.buildPayload("neo4j", str)
+        assertEquals(strExpected, str)
+    }
+
+    @Test
+    fun shouldCreateNode() {
+        // Given
+        streamsProcedures.db = MockGraphDatabaseAPI()
+        val node = MockNode(id = 1, labels = mutableListOf(Label.label("Foo"), Label.label("Bar")),
+                properties = mutableMapOf("prop" to "foo", "prop1" to "bar"))
+
+        // When
+        val nodePayload = streamsProcedures.buildPayload("neo4j", node)
+
+        // Then
+        assertTrue { nodePayload is Map<*, *> }
+        val nodeMap = nodePayload as Map<String, Any>
+        assertEquals(node.id.toString(), nodeMap["id"])
+        assertEquals(node.labelNames(), nodeMap["labels"])
+        assertEquals(node.properties, nodeMap["properties"])
+    }
+
+    @Test
+    fun shouldCreateNodeWithIncludedProperties() {
+        // Given
+        val nodeRouting = NodeRoutingConfiguration(all = false, labels = listOf("Foo"), include = listOf("prop1"))
+        val dependencyResolver = MockDependencyResolver(nodeRouting = listOf(nodeRouting))
+        streamsProcedures.db = MockGraphDatabaseAPI(dependencyResolver)
+        val node = MockNode(id = 1, labels = mutableListOf(Label.label("Foo"), Label.label("Bar")),
+                properties = mutableMapOf("prop" to "foo", "prop1" to "bar"))
+
+        // When
+        val nodePayload = streamsProcedures.buildPayload("neo4j", node)
+
+        // Then
+        assertTrue { nodePayload is Map<*, *> }
+        val nodeMap = nodePayload as Map<String, Any>
+        assertEquals(node.id.toString(), nodeMap["id"])
+        assertEquals(node.labelNames(), nodeMap["labels"])
+        assertEquals(node.properties.filter { nodeRouting.include.contains(it.key) }, nodeMap["properties"])
+    }
+
+    @Test
+    fun shouldCreateNodeWithoutExcludedProperties() {
+        // Given
+        val nodeRouting = NodeRoutingConfiguration(all = false, labels = listOf("Foo"), exclude = listOf("prop1"))
+        val dependencyResolver = MockDependencyResolver(nodeRouting = listOf(nodeRouting))
+        streamsProcedures.db = MockGraphDatabaseAPI(dependencyResolver)
+        val node = MockNode(id = 1, labels = mutableListOf(Label.label("Foo"), Label.label("Bar")),
+                properties = mutableMapOf("prop" to "foo", "prop1" to "bar"))
+
+        // When
+        val nodePayload = streamsProcedures.buildPayload("neo4j", node)
+
+        // Then
+        assertTrue { nodePayload is Map<*, *> }
+        val nodeMap = nodePayload as Map<String, Any>
+        assertEquals(node.id.toString(), nodeMap["id"])
+        assertEquals(node.labelNames(), nodeMap["labels"])
+        assertEquals(node.properties.filter { !nodeRouting.exclude.contains(it.key) }, nodeMap["properties"])
+    }
+
+    @Test
+    fun shouldCreateRelationship() {
+        // Given
+        streamsProcedures.db = MockGraphDatabaseAPI()
+        val relationship = MockRelationship(id = 10, type = "KNOWS", properties = mutableMapOf("prop" to "foo", "prop1" to "bar"),
+                startNode = MockNode(id = 1, labels = mutableListOf(Label.label("Foo"), Label.label("Bar")),
+                        properties = mutableMapOf("prop" to "foo", "prop1" to "bar")),
+                endNode = MockNode(id = 2, labels = mutableListOf(Label.label("FooEnd"), Label.label("BarEnd")),
+                        properties = mutableMapOf("prop" to "fooEnd", "prop1" to "barEnd")))
+
+        // When
+        val relationshipPayload = streamsProcedures.buildPayload("neo4j", relationship)
+
+        // Then
+        assertTrue { relationshipPayload is Map<*, *> }
+        val relationshipMap = relationshipPayload as Map<String, Any>
+        assertEquals(relationship.id.toString(), relationshipMap["id"])
+        assertEquals(relationship.type, relationshipMap["label"])
+        assertEquals(relationship.properties, relationshipMap["properties"])
+        val startNodeRelMap = relationshipMap["start"] as RelationshipNodeChange
+        assertEquals(relationship.startNode.id.toString(), startNodeRelMap.id)
+        assertEquals(relationship.startNode.labelNames(), startNodeRelMap.labels)
+        val endNodeRelMap = relationshipMap["end"] as RelationshipNodeChange
+        assertEquals(relationship.endNode.id.toString(), endNodeRelMap.id)
+        assertEquals(relationship.endNode.labelNames(), endNodeRelMap.labels)
+    }
+
+    @Test
+    fun shouldCreateRelationshipWithIncludedProperties() {
+        // Given
+        val relRouting = RelationshipRoutingConfiguration(all = false, name = "KNOWS", include = listOf("prop1"))
+        val dependencyResolver = MockDependencyResolver(relRouting = listOf(relRouting))
+        streamsProcedures.db = MockGraphDatabaseAPI(dependencyResolver)
+        val relationship = MockRelationship(id = 10, type = "KNOWS", properties = mutableMapOf("prop" to "foo", "prop1" to "bar"),
+                startNode = MockNode(id = 1, labels = mutableListOf(Label.label("Foo"), Label.label("Bar")),
+                        properties = mutableMapOf("prop" to "foo", "prop1" to "bar")),
+                endNode = MockNode(id = 2, labels = mutableListOf(Label.label("FooEnd"), Label.label("BarEnd")),
+                        properties = mutableMapOf("prop" to "fooEnd", "prop1" to "barEnd")))
+
+        // When
+        val relationshipPayload = streamsProcedures.buildPayload("neo4j", relationship)
+
+        // Then
+        assertTrue { relationshipPayload is Map<*, *> }
+        val relationshipMap = relationshipPayload as Map<String, Any>
+        assertEquals(relationship.id.toString(), relationshipMap["id"])
+        assertEquals(relationship.type, relationshipMap["label"])
+        assertEquals(relationship.properties.filter { relRouting.include.contains(it.key) }, relationshipMap["properties"])
+        val startNodeRelMap = relationshipMap["start"] as RelationshipNodeChange
+        assertEquals(relationship.startNode.id.toString(), startNodeRelMap.id)
+        assertEquals(relationship.startNode.labelNames(), startNodeRelMap.labels)
+        val endNodeRelMap = relationshipMap["end"] as RelationshipNodeChange
+        assertEquals(relationship.endNode.id.toString(), endNodeRelMap.id)
+        assertEquals(relationship.endNode.labelNames(), endNodeRelMap.labels)
+    }
+
+    @Test
+    fun shouldCreateRelationshipWithoutExcludedProperties() {
+        // Given
+        val relRouting = RelationshipRoutingConfiguration(all = false, name = "KNOWS", exclude = listOf("prop1"))
+        val dependencyResolver = MockDependencyResolver(relRouting = listOf(relRouting))
+        streamsProcedures.db = MockGraphDatabaseAPI(dependencyResolver)
+        val relationship = MockRelationship(id = 10, type = "KNOWS", properties = mutableMapOf("prop" to "foo", "prop1" to "bar"),
+                startNode = MockNode(id = 1, labels = mutableListOf(Label.label("Foo"), Label.label("Bar")),
+                        properties = mutableMapOf("prop" to "foo", "prop1" to "bar")),
+                endNode = MockNode(id = 2, labels = mutableListOf(Label.label("FooEnd"), Label.label("BarEnd")),
+                        properties = mutableMapOf("prop" to "fooEnd", "prop1" to "barEnd")))
+
+        // When
+        val relationshipPayload = streamsProcedures.buildPayload("neo4j", relationship)
+
+        // Then
+        assertTrue { relationshipPayload is Map<*, *> }
+        val relationshipMap = relationshipPayload as Map<String, Any>
+        assertEquals(relationship.id.toString(), relationshipMap["id"])
+        assertEquals(relationship.type, relationshipMap["label"])
+        assertEquals(relationship.properties.filter { !relRouting.exclude.contains(it.key) }, relationshipMap["properties"])
+        val startNodeRelMap = relationshipMap["start"] as RelationshipNodeChange
+        assertEquals(relationship.startNode.id.toString(), startNodeRelMap.id)
+        assertEquals(relationship.startNode.labelNames(), startNodeRelMap.labels)
+        val endNodeRelMap = relationshipMap["end"] as RelationshipNodeChange
+        assertEquals(relationship.endNode.id.toString(), endNodeRelMap.id)
+        assertEquals(relationship.endNode.labelNames(), endNodeRelMap.labels)
+    }
+
+    @Test
+    fun shouldReturnSimpleMap() {
+        // Given
+        streamsProcedures.db = MockGraphDatabaseAPI()
+        val expectedMap = mapOf("foo" to "bar", "bar" to 10, "prop" to listOf(1, "two", null, mapOf("foo" to "bar")))
+
+        // When
+        val resultMap = streamsProcedures.buildPayload("neo4j", expectedMap)
+
+        // Then
+        assertEquals(expectedMap, resultMap)
+    }
+
+    @Test
+    fun shouldReturnSimpleList() {
+        // Given
+        streamsProcedures.db = MockGraphDatabaseAPI()
+        val expectedList = listOf("3", 2, 1, mapOf("foo" to "bar", "bar" to 10, "prop" to listOf(1, "two", null, mapOf("foo" to "bar"))))
+
+        // When
+        val resultList = streamsProcedures.buildPayload("neo4j", expectedList)
+
+        // Then
+        assertEquals(expectedList, resultList)
+    }
+
+    @Test
+    fun shouldReturnMapWithComplexTypes() {
+        // Given
+        streamsProcedures.db = MockGraphDatabaseAPI()
+        val node = MockNode(id = 1, labels = mutableListOf(Label.label("Foo"), Label.label("Bar")),
+                properties = mutableMapOf("prop" to "foo", "prop1" to "bar"))
+        val relationship = MockRelationship(id = 10, type = "KNOWS", properties = mutableMapOf("prop" to "foo", "prop1" to "bar"),
+                startNode = MockNode(id = 1, labels = mutableListOf(Label.label("Foo"), Label.label("Bar")),
+                        properties = mutableMapOf("prop" to "foo", "prop1" to "bar")),
+                endNode = MockNode(id = 2, labels = mutableListOf(Label.label("FooEnd"), Label.label("BarEnd")),
+                        properties = mutableMapOf("prop" to "fooEnd", "prop1" to "barEnd")))
+        val mapComplex = mapOf("node" to node, "relationship" to relationship, "prop" to listOf(1, "two", null, mapOf("foo" to "bar")))
+
+        // When
+        val resultMapComplex = streamsProcedures.buildPayload("neo4j", mapComplex)
+
+        // Then
+        val expectedMapComplex = mapComplex.mapValues {
+            if (it.key == "node" || it.key == "relationship") {
+                streamsProcedures.buildPayload("neo4j", it.value)
+            } else {
+                it.value
+            }
+        }
+        assertEquals(expectedMapComplex, resultMapComplex)
+    }
+
+    @Test
+    fun shouldReturnMapWithComplexTypesFiltered() {
+        // Given
+        val nodeRouting = NodeRoutingConfiguration(all = false, labels = listOf("Foo"), include = listOf("prop1"))
+        val relRouting = RelationshipRoutingConfiguration(all = false, name = "KNOWS", include = listOf("prop1"))
+        val dependencyResolver = MockDependencyResolver(nodeRouting = listOf(nodeRouting), relRouting = listOf(relRouting))
+        streamsProcedures.db = MockGraphDatabaseAPI(dependencyResolver)
+        val node = MockNode(id = 1, labels = mutableListOf(Label.label("Foo"), Label.label("Bar")),
+                properties = mutableMapOf("prop" to "foo", "prop1" to "bar"))
+        val relationship = MockRelationship(id = 10, type = "KNOWS", properties = mutableMapOf("prop" to "foo", "prop1" to "bar"),
+                startNode = MockNode(id = 1, labels = mutableListOf(Label.label("Foo"), Label.label("Bar")),
+                        properties = mutableMapOf("prop" to "foo", "prop1" to "bar")),
+                endNode = MockNode(id = 2, labels = mutableListOf(Label.label("FooEnd"), Label.label("BarEnd")),
+                        properties = mutableMapOf("prop" to "fooEnd", "prop1" to "barEnd")))
+        val mapComplex = mapOf("node" to node, "relationship" to relationship, "prop" to listOf(1, "two", null, mapOf("foo" to "bar")))
+
+        // When
+        val resultMapComplex = streamsProcedures.buildPayload("neo4j", mapComplex)
+
+        // Then
+        val expectedMapComplex = mapComplex.mapValues {
+            if (it.key == "node" || it.key == "relationship") {
+                streamsProcedures.buildPayload("neo4j", it.value)
+            } else {
+                it.value
+            }
+        }
+        assertEquals(expectedMapComplex, resultMapComplex)
+    }
+
+    @Test
+    fun shouldReturnPath() {
+        // Given
+        streamsProcedures.db = MockGraphDatabaseAPI()
+        val relationship = MockRelationship(id = 10, type = "KNOWS", properties = mutableMapOf("prop" to "foo", "prop1" to "bar"),
+                startNode = MockNode(id = 1, labels = mutableListOf(Label.label("Foo"), Label.label("Bar")),
+                        properties = mutableMapOf("prop" to "foo", "prop1" to "bar")),
+                endNode = MockNode(id = 2, labels = mutableListOf(Label.label("FooEnd"), Label.label("BarEnd")),
+                        properties = mutableMapOf("prop" to "fooEnd", "prop1" to "barEnd")))
+        val path = MockPath(relationship = relationship, startNode = relationship.startNode, endNode = relationship.endNode)
+
+        // When
+        val resultPath = streamsProcedures.buildPayload("neo4j", path)
+
+        // Then
+        val nodes = path.nodes().map { streamsProcedures.buildPayload("neo4j", it) }
+        val rels = path.relationships().map { streamsProcedures.buildPayload("neo4j", it) }
+        val expectedPath = mapOf("length" to 1, "nodes" to nodes, "rels" to rels)
+        assertEquals(expectedPath, resultPath)
+    }
+
+    @Test
+    fun shouldReturnPathWithFilteredProperties() {
+        // Given
+        val nodeRouting = NodeRoutingConfiguration(all = false, labels = listOf("Foo"), include = listOf("prop1"))
+        val relRouting = RelationshipRoutingConfiguration(all = false, name = "KNOWS", include = listOf("prop1"))
+        val dependencyResolver = MockDependencyResolver(nodeRouting = listOf(nodeRouting), relRouting = listOf(relRouting))
+        streamsProcedures.db = MockGraphDatabaseAPI(dependencyResolver)
+        val relationship = MockRelationship(id = 10, type = "KNOWS", properties = mutableMapOf("prop" to "foo", "prop1" to "bar"),
+                startNode = MockNode(id = 1, labels = mutableListOf(Label.label("Foo"), Label.label("Bar")),
+                        properties = mutableMapOf("prop" to "foo", "prop1" to "bar")),
+                endNode = MockNode(id = 2, labels = mutableListOf(Label.label("FooEnd"), Label.label("BarEnd")),
+                        properties = mutableMapOf("prop" to "fooEnd", "prop1" to "barEnd")))
+        val path = MockPath(relationship = relationship, startNode = relationship.startNode, endNode = relationship.endNode)
+
+        // When
+        val resultPath = streamsProcedures.buildPayload("neo4j", path)
+
+        // Then
+        val nodes = path.nodes().map { streamsProcedures.buildPayload("neo4j", it) }
+        val rels = path.relationships().map { streamsProcedures.buildPayload("neo4j", it) }
+        val expectedPath = mapOf("length" to 1, "nodes" to nodes, "rels" to rels)
+        assertEquals(expectedPath, resultPath)
+    }
+
+}
+


### PR DESCRIPTION
Fixes #84 

Added a procedure `streams.publish` that allows sending custom messages

## Proposed Changes (Mandatory)

A brief list of proposed changes in order to fix the issue:

 - Added Lifecycle methods to `StreamsEventRouter`
 - Changed **StreamsEvent** to `open class StreamsEvent(open val payload: Any)` and created a new class **StreamsTransactionEvent** as `data class StreamsTransactionEvent(val meta: Meta, override val payload: Payload, val schema: Schema): StreamsEvent(payload)` that manages the transaction event event
 - Changed the method `StreamsEventRouter##sendEvents` in order to get topic as input and use it from the `streams.publish` procedure
 - The procedure Manages all kind of Neo4jTypes, in case of Node/Relationship if the topic is has filtering rules all the properties will be filtered according to those rules
 - Updated the documentation