### PR TITLE
fixes #88: Create a unique package

### DIFF
--- a/assembly/assembly.xml
+++ b/assembly/assembly.xml
@@ -1,0 +1,21 @@
+<assembly
+        xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0 http://maven.apache.org/xsd/assembly-1.1.0.xsd">
+    <id>streams-assembly-all</id>
+    <formats>
+        <format>jar</format>
+    </formats>
+    <includeBaseDirectory>false</includeBaseDirectory> <!-- strip the module prefixes -->
+    <dependencySets>
+        <dependencySet>
+            <unpack>true</unpack> <!-- unpack , then repack the jars -->
+            <useTransitiveDependencies>false</useTransitiveDependencies> <!-- do not pull in any transitive dependencies -->
+        </dependencySet>
+    </dependencySets>
+    <containerDescriptorHandlers>
+        <containerDescriptorHandler>
+            <handlerName>metaInf-services</handlerName>
+        </containerDescriptorHandler>
+    </containerDescriptorHandlers>
+</assembly>

--- a/consumer/pom.xml
+++ b/consumer/pom.xml
@@ -6,7 +6,6 @@
 
     <groupId>org.neo4j</groupId>
     <artifactId>neo4j-streams-consumer</artifactId>
-    <version>3.4.7.1</version>
     <name>Neo4j Streams - Consumer</name>
     <description>Neo4j Streams - Kafka Consumer</description>
     <packaging>jar</packaging>
@@ -16,6 +15,5 @@
         <artifactId>neo4j-streams-parent</artifactId>
         <version>3.4.7.1</version>
     </parent>
-
 
 </project>

--- a/consumer/src/main/kotlin/streams/StreamsEventSink.kt
+++ b/consumer/src/main/kotlin/streams/StreamsEventSink.kt
@@ -11,8 +11,14 @@ abstract class StreamsEventSink(private val config: Config,
 
     abstract fun stop()
 
+    abstract fun start()
+
     override fun unavailable() {
         stop()
+    }
+
+    override fun available() {
+        start()
     }
 
 }

--- a/consumer/src/main/kotlin/streams/StreamsEventSinkExtensionFactory.kt
+++ b/consumer/src/main/kotlin/streams/StreamsEventSinkExtensionFactory.kt
@@ -29,7 +29,7 @@ class StreamsEventSinkExtensionFactory : KernelExtensionFactory<StreamsEventSink
         private val configuration = dependencies.config()
         private var streamsLog = log.getUserLog(StreamsEventLifecycle::class.java)
 
-        lateinit var eventSink: StreamsEventSink
+        private lateinit var eventSink: StreamsEventSink
 
         override fun start() {
             try {

--- a/consumer/src/main/kotlin/streams/StreamsSinkConfiguration.kt
+++ b/consumer/src/main/kotlin/streams/StreamsSinkConfiguration.kt
@@ -4,22 +4,27 @@ import org.apache.commons.lang3.StringUtils
 import org.neo4j.kernel.configuration.Config
 
 
-private const val streamsConfigPrefix = "streams."
-private const val streamsSinkTopicPrefix = "sink.topic.cypher."
+private object StreamsSinkConfigurationConstants {
+    const val STREAMS_CONFIG_PREFIX: String = "streams."
+    const val STREAMS_SINK_TOPIC_CYPHER_PREFIX: String = "sink.topic.cypher."
+    const val ENABLED = "sink.enabled"
+}
 
-data class StreamsSinkConfiguration(val sinkPollingInterval: Long = Long.MAX_VALUE,
+data class StreamsSinkConfiguration(val enabled: Boolean = true,
+                                    val sinkPollingInterval: Long = Long.MAX_VALUE,
                                     val topics: Map<String, String> = emptyMap()) {
 
     companion object {
         fun from(cfg: Config): StreamsSinkConfiguration {
             val default = StreamsSinkConfiguration()
             val config = cfg.raw
-                    .filterKeys { it.startsWith(streamsConfigPrefix) }
-                    .mapKeys { it.key.substring(streamsConfigPrefix.length) }
+                    .filterKeys { it.startsWith(StreamsSinkConfigurationConstants.STREAMS_CONFIG_PREFIX) }
+                    .mapKeys { it.key.substring(StreamsSinkConfigurationConstants.STREAMS_CONFIG_PREFIX.length) }
             val topics = config
-                    .filterKeys { it.startsWith(streamsSinkTopicPrefix) }
-                    .mapKeys { it.key.replace(streamsSinkTopicPrefix, StringUtils.EMPTY) }
-            return default.copy(sinkPollingInterval = config.getOrDefault("sink.polling.interval", default.sinkPollingInterval).toString().toLong(),
+                    .filterKeys { it.startsWith(StreamsSinkConfigurationConstants.STREAMS_SINK_TOPIC_CYPHER_PREFIX) }
+                    .mapKeys { it.key.replace(StreamsSinkConfigurationConstants.STREAMS_SINK_TOPIC_CYPHER_PREFIX, StringUtils.EMPTY) }
+            return default.copy(enabled = config.getOrDefault(StreamsSinkConfigurationConstants.ENABLED, default.enabled).toString().toBoolean(),
+                    sinkPollingInterval = config.getOrDefault("sink.polling.interval", default.sinkPollingInterval).toString().toLong(),
                     topics = topics)
         }
     }

--- a/consumer/src/main/kotlin/streams/kafka/KafkaEventSink.kt
+++ b/consumer/src/main/kotlin/streams/kafka/KafkaEventSink.kt
@@ -40,7 +40,7 @@ class KafkaEventSink: StreamsEventSink {
         this.db = db
     }
 
-    override fun available() {
+    override fun start() {
         this.streamsTopicService = StreamsTopicService(this.db, kafkaConfig.streamsSinkConfiguration)
         if (streamsTopicService!!.getTopics().isEmpty()) {
             log.info("No topic configuration found under streams.sink.topic.*, Kafka Sink will not stared")
@@ -48,7 +48,7 @@ class KafkaEventSink: StreamsEventSink {
         }
 
         this.queryExecution = StreamsEventSinkQueryExecution(this.streamsTopicService!!, db, log)
-        createConsumer();
+        createConsumer()
 
         job = createJob()
         log.info("Kafka Sink Connector started.")

--- a/consumer/src/main/kotlin/streams/kafka/KafkaSinkConfiguration.kt
+++ b/consumer/src/main/kotlin/streams/kafka/KafkaSinkConfiguration.kt
@@ -61,8 +61,8 @@ data class KafkaSinkConfiguration(val zookeeperConnect: String = "localhost:2181
                 .mapKeys { it.key.toPointCase() }
         props.putAll(map)
         props.putAll(extraProperties)
-        props.putAll(addDeserializers())
-        props[ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG] = true
+        props.putAll(addDeserializers()) // Fixed deserializers
+        props[ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG] = true // Fixed autocommit
         return props
     }
 

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.neo4j</groupId>
+    <artifactId>neo4j-streams-distribution</artifactId>
+    <name>Neo4j Streams - Distribution</name>
+    <description>Neo4j Streams - Distribution Package</description>
+    <packaging>pom</packaging>
+
+    <parent>
+        <groupId>org.neo4j</groupId>
+        <artifactId>neo4j-streams-parent</artifactId>
+        <version>3.4.7.1</version>
+    </parent>
+
+    <!-- Include here all the required dependencies of the final package -->
+    <dependencies>
+        <dependency>
+            <groupId>org.neo4j</groupId>
+            <artifactId>neo4j-streams-producer</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.neo4j</groupId>
+            <artifactId>neo4j-streams-consumer</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>2.4</version>
+                <executions>
+                    <execution>
+                        <id>streams-assembly</id>
+                        <phase>package</phase> <!-- create assembly in package phase (invoke 'single' goal on assemby plugin)-->
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                        <configuration>
+                            <descriptors>
+                                <descriptor>assembly/assembly.xml</descriptor>
+                            </descriptors>
+                            <appendAssemblyId>false</appendAssemblyId>
+                            <finalName>neo4j-streams-${project.version}</finalName>
+                            <appendAssemblyId>false</appendAssemblyId>
+                            <outputDirectory>../target</outputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/doc/asciidoc/consumer/configuration.adoc
+++ b/doc/asciidoc/consumer/configuration.adoc
@@ -6,8 +6,10 @@ kafka.zookeeper.connect=localhost:2181
 kafka.bootstrap.servers=localhost:9092
 kafka.auto.offset.reset=earliest
 kafka.group.id=neo4j
+
 streams.sink.polling.interval=<The time, in milliseconds, spent waiting in poll if data is not available in the buffer. default=Long.MAX_VALUE>
 streams.sink.topic.cypher.<TOPIC_NAME>=<CYPHER_QUERY>
+streams.sink.enable=<true/false, default=true>
 ----
 
 See the https://kafka.apache.org/documentation/#brokerconfigs[Apache Kafka documentation] for details on these settings.

--- a/doc/asciidoc/producer/configuration.adoc
+++ b/doc/asciidoc/producer/configuration.adoc
@@ -18,6 +18,8 @@ kafka.transaction.id=
 
 streams.source.topic.nodes.<TOPIC_NAME>=<PATTERN>
 streams.source.topic.relationships.<TOPIC_NAME>=<PATTERN>
+streams.source.enable=<true/false, default=true>
+streams.procedures.enable=<true/false, default=true>
 ----
 
 Note: To use the Kafka transactions please set `kafka.transaction.id` and `kafka.acks` properly

--- a/performance/docker-compose.yml
+++ b/performance/docker-compose.yml
@@ -21,6 +21,7 @@ services:
       NEO4J_dbms_memory_heap_max__size: 8G
       # NEO4J_dbms_logs_debug_level: DEBUG
       NEO4J_kafka_batch_size: 16384
+      NEO4J_streams_sink_enabled: "false"
 
   neo4j-consumer:
     image: neo4j:3.4
@@ -40,6 +41,7 @@ services:
       NEO4J_AUTH: neo4j/consumer
       NEO4J_dbms_memory_heap_max__size: 2G
       NEO4J_kafka_max_poll_records: 16384
+      NEO4J_streams_source_enabled: "false"
       NEO4J_streams_sink_topic_cypher_neo4j: "WITH event.payload AS payload, event.meta AS meta CALL apoc.do.case( [
       payload.type = 'node' AND meta.operation = 'created', \
       'CREATE (x:Performance {received_time: apoc.date.currentTimestamp()}) SET x+=props RETURN count(x)'] 

--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,7 @@
         <module>producer</module>
         <module>consumer</module>
         <module>doc</module>
+        <module>distribution</module>
     </modules>
 
     <properties>
@@ -30,7 +31,7 @@
         <java.version>1.8</java.version>
         <kotlin.version>1.3.0</kotlin.version>
         <kotlin.coroutines.version>1.0.0</kotlin.coroutines.version>
-        <neo4j.version>3.4.7</neo4j.version>
+        <neo4j.version>3.4.10</neo4j.version>
         <kafka.version>1.0.1</kafka.version>
         <kotlin.compiler.incremental>true</kotlin.compiler.incremental>
     </properties>

--- a/producer/pom.xml
+++ b/producer/pom.xml
@@ -6,7 +6,6 @@
 
     <groupId>org.neo4j</groupId>
     <artifactId>neo4j-streams-producer</artifactId>
-    <version>3.4.7.1</version>
     <name>Neo4j Streams - Producer</name>
     <description>Neo4j Streams - Kafka Producer</description>
     <packaging>jar</packaging>
@@ -16,6 +15,5 @@
         <artifactId>neo4j-streams-parent</artifactId>
         <version>3.4.7.1</version>
     </parent>
-
 
 </project>

--- a/producer/src/main/kotlin/streams/Extensions.kt
+++ b/producer/src/main/kotlin/streams/Extensions.kt
@@ -21,3 +21,7 @@ fun Relationship.toMap(): Map<String, Any?> {
 fun Node.labelNames() : List<String> {
     return this.labels.map { it.name() }
 }
+
+fun String.toPointCase(): String {
+    return this.split("(?<=[a-z])(?=[A-Z])".toRegex()).joinToString(separator = ".").toLowerCase()
+}

--- a/producer/src/main/kotlin/streams/StreamsEventRouterConfiguration.kt
+++ b/producer/src/main/kotlin/streams/StreamsEventRouterConfiguration.kt
@@ -12,10 +12,12 @@ private fun <T> filterMap(config: Map<String, String>, routingPrefix: String): L
 private object StreamsRoutingConfigurationConstants {
     const val NODE_ROUTING_KEY_PREFIX: String = "streams.source.topic.nodes."
     const val REL_ROUTING_KEY_PREFIX: String = "streams.source.topic.relationships."
-    const val ENABLED = "streams.produce.enabled"
+    const val ENABLED = "streams.source.enabled"
+    const val PROCEDURES_ENABLED = "streams.procedures.enabled"
 }
 
 data class StreamsEventRouterConfiguration(val enabled: Boolean = true,
+                                           val proceduresEnabled: Boolean = true,
                                            val nodeRouting: List<NodeRoutingConfiguration> = listOf(NodeRoutingConfiguration()),
                                            val relRouting: List<RelationshipRoutingConfiguration> = listOf(RelationshipRoutingConfiguration())) {
     companion object {
@@ -28,6 +30,7 @@ data class StreamsEventRouterConfiguration(val enabled: Boolean = true,
 
             val default = StreamsEventRouterConfiguration()
             return default.copy(enabled = config.getOrDefault(StreamsRoutingConfigurationConstants.ENABLED, default.enabled).toString().toBoolean(),
+                    proceduresEnabled = config.getOrDefault(StreamsRoutingConfigurationConstants.PROCEDURES_ENABLED, default.proceduresEnabled).toString().toBoolean(),
                     nodeRouting = if (nodeRouting.isEmpty()) default.nodeRouting else nodeRouting,
                     relRouting = if (relRouting.isEmpty()) default.relRouting else relRouting)
         }

--- a/producer/src/main/kotlin/streams/StreamsExtensionFactory.kt
+++ b/producer/src/main/kotlin/streams/StreamsExtensionFactory.kt
@@ -45,12 +45,16 @@ class StreamsEventRouterLifecycle(val db: GraphDatabaseAPI, val streamHandler: S
     }
 
     fun registerTransactionEventHandler() {
-        txHandler = StreamsTransactionEventHandler(streamHandler, streamsEventRouterConfiguration)
-        db.registerTransactionEventHandler(txHandler)
+        if (streamsEventRouterConfiguration.enabled) {
+            txHandler = StreamsTransactionEventHandler(streamHandler, streamsEventRouterConfiguration)
+            db.registerTransactionEventHandler(txHandler)
+        }
     }
 
     fun unregisterTransactionEventHandler() {
-        db.unregisterTransactionEventHandler(txHandler)
+        if (streamsEventRouterConfiguration.enabled) {
+            db.unregisterTransactionEventHandler(txHandler)
+        }
     }
 
     override fun stop() {

--- a/producer/src/main/kotlin/streams/procedures/StreamsProcedures.kt
+++ b/producer/src/main/kotlin/streams/procedures/StreamsProcedures.kt
@@ -6,6 +6,7 @@ import org.neo4j.procedure.*
 import streams.StreamsEventRouter
 import streams.StreamsEventRouterConfiguration
 import streams.events.StreamsEventBuilder
+import java.lang.RuntimeException
 
 class StreamsProcedures {
 
@@ -15,7 +16,7 @@ class StreamsProcedures {
     @Description("streams.publish(topic, config) - Allows custom streaming from Neo4j to the configured stream environment")
     fun publish(@Name("topic") topic: String?, @Name("payload") payload: Any?,
                 @Name(value = "config", defaultValue = "{}") config: Map<String, Any>?) {
-
+        checkEnabled()
         if (topic == null || topic == StringUtils.EMPTY) {
             log?.info("Topic empty, no message sent")
             return
@@ -37,6 +38,12 @@ class StreamsProcedures {
                 .withTopic(topic)
                 .build()
         StreamsProcedures.eventRouter.sendEvents(topic, listOf(streamsEvent))
+    }
+
+    private fun checkEnabled() {
+        if (!StreamsProcedures.eventRouterConfiguration.proceduresEnabled) {
+            throw RuntimeException("In order to use the procedure you must set streams.procedures.enabled=true")
+        }
     }
 
     companion object {

--- a/producer/src/test/kotlin/streams/kafka/KafkaConfigurationTest.kt
+++ b/producer/src/test/kotlin/streams/kafka/KafkaConfigurationTest.kt
@@ -2,6 +2,7 @@ package streams.kafka
 
 import org.junit.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class KafkaConfigurationTest {
@@ -20,9 +21,16 @@ class KafkaConfigurationTest {
                 "kafka.connection.timeout.ms" to 1,
                 "kafka.replication" to 2,
                 "kafka.transactional.id" to "foo",
-                "kafka.linger.ms" to 10)
+                "kafka.linger.ms" to 10,
+                "kafka.fetch.min.bytes" to 1234)
 
-        val properties = KafkaConfiguration.from(map.mapValues { it.value.toString() }).asProperties()
+        val kafkaConfig = KafkaConfiguration.from(map.mapValues { it.value.toString() })
+
+        assertFalse { kafkaConfig.extraProperties.isEmpty() }
+        assertTrue { kafkaConfig.extraProperties.containsKey("fetch.min.bytes") }
+        assertEquals(1,  kafkaConfig.extraProperties.size)
+
+        val properties = kafkaConfig.asProperties()
 
         assertEquals(map["kafka.zookeeper.connect"], properties["zookeeper.connect"])
         assertEquals(map["kafka.bootstrap.servers"], properties["bootstrap.servers"])
@@ -37,5 +45,6 @@ class KafkaConfigurationTest {
         assertEquals(map["kafka.replication"], properties["replication"])
         assertEquals(map["kafka.transactional.id"], properties["transactional.id"])
         assertEquals(map["kafka.linger.ms"], properties["linger.ms"])
+        assertEquals(map["kafka.fetch.min.bytes"].toString(), properties["fetch.min.bytes"])
     }
 }

--- a/readme.adoc
+++ b/readme.adoc
@@ -15,7 +15,7 @@ Build locally
 mvn clean install
 ----
 
-2. Copy `<producer_or_consumer_dir>/target/neo4j-streams-*.jar` into `$NEO4J_HOME/plugins`
+2. Copy `<project_dir>/target/neo4j-streams-<VERSION>.jar` into `$NEO4J_HOME/plugins`
 3. Restart Neo4j
 
 == Streams Producer


### PR DESCRIPTION
Fixes #88 
Create a `neo4j-streams-<VERSION>.jar` package that contains both producer and consumer

## Proposed Changes (Mandatory)

A brief list of proposed changes in order to fix the issue:
- Create flags in order to enable/disable the components:
   - `streams.source.enabled=true/false`: in order to manage the producer startup
   - `streams.procedures.enabled=true/false`: in order to manage the procedures for producer and consumers (in the future)
   - `streams.sink.enabled=true/false`: in order to manage the sink startup
- Added distribution module that builds the package
- Updated Documentation
