### PR TITLE
fixes #96: New procedure to receive data from the stream

### DIFF
--- a/common/src/main/kotlin/streams/utils/StreamsUtils.kt
+++ b/common/src/main/kotlin/streams/utils/StreamsUtils.kt
@@ -12,7 +12,10 @@ object StreamsUtils {
         return try {
             action()
         } catch (e: Throwable) {
-            when (e::class.java) {
+            if (toIgnore.isEmpty()) {
+                return null
+            }
+            return when (e::class.java) {
                 in toIgnore -> null
                 else -> throw e
             }

--- a/consumer/src/main/kotlin/streams/StreamsEventSink.kt
+++ b/consumer/src/main/kotlin/streams/StreamsEventSink.kt
@@ -1,33 +1,51 @@
 package streams
 
-import org.neo4j.kernel.AvailabilityGuard
 import org.neo4j.kernel.configuration.Config
-import org.neo4j.kernel.internal.GraphDatabaseAPI
+import org.neo4j.logging.Log
 
 abstract class StreamsEventSink(private val config: Config,
-                                private val db: GraphDatabaseAPI): AvailabilityGuard.AvailabilityListener {
-
-    abstract var streamsTopicService: StreamsTopicService?
+                                private val queryExecution: StreamsEventSinkQueryExecution,
+                                private val streamsTopicService: StreamsTopicService,
+                                private val log: Log) {
 
     abstract fun stop()
 
     abstract fun start()
 
-    override fun unavailable() {
-        stop()
-    }
+    abstract fun getEventConsumerFactory(): StreamsEventConsumerFactory
 
-    override fun available() {
-        start()
-    }
+    abstract fun getEventSinkConfigMapper(): StreamsEventSinkConfigMapper
 
 }
 
+abstract class StreamsEventConsumer<T>(private val consumer: T, config: StreamsSinkConfiguration, private val log: Log) {
+
+    abstract fun stop()
+
+    abstract fun withTopics(topics: Set<String>): StreamsEventConsumer<T>
+
+    abstract fun start()
+
+    abstract fun read(): Map<String, List<Map<String, Any?>>>?
+
+}
+
+abstract class StreamsEventConsumerFactory {
+    abstract fun createStreamsEventConsumer(config: Map<String, String>, log: Log): StreamsEventConsumer<*>
+}
+
 object StreamsEventSinkFactory {
-    fun getStreamsEventSink(config: Config, db: GraphDatabaseAPI): StreamsEventSink {
+    fun getStreamsEventSink(config: Config, streamsQueryExecution: StreamsEventSinkQueryExecution,
+                            streamsTopicService: StreamsTopicService, log: Log): StreamsEventSink {
         return Class.forName(config.raw.getOrDefault("streams.sink", "streams.kafka.KafkaEventSink"))
                 .getConstructor(Config::class.java,
-                        GraphDatabaseAPI::class.java)
-                .newInstance(config, db) as StreamsEventSink
+                        StreamsEventSinkQueryExecution::class.java,
+                        StreamsTopicService::class.java,
+                        Log::class.java)
+                .newInstance(config, streamsQueryExecution, streamsTopicService, log) as StreamsEventSink
     }
+}
+
+abstract class StreamsEventSinkConfigMapper(private val baseConfiguration: Map<String, String>, private val mapping: Map<String, String>) {
+    abstract fun convert(config: Map<String, String>): Map<String, String>
 }

--- a/consumer/src/main/kotlin/streams/StreamsEventSinkQueryExecution.kt
+++ b/consumer/src/main/kotlin/streams/StreamsEventSinkQueryExecution.kt
@@ -1,21 +1,34 @@
 package streams
 
+import org.neo4j.graphdb.GraphDatabaseService
 import org.neo4j.kernel.internal.GraphDatabaseAPI
 import org.neo4j.logging.Log
+import streams.utils.Neo4jUtils
+import streams.utils.StreamsUtils
 
 class StreamsEventSinkQueryExecution(private val streamsTopicService: StreamsTopicService, private val db: GraphDatabaseAPI, val log: Log) {
-
-    private val UNWIND: String = "UNWIND {events} AS event"
 
     fun execute(topic: String, params: Collection<Any>) {
         val cypherQuery = streamsTopicService.get(topic)
         if (cypherQuery == null) {
             return
         }
+        val query = "${StreamsUtils.UNWIND} $cypherQuery"
         if(log.isDebugEnabled){
-            log.debug("Processing ${params.size} events from Kafka")
+            log.debug("Processing ${params.size} events with query: $query")
         }
-        db.execute("$UNWIND $cypherQuery", mapOf("events" to params)).close()
+        if (Neo4jUtils.isWriteableInstance(db)) {
+            try {
+                db.execute(query, mapOf("events" to params)).close()
+            } catch (e: Exception) {
+                log.error("Error while executing the query", e)
+            }
+        } else {
+            if(log.isDebugEnabled){
+                log.debug("Not writeable instance")
+            }
+        }
+
     }
 
     fun execute(map: Map<String, Collection<Any>>) {

--- a/consumer/src/main/kotlin/streams/StreamsSinkConfiguration.kt
+++ b/consumer/src/main/kotlin/streams/StreamsSinkConfiguration.kt
@@ -8,22 +8,30 @@ private object StreamsSinkConfigurationConstants {
     const val STREAMS_CONFIG_PREFIX: String = "streams."
     const val STREAMS_SINK_TOPIC_CYPHER_PREFIX: String = "sink.topic.cypher."
     const val ENABLED = "sink.enabled"
+    const val PROCEDURES_ENABLED = "procedures.enabled"
 }
 
 data class StreamsSinkConfiguration(val enabled: Boolean = true,
+                                    val proceduresEnabled: Boolean = true,
                                     val sinkPollingInterval: Long = Long.MAX_VALUE,
                                     val topics: Map<String, String> = emptyMap()) {
 
     companion object {
         fun from(cfg: Config): StreamsSinkConfiguration {
+            return from(cfg.raw)
+        }
+
+        fun from(cfg: Map<String, String>): StreamsSinkConfiguration {
             val default = StreamsSinkConfiguration()
-            val config = cfg.raw
+            val config = cfg
                     .filterKeys { it.startsWith(StreamsSinkConfigurationConstants.STREAMS_CONFIG_PREFIX) }
                     .mapKeys { it.key.substring(StreamsSinkConfigurationConstants.STREAMS_CONFIG_PREFIX.length) }
             val topics = config
                     .filterKeys { it.startsWith(StreamsSinkConfigurationConstants.STREAMS_SINK_TOPIC_CYPHER_PREFIX) }
                     .mapKeys { it.key.replace(StreamsSinkConfigurationConstants.STREAMS_SINK_TOPIC_CYPHER_PREFIX, StringUtils.EMPTY) }
             return default.copy(enabled = config.getOrDefault(StreamsSinkConfigurationConstants.ENABLED, default.enabled).toString().toBoolean(),
+                    proceduresEnabled = config.getOrDefault(StreamsSinkConfigurationConstants.PROCEDURES_ENABLED, default.proceduresEnabled)
+                            .toString().toBoolean(),
                     sinkPollingInterval = config.getOrDefault("sink.polling.interval", default.sinkPollingInterval).toString().toLong(),
                     topics = topics)
         }

--- a/consumer/src/main/kotlin/streams/StreamsTopicService.kt
+++ b/consumer/src/main/kotlin/streams/StreamsTopicService.kt
@@ -3,19 +3,45 @@ package streams
 import org.apache.commons.lang3.StringUtils
 import org.neo4j.kernel.impl.core.EmbeddedProxySPI
 import org.neo4j.kernel.impl.core.GraphProperties
-import org.neo4j.kernel.impl.logging.LogService
 import org.neo4j.kernel.internal.GraphDatabaseAPI
 import streams.utils.Neo4jUtils
 
 
 private const val STREAMS_TOPIC_KEY: String = "streams.sink.topic."
 
-class StreamsTopicService(private val db: GraphDatabaseAPI, private val streamsSinkConfiguration: StreamsSinkConfiguration) {
+class StreamsTopicService(private val db: GraphDatabaseAPI, private val topicMap: Map<String, String>) {
     private val properties: GraphProperties = db.dependencyResolver.resolveDependency(EmbeddedProxySPI::class.java).newGraphPropertiesProxy()
     private val log = Neo4jUtils.getLogService(db).getUserLog(StreamsTopicService::class.java)
 
     init {
-        setAll(streamsSinkConfiguration.topics)
+        clear()
+        setAll(topicMap)
+    }
+
+    fun clear() {
+        return db.beginTx().use {
+            val keys = properties.allProperties
+                    .filterKeys { it.startsWith(STREAMS_TOPIC_KEY) }
+                    .keys
+            keys.forEach {
+                properties.removeProperty(it)
+            }
+            it.success()
+        }
+    }
+
+    fun remove(topic: String) {
+        val key = "$STREAMS_TOPIC_KEY$topic"
+        return db.beginTx().use {
+            if (!properties.hasProperty(key)) {
+                if (log.isDebugEnabled) {
+                    log.debug("No query registered for topic $topic")
+                }
+                return
+            }
+            properties.removeProperty(key)
+            it.success()
+        }
     }
 
     fun set(topic: String, query: String) {

--- a/consumer/src/main/kotlin/streams/kafka/KafkaEventSink.kt
+++ b/consumer/src/main/kotlin/streams/kafka/KafkaEventSink.kt
@@ -4,109 +4,133 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
-import org.apache.kafka.clients.consumer.ConsumerRecords
 import org.apache.kafka.clients.consumer.KafkaConsumer
 import org.apache.kafka.common.errors.WakeupException
-import org.codehaus.jackson.map.ObjectMapper
 import org.neo4j.kernel.configuration.Config
-import org.neo4j.kernel.internal.GraphDatabaseAPI
 import org.neo4j.logging.Log
-import streams.StreamsEventSink
-import streams.StreamsEventSinkQueryExecution
-import streams.StreamsTopicService
-import streams.utils.Neo4jUtils
+import streams.*
+import streams.serialization.JSONUtils
 import streams.utils.StreamsUtils
 
-class KafkaEventSink: StreamsEventSink {
+class KafkaEventSink(private val config: Config,
+                     private val queryExecution: StreamsEventSinkQueryExecution,
+                     private val streamsTopicService: StreamsTopicService,
+                     private val log: Log): StreamsEventSink(config, queryExecution, streamsTopicService, log) {
 
-    private val log: Log
-    private val kafkaConfig: KafkaSinkConfiguration
-    private val db: GraphDatabaseAPI
-
-    private val objectMapper: ObjectMapper = ObjectMapper()
-
+    private lateinit var eventConsumer: StreamsEventConsumer<*>
     private lateinit var job: Job
-    private lateinit var queryExecution: StreamsEventSinkQueryExecution
-    private lateinit var kafkaConsumer: KafkaConsumer<String, ByteArray>
 
-    override var streamsTopicService: StreamsTopicService? = null
+    private val streamsConfigMap = config.raw.filterKeys {
+        it.startsWith("kafka.") || (it.startsWith("streams.") && !it.startsWith("streams.sink.topic.cypher."))
+    }.toMap()
 
-    constructor(config: Config,
-                db: GraphDatabaseAPI): super(config, db) {
-        this.log = Neo4jUtils.getLogService(db)
-                .getUserLog(KafkaEventSink::class.java)
-        log.info("Initializing Kafka Sink Connector")
-        this.kafkaConfig = KafkaSinkConfiguration.from(config)
-        this.db = db
+    private val mappingKeys = mapOf("timeout" to "streams.sink.polling.interval",
+            "from" to "kafka.auto.offset.reset")
+
+    override fun getEventConsumerFactory(): StreamsEventConsumerFactory {
+        return object: StreamsEventConsumerFactory() {
+            override fun createStreamsEventConsumer(config: Map<String, String>, log: Log): StreamsEventConsumer<*> {
+                val kafkaConfig = KafkaSinkConfiguration.from(config)
+                val kafkaConsumer = KafkaConsumer<String, ByteArray>(kafkaConfig.asProperties())
+                return KafkaEventConsumer(kafkaConsumer, kafkaConfig.streamsSinkConfiguration, log)
+            }
+        }
     }
 
     override fun start() {
-        this.streamsTopicService = StreamsTopicService(this.db, kafkaConfig.streamsSinkConfiguration)
-        if (streamsTopicService!!.getTopics().isEmpty()) {
-            log.info("No topic configuration found under streams.sink.topic.*, Kafka Sink will not stared")
+        val streamsConfig = StreamsSinkConfiguration.from(config)
+        if (!streamsConfig.enabled) {
+            log.info("The sink will not started, please set the property streams.sink.enabled=true")
             return
         }
-
-        this.queryExecution = StreamsEventSinkQueryExecution(this.streamsTopicService!!, db, log)
-        createConsumer()
-
-        job = createJob()
-        log.info("Kafka Sink Connector started.")
+        log.info("Starting the Kafka Sink")
+        val topics = streamsTopicService.getAll()
+        this.eventConsumer = getEventConsumerFactory()
+                .createStreamsEventConsumer(config.raw, log)
+                .withTopics(topics.keys)
+        this.eventConsumer.start()
+        if (log.isDebugEnabled) {
+            log.debug("Subscribed topics with queries: $topics")
+        }
+        this.job = createJob()
+        log.info("Kafka Sink started")
     }
 
-    private fun createConsumer() {
-        this.kafkaConsumer = KafkaConsumer(kafkaConfig.asProperties())
-        kafkaConsumer.subscribe(streamsTopicService!!.getTopics())
-        if (log.isDebugEnabled) {
-            log.debug("Subscribing topics: ${streamsTopicService!!.getAll()}")
-        } else {
-            log.info("Subscribing topics: ${streamsTopicService!!.getTopics()}")
+    override fun stop() {
+        log.info("Stopping Sink daemon Job")
+        this.eventConsumer.stop()
+        StreamsUtils.ignoreExceptions({ job.cancel() }, UninitializedPropertyAccessException::class.java)
+    }
+
+    override fun getEventSinkConfigMapper(): StreamsEventSinkConfigMapper {
+        return object: StreamsEventSinkConfigMapper(streamsConfigMap, mappingKeys) {
+            override fun convert(config: Map<String, String>): Map<String, String> {
+                val props = streamsConfigMap
+                        .toMutableMap()
+                props += config.mapKeys { mappingKeys.getOrDefault(it.key, it.key) }
+                return props
+            }
+
         }
     }
 
     private fun createJob(): Job {
+        log.info("Creating Sink daemon Job")
         return GlobalScope.launch(Dispatchers.IO) {
             try {
                 while (true) {
-                    val records = StreamsUtils.ignoreExceptions({
-                        kafkaConsumer.poll(kafkaConfig.streamsSinkConfiguration.sinkPollingInterval)
-                    })
-                    if (records != null) {
-                        consume(records)
+                    val data= eventConsumer.read()
+                    data?.forEach {
+                        if (log.isDebugEnabled) {
+                            log.debug("Reading data from topic ${it.key}, with data ${it.value}")
+                        }
+                        queryExecution.execute(it.key, it.value)
                     }
                 }
             } catch (e: Throwable) {
                 val message = e.message ?: "Generic error, please check the stack trace: "
                 log.error(message, e)
-            } finally {
-                kafkaConsumer.close()
+                eventConsumer.stop()
             }
         }
     }
 
-    private fun consume(records: ConsumerRecords<String, ByteArray>) {
-        streamsTopicService!!.getTopics().forEach {
-            if (log.isDebugEnabled) {
-                log.debug("Reading data from topic $it")
-            }
-            val list = records.records(it)
-                    .map {
-                        objectMapper.readValue(it.value(), Map::class.java)
-                                .mapKeys { it.key.toString() }
-                    }
-            if (list.isNotEmpty()) {
-                if (log.isDebugEnabled) {
-                    log.debug("Reading data from topic $it, with data $list")
-                }
-                queryExecution.execute(it, list)
-            }
+}
+
+class KafkaEventConsumer(private val consumer: KafkaConsumer<String, ByteArray>,
+                         private val config: StreamsSinkConfiguration,
+                         private val log: Log): StreamsEventConsumer<KafkaConsumer<String, ByteArray>>(consumer, config, log) {
+
+    private lateinit var topics: Set<String>
+
+    override fun withTopics(topics: Set<String>): StreamsEventConsumer<KafkaConsumer<String, ByteArray>> {
+        this.topics = topics
+        return this
+    }
+
+    override fun start() {
+        if (topics.isEmpty()) {
+            log.info("No topics specified Kafka Consumer will not started")
+            return
         }
+        this.consumer.subscribe(topics)
+        log.info("Subscribing topics: $topics")
     }
 
     override fun stop() {
-        StreamsUtils.ignoreExceptions({ job.cancel() }, UninitializedPropertyAccessException::class.java)
-        StreamsUtils.ignoreExceptions({ kafkaConsumer.wakeup() }, UninitializedPropertyAccessException::class.java,
-                WakeupException::class.java)
+        StreamsUtils.ignoreExceptions({ consumer.close() }, UninitializedPropertyAccessException::class.java)
     }
 
+    override fun read(): Map<String, List<Map<String, Any?>>>? {
+        val records = consumer.poll(config.sinkPollingInterval)
+        if (records != null && !records.isEmpty) {
+            return records
+                    .map {
+                        it.topic()!! to JSONUtils.readValue(it.value(), Map::class.java)
+                                .mapKeys { it.key.toString() }
+                    }
+                    .groupBy({ it.first }, { it.second })
+        }
+        return null
+    }
 }

--- a/consumer/src/main/kotlin/streams/kafka/KafkaSinkConfiguration.kt
+++ b/consumer/src/main/kotlin/streams/kafka/KafkaSinkConfiguration.kt
@@ -24,7 +24,11 @@ data class KafkaSinkConfiguration(val zookeeperConnect: String = "localhost:2181
     companion object {
 
         fun from(cfg: Config) : KafkaSinkConfiguration {
-            val config = cfg.raw
+            return from(cfg.raw)
+        }
+
+        fun from(cfg: Map<String, String>) : KafkaSinkConfiguration {
+            val config = cfg
                     .filterKeys { it.startsWith(kafkaConfigPrefix) }
                     .mapKeys { it.key.substring(kafkaConfigPrefix.length) }
             val default = KafkaSinkConfiguration()

--- a/consumer/src/main/kotlin/streams/procedures/StreamsSinkProcedures.kt
+++ b/consumer/src/main/kotlin/streams/procedures/StreamsSinkProcedures.kt
@@ -1,0 +1,69 @@
+package streams.procedures
+
+import org.apache.commons.lang3.StringUtils
+import org.neo4j.logging.Log
+import org.neo4j.procedure.*
+import streams.StreamsEventConsumerFactory
+import streams.StreamsEventSinkConfigMapper
+import streams.StreamsSinkConfiguration
+import java.util.stream.Stream
+
+class StreamResult(@JvmField val event: Any)
+
+class StreamsSinkProcedures {
+
+    @JvmField @Context
+    var log: Log? = null
+
+    @Procedure(mode = Mode.SCHEMA, name = "streams.consume")
+    @Description("streams.consume(topic, config) - Allows to subscribe custom topics")
+    fun consume(@Name("topic") topic: String?,
+                @Name(value = "config", defaultValue = "{}") config: Map<String, Any>?): Stream<StreamResult> {
+        checkEnabled()
+        if (topic.isNullOrEmpty()) {
+            log?.info("Topic empty, no message sent")
+            return Stream.empty()
+        }
+
+        val properties = config?.mapValues { it.value.toString() } ?: emptyMap()
+        val configuration = StreamsSinkProcedures.streamsEventSinkConfigMapper.convert(config = properties)
+
+        val consumer = StreamsSinkProcedures
+                .streamsEventConsumerFactory
+                .createStreamsEventConsumer(configuration, log!!)
+                .withTopics(setOf(topic))
+        consumer.start()
+        val data = consumer.read()
+        consumer.stop()
+
+        if (log?.isDebugEnabled!!) {
+            log?.debug("Data retrieved after ${configuration["streams.sink.polling.interval"]} milliseconds: $data")
+        }
+        return data?.values?.flatMap { list -> list.map { StreamResult(it) } }?.stream() ?: Stream.empty()
+    }
+
+    private fun checkEnabled() {
+        if (!StreamsSinkProcedures.streamsSinkConfiguration.proceduresEnabled) {
+            throw RuntimeException("In order to use the procedure you must set streams.procedures.enabled=true")
+        }
+    }
+
+
+    companion object {
+        private lateinit var streamsSinkConfiguration: StreamsSinkConfiguration
+        private lateinit var streamsEventConsumerFactory: StreamsEventConsumerFactory
+        private lateinit var streamsEventSinkConfigMapper: StreamsEventSinkConfigMapper
+
+        fun registerStreamsEventSinkConfigMapper(streamsEventSinkConfigMapper: StreamsEventSinkConfigMapper) {
+            this.streamsEventSinkConfigMapper = streamsEventSinkConfigMapper
+        }
+
+        fun registerStreamsSinkConfiguration(streamsSinkConfiguration: StreamsSinkConfiguration) {
+            this.streamsSinkConfiguration = streamsSinkConfiguration
+        }
+
+        fun registerStreamsEventConsumerFactory(streamsEventConsumerFactory: StreamsEventConsumerFactory) {
+            this.streamsEventConsumerFactory = streamsEventConsumerFactory
+        }
+    }
+}

--- a/consumer/src/test/kotlin/streams/StreamsEventSinkQueryExecutionTest.kt
+++ b/consumer/src/test/kotlin/streams/StreamsEventSinkQueryExecutionTest.kt
@@ -21,7 +21,7 @@ class StreamsEventSinkQueryExecutionTest {
                 .newGraphDatabase()
         val kafkaConfig = KafkaSinkConfiguration(streamsSinkConfiguration = StreamsSinkConfiguration(topics = mapOf("shouldWriteCypherQuery" to "MERGE (n:Label {id: event.id})\n" +
                 "    ON CREATE SET n += event.properties")))
-        val streamsTopicService = StreamsTopicService(db as GraphDatabaseAPI, kafkaConfig.streamsSinkConfiguration)
+        val streamsTopicService = StreamsTopicService(db as GraphDatabaseAPI, kafkaConfig.streamsSinkConfiguration.topics)
         streamsEventSinkQueryExecution = StreamsEventSinkQueryExecution(streamsTopicService, db as GraphDatabaseAPI, NullLog.getInstance())
     }
 

--- a/consumer/src/test/kotlin/streams/StreamsSinkConfigurationTest.kt
+++ b/consumer/src/test/kotlin/streams/StreamsSinkConfigurationTest.kt
@@ -3,6 +3,7 @@ package streams
 import org.junit.Test
 import org.neo4j.kernel.configuration.Config
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class StreamsSinkConfigurationTest {
@@ -22,9 +23,11 @@ class StreamsSinkConfigurationTest {
         val config = Config.builder()
                 .withSetting("streams.sink.polling.interval", pollingInterval)
                 .withSetting(topicKey, topicValue)
+                .withSetting("streams.sink.enabled", "false")
                 .build()
         val streamsConfig = StreamsSinkConfiguration.from(config)
         testFromConf(streamsConfig, pollingInterval, topic, topicValue)
+        assertFalse { streamsConfig.enabled }
     }
 
     companion object {

--- a/consumer/src/test/kotlin/streams/StreamsTopicServiceTest.kt
+++ b/consumer/src/test/kotlin/streams/StreamsTopicServiceTest.kt
@@ -25,7 +25,7 @@ class StreamsTopicServiceTest {
                 .newGraphDatabase() as GraphDatabaseAPI
         kafkaConfig = KafkaSinkConfiguration(streamsSinkConfiguration = StreamsSinkConfiguration(topics = mapOf("shouldWriteCypherQuery" to "MERGE (n:Label {id: event.id})\n" +
                 "    ON CREATE SET n += event.properties")))
-        streamsTopicService = StreamsTopicService(db, kafkaConfig.streamsSinkConfiguration)
+        streamsTopicService = StreamsTopicService(db, kafkaConfig.streamsSinkConfiguration.topics)
         graphProperties = db.dependencyResolver.resolveDependency(EmbeddedProxySPI::class.java).newGraphPropertiesProxy()
     }
 

--- a/doc/asciidoc/procedures/index.adoc
+++ b/doc/asciidoc/procedures/index.adoc
@@ -34,6 +34,7 @@ Input Parameters:
 |Variable Name
 |Type
 |Description
+
 |`topic`
 |String
 |The topic where you want to publish the data
@@ -47,3 +48,55 @@ Input Parameters:
 You can send any kind of data in the payload, nodes, relationships, paths, lists, maps, scalar values and nested versions thereof.
 
 In case of nodes or relationships if the topic is defined in the patterns provided by the configuration their properties will be filtered in according with the configuration.
+
+=== streams.consume
+
+This procedure allows to consume messages from a given topic.
+
+Uses:
+
+`CALL streams.consume('my-topic', {<config>}) YIELD event RETURN event`
+
+Example:
+Imagine you have a producer that publish events like this `{"name": "Andrea", "surname": "Santurbano"}`), we can create user nodes in this way:
+
+```
+CALL streams.consume('my-topic', {<config>}) YIELD event
+CREATE (p:Person{firstName: event.name, lastName: event.surname})
+```
+
+Input Parameters:
+
+[cols="3*",options="header"]
+|===
+|Variable Name
+|Type
+|Description
+
+|`topic`
+|String
+|The topic where you want to publish the data
+
+|`config`
+|Object
+|The configuration parameters
+
+|===
+
+==== Available configuration parameters
+
+[cols="3*",options="header"]
+|===
+|Variable Name
+|Type
+|Description
+
+|`timeout`
+|Long
+|It's the value passed to Kafka https://kafka.apache.org/10/javadoc/org/apache/kafka/clients/consumer/KafkaConsumer.html#poll-long-[`Consumer#poll`] method (milliseconds). Default 1000
+
+|`from`
+|String
+|It's the Kafka configuration parameter `auto.offset.reset`
+
+|===

--- a/kafka-connect-neo4j/src/test/kotlin/streams/kafka/connect/sink/Neo4jSinkTaskTest.kt
+++ b/kafka-connect-neo4j/src/test/kotlin/streams/kafka/connect/sink/Neo4jSinkTaskTest.kt
@@ -1,6 +1,5 @@
 package streams.kafka.connect.sink
 
-import com.github.jcustenborder.kafka.connect.utils.VersionUtil
 import org.apache.kafka.connect.data.Schema
 import org.apache.kafka.connect.data.SchemaBuilder
 import org.apache.kafka.connect.data.Struct

--- a/producer/src/main/kotlin/streams/kafka/KafkaConfiguration.kt
+++ b/producer/src/main/kotlin/streams/kafka/KafkaConfiguration.kt
@@ -4,9 +4,9 @@ import org.apache.commons.lang3.StringUtils
 import org.apache.kafka.clients.producer.ProducerConfig
 import org.apache.kafka.common.serialization.ByteArraySerializer
 import org.apache.kafka.common.serialization.StringSerializer
-import org.codehaus.jackson.map.ObjectMapper
 import streams.extensions.getInt
 import streams.extensions.toPointCase
+import streams.serialization.JSONUtils
 import java.util.*
 
 private val configPrefix = "kafka."
@@ -26,18 +26,13 @@ data class KafkaConfiguration(val zookeeperConnect: String = "localhost:2181",
                               val lingerMs: Int = 1,
                               val extraProperties: Map<String, String> = emptyMap()) {
 
-    private fun asMap(): Map<String, Any?> {
-        return ObjectMapper().convertValue(this, Map::class.java)
-                .mapKeys { it.key.toString() }
-    }
-
     companion object {
         fun from(cfg: Map<String, String>) : KafkaConfiguration {
             val config = cfg.filterKeys { it.startsWith(configPrefix) }.mapKeys { it.key.substring(configPrefix.length) }
 
             val default = KafkaConfiguration()
 
-            val keys = default.asMap().keys.map { it.toPointCase() }
+            val keys = JSONUtils.asMap(default).keys.map { it.toPointCase() }
             val extraProperties = config.filterKeys { !keys.contains(it) }
 
             return default.copy(zookeeperConnect = config.getOrDefault("zookeeper.connect",default.zookeeperConnect),
@@ -60,7 +55,7 @@ data class KafkaConfiguration(val zookeeperConnect: String = "localhost:2181",
 
     fun asProperties(): Properties {
         val props = Properties()
-        val map = this.asMap()
+        val map = JSONUtils.asMap(this)
                 .filter {
                     if (it.key == "transactionalId") {
                         it.value != StringUtils.EMPTY

--- a/producer/src/main/kotlin/streams/procedures/StreamsProcedures.kt
+++ b/producer/src/main/kotlin/streams/procedures/StreamsProcedures.kt
@@ -17,7 +17,7 @@ class StreamsProcedures {
     fun publish(@Name("topic") topic: String?, @Name("payload") payload: Any?,
                 @Name(value = "config", defaultValue = "{}") config: Map<String, Any>?) {
         checkEnabled()
-        if (topic == null || topic == StringUtils.EMPTY) {
+        if (topic.isNullOrEmpty()) {
             log?.info("Topic empty, no message sent")
             return
         }

--- a/producer/src/test/kotlin/streams/integrations/KafkaEventRouterIT.kt
+++ b/producer/src/test/kotlin/streams/integrations/KafkaEventRouterIT.kt
@@ -46,6 +46,7 @@ class KafkaEventRouterIT {
                 .newGraphDatabase() as GraphDatabaseAPI
         db.dependencyResolver.resolveDependency(Procedures::class.java)
                 .registerProcedure(StreamsProcedures::class.java, true)
+
     }
 
     @After
@@ -55,7 +56,8 @@ class KafkaEventRouterIT {
 
     @Test
     fun testCreateNode() {
-        val config = KafkaConfiguration(bootstrapServers = kafka.bootstrapServers)
+        val config = KafkaConfiguration(bootstrapServers = kafka.bootstrapServers,
+                zookeeperConnect = kafka.envMap["KAFKA_ZOOKEEPER_CONNECT"]!!)
         val consumer = createConsumer(config)
         consumer.subscribe(listOf("neo4j"))
         db.execute("CREATE (:Person {name:'John Doe', age:42})").close()


### PR DESCRIPTION
Fixes #96 
Created a procedure `streams.consume` that allows to create consume custom topics at runtime. Example of usage:

```
CALL streams.consume('my-topic', {<config>}) YIELD event
CREATE (p:Person{firstName: event.name, lastName: event.surname})
```

Kafka does not allow to define the number of event that a user want to collect as requested: `events:100`, it has a property `fetch.min.bytes` that _is the minimum amount of data the server should return for a fetch request_ (currently this property is not mapped, let me know if you want it)

## Proposed Changes (Mandatory)

A brief list of proposed changes in order to fix the issue:

  - refactored the Sink in order to expose a common apis that allows to create custom cosumer
  - created the procedure `streams.consume`
  - updated the documentation
