### PR TITLE
fixes #108 (StreamTopicService error in cluster environment at startup) / #109 (Error when Neo4j server shutdown) / #111 (streams.consume procedure consumes just maps messages)

### DIFF
--- a/consumer/src/main/kotlin/streams/StreamsEventSink.kt
+++ b/consumer/src/main/kotlin/streams/StreamsEventSink.kt
@@ -26,7 +26,7 @@ abstract class StreamsEventConsumer<T>(private val consumer: T, config: StreamsS
 
     abstract fun start()
 
-    abstract fun read(): Map<String, List<Map<String, Any?>>>?
+    abstract fun read(): Map<String, List<Any>>?
 
 }
 

--- a/consumer/src/main/kotlin/streams/StreamsEventSinkQueryExecution.kt
+++ b/consumer/src/main/kotlin/streams/StreamsEventSinkQueryExecution.kt
@@ -1,6 +1,5 @@
 package streams
 
-import org.neo4j.graphdb.GraphDatabaseService
 import org.neo4j.kernel.internal.GraphDatabaseAPI
 import org.neo4j.logging.Log
 import streams.utils.Neo4jUtils
@@ -14,12 +13,16 @@ class StreamsEventSinkQueryExecution(private val streamsTopicService: StreamsTop
             return
         }
         val query = "${StreamsUtils.UNWIND} $cypherQuery"
-        if(log.isDebugEnabled){
-            log.debug("Processing ${params.size} events with query: $query")
+        if (log.isDebugEnabled) {
+            log.debug("Processing ${params.size} events, for topic $topic with query: $query")
         }
         if (Neo4jUtils.isWriteableInstance(db)) {
             try {
-                db.execute(query, mapOf("events" to params)).close()
+                val result = db.execute(query, mapOf("events" to params))
+                if (log.isDebugEnabled) {
+                    log.debug("Query statistics:\n${result.queryStatistics}")
+                }
+                result.close()
             } catch (e: Exception) {
                 log.error("Error while executing the query", e)
             }

--- a/consumer/src/main/kotlin/streams/StreamsSinkConfiguration.kt
+++ b/consumer/src/main/kotlin/streams/StreamsSinkConfiguration.kt
@@ -13,7 +13,7 @@ private object StreamsSinkConfigurationConstants {
 
 data class StreamsSinkConfiguration(val enabled: Boolean = true,
                                     val proceduresEnabled: Boolean = true,
-                                    val sinkPollingInterval: Long = Long.MAX_VALUE,
+                                    val sinkPollingInterval: Long = 10000,
                                     val topics: Map<String, String> = emptyMap()) {
 
     companion object {

--- a/consumer/src/main/kotlin/streams/StreamsTopicService.kt
+++ b/consumer/src/main/kotlin/streams/StreamsTopicService.kt
@@ -19,6 +19,9 @@ class StreamsTopicService(private val db: GraphDatabaseAPI, private val topicMap
     }
 
     fun clear() {
+        if (!Neo4jUtils.isWriteableInstance(db)) {
+            return
+        }
         return db.beginTx().use {
             val keys = properties.allProperties
                     .filterKeys { it.startsWith(STREAMS_TOPIC_KEY) }
@@ -31,6 +34,9 @@ class StreamsTopicService(private val db: GraphDatabaseAPI, private val topicMap
     }
 
     fun remove(topic: String) {
+        if (!Neo4jUtils.isWriteableInstance(db)) {
+            return
+        }
         val key = "$STREAMS_TOPIC_KEY$topic"
         return db.beginTx().use {
             if (!properties.hasProperty(key)) {

--- a/consumer/src/test/kotlin/streams/StreamsSinkConfigurationTest.kt
+++ b/consumer/src/test/kotlin/streams/StreamsSinkConfigurationTest.kt
@@ -33,7 +33,7 @@ class StreamsSinkConfigurationTest {
     companion object {
         fun testDefaultConf(default: StreamsSinkConfiguration) {
             assertEquals(emptyMap(), default.topics)
-            assertEquals(Long.MAX_VALUE, default.sinkPollingInterval)
+            assertEquals(10000, default.sinkPollingInterval)
         }
         fun testFromConf(streamsConfig: StreamsSinkConfiguration, pollingInterval: String, topic: String, topicValue: String) {
             assertEquals(pollingInterval.toLong(), streamsConfig.sinkPollingInterval)

--- a/doc/asciidoc/procedures/index.adoc
+++ b/doc/asciidoc/procedures/index.adoc
@@ -58,11 +58,11 @@ Uses:
 `CALL streams.consume('my-topic', {<config>}) YIELD event RETURN event`
 
 Example:
-Imagine you have a producer that publish events like this `{"name": "Andrea", "surname": "Santurbano"}`), we can create user nodes in this way:
+Imagine you have a producer that publish events like this `{"name": "Andrea", "surname": "Santurbano"}`, we can create user nodes in this way:
 
 ```
 CALL streams.consume('my-topic', {<config>}) YIELD event
-CREATE (p:Person{firstName: event.name, lastName: event.surname})
+CREATE (p:Person{firstName: event.data.name, lastName: event.data.surname})
 ```
 
 Input Parameters:

--- a/producer/src/main/kotlin/streams/StreamsExtensionFactory.kt
+++ b/producer/src/main/kotlin/streams/StreamsExtensionFactory.kt
@@ -29,29 +29,31 @@ class StreamsExtensionFactory : KernelExtensionFactory<StreamsExtensionFactory.D
 class StreamsEventRouterLifecycle(val db: GraphDatabaseAPI, val streamHandler: StreamsEventRouter,
                                   val streamsEventRouterConfiguration: StreamsEventRouterConfiguration,
                                   private val log: LogService): LifecycleAdapter() {
-    private val streamsLog = log.getUserLog(StreamsExtensionFactory::class.java)
+    private val streamsLog = log.getUserLog(StreamsEventRouterLifecycle::class.java)
     private lateinit var txHandler: StreamsTransactionEventHandler
 
     override fun start() {
         try {
+            streamsLog.info("Initialising the Streams Source module")
             StreamsProcedures.registerEventRouter(eventRouter = streamHandler)
             StreamsProcedures.registerEventRouterConfiguration(eventRouterConfiguration = streamsEventRouterConfiguration)
             streamHandler.start()
             registerTransactionEventHandler()
+            streamsLog.info("Streams Source module initialised")
         } catch (e: Exception) {
             e.printStackTrace()
             streamsLog.error("Error initializing the streaming producer", e)
         }
     }
 
-    fun registerTransactionEventHandler() {
+    private fun registerTransactionEventHandler() {
         if (streamsEventRouterConfiguration.enabled) {
             txHandler = StreamsTransactionEventHandler(streamHandler, streamsEventRouterConfiguration)
             db.registerTransactionEventHandler(txHandler)
         }
     }
 
-    fun unregisterTransactionEventHandler() {
+    private fun unregisterTransactionEventHandler() {
         if (streamsEventRouterConfiguration.enabled) {
             db.unregisterTransactionEventHandler(txHandler)
         }


### PR DESCRIPTION
Fixes #108, #109, #111 

This PR fixes the three issues.

## Proposed Changes (Mandatory)

A brief list of proposed changes in order to fix the issue:

  - added `Neo4jUtils.isWriteableInstance` where necessary
  - in order to fix #109 we reduced the poll interval to 10 seconds (this is an intermediate solution), the next step is providing #102
  - the `streams.consume` procedure now is able consume messages like `[{"name": "Andrea", "surname": "Santurbano"}, {"name": "Michael", "surname": "Hunger"}]`, moreover a better failure management is provided
 