### PR TITLE
Adjust config for kafka-connect-maven-plugin in Kafka connector

### DIFF
--- a/kafka-connect-neo4j/pom.xml
+++ b/kafka-connect-neo4j/pom.xml
@@ -107,7 +107,8 @@
                             <documentationUrl>https://neo4j-contrib.github.io/neo4j-streams/</documentationUrl>
                             <description>It's a basic Apache Kafka Connect SinkConnector which allows moving data from Kafka topics into Neo4j via Cypher templated queries.</description>
                             <logo>assets/neo4j-logo.png</logo>
-                            <supportSummary>Support provided through community involvement.</supportSummary>
+                            <supportSummary><![CDATA[Support through <a href="https://neo4j.com/labs/">Neo4j Labs</a>]]></supportSummary>
+                            <sourceUrl>https://github.com/neo4j-contrib/neo4j-streams/tree/master/kafka-connect-neo4j</sourceUrl>
                             <supportUrl>${project.issueManagement.url}</supportUrl>
                             <confluentControlCenterIntegration>true</confluentControlCenterIntegration>
                             <tags>


### PR DESCRIPTION
(No issue filed)

There were some small issues with the metadata associated with the Kafka connector in Confluent Hub.

## Proposed Changes (Mandatory)

  - Alter the `supportSummary` configuration for the `kafka-connect-maven-plugin` to match verbiage provided by @jexp
  - Add a `sourceUrl` that provides a visitable link to the source code for the connector to the configuration for the `kafka-connect-maven-plugin`
