### PR TITLE
fixes #116: Connector Configuration (Sink)

### DIFF
--- a/kafka-connect-neo4j/docker/readme.adoc
+++ b/kafka-connect-neo4j/docker/readme.adoc
@@ -6,22 +6,22 @@ You can set the following configuration values via Confluent Connect UI, or via 
 |===
 |Field|Type|Description
 
-|neo4j.server.uri|String|The Bolt URI
+|neo4j.server.uri|String|The Bolt URI (default bolt://localhost:7687)
 |neo4j.authentication.type|enum[NONE, BASIC, KERBEROS]| The authentication type (default BASIC)
 |neo4j.batch.size|Int|The max number of events processed by the Cypher query (default 1000)
-|neo4j.batch.timeout.msec|Long|The execution timeout for the cypher query (default 30000)
+|neo4j.batch.timeout.msecs|Long|The execution timeout for the cypher query (default 30000)
 |neo4j.authentication.basic.username|String| The authentication username
 |neo4j.authentication.basic.password|String| The authentication password
 |neo4j.authentication.basic.realm|String| The authentication realm
 |neo4j.authentication.kerberos.ticket|String| The Kerberos ticket
 |neo4j.encryption.enabled|Boolean| If the encryption is enabled (default false)
-|neo4j.encryption.trust.strategy|enum[TRUST_ALL_CERTIFICATES,TRUST_CUSTOM_CA_SIGNED_CERTIFICATES,TRUST_SYSTEM_CA_SIGNED_CERTIFICATES]| The Neo4j trust strategy (default TRUST_ALL_CERTIFICATES)
+|neo4j.encryption.trust.strategy|enum[TRUST_ALL_CERTIFICATES, TRUST_CUSTOM_CA_SIGNED_CERTIFICATES, TRUST_SYSTEM_CA_SIGNED_CERTIFICATES]| The Neo4j trust strategy (default TRUST_ALL_CERTIFICATES)
 |neo4j.encryption.ca.certificate.path|String| The path of the certificate
 |neo4j.connection.max.lifetime.msecs|Long| The max Neo4j connection lifetime (default 1 hour)
 |neo4j.connection.acquisition.timeout.msecs|Long| The max Neo4j acquisition timeout (default 1 hour)
 |neo4j.connection.liveness.check.timeout.msecs|Long| The max Neo4j liveness check timeout (default 1 hour)
 |neo4j.connection.max.pool.size|Int| The max pool size (default 100)
-|neo4j.load.balance.strategy|enum[ROUND_ROBIN,LEAST_CONNECTED]| The Neo4j load balance strategy (default LEAST_CONNECTED)
+|neo4j.load.balance.strategy|enum[ROUND_ROBIN, LEAST_CONNECTED]| The Neo4j load balance strategy (default LEAST_CONNECTED)
 |===
 
 === Build it locally

--- a/kafka-connect-neo4j/src/main/kotlin/streams/kafka/connect/sink/Neo4jSinkConnectorConfig.kt
+++ b/kafka-connect-neo4j/src/main/kotlin/streams/kafka/connect/sink/Neo4jSinkConnectorConfig.kt
@@ -8,6 +8,7 @@ import com.github.jcustenborder.kafka.connect.utils.config.validators.Validators
 import com.github.jcustenborder.kafka.connect.utils.config.validators.filesystem.ValidFile
 import org.apache.kafka.common.config.AbstractConfig
 import org.apache.kafka.common.config.ConfigDef
+import org.apache.kafka.common.config.ConfigException
 import org.apache.kafka.connect.sink.SinkTask
 import org.neo4j.driver.internal.async.pool.PoolSettings
 import org.neo4j.driver.v1.Config
@@ -19,21 +20,33 @@ enum class AuthenticationType {
     NONE, BASIC, KERBEROS
 }
 
-class Neo4jSinkConnectorConfig(originals: Map<*, *>) : AbstractConfig(config(), originals) {
+object ConfigGroup {
+    const val ENCRYPTION = "Encryption"
+    const val CONNECTION = "Connection"
+    const val AUTHENTICATION = "Authentication"
+    const val TOPIC_CYPHER_MAPPING = "Topic Cypher Mapping"
+    const val BATCH = "Batch Management"
+    const val DEPRECATED = "Deprecated Properties (please check the documentation)"
+}
+
+class Neo4jSinkConnectorConfig(originals: Map<*, *>): AbstractConfig(config(), originals) {
     val encryptionEnabled: Boolean
     val encryptionTrustStrategy: Config.TrustStrategy.Strategy
+    var encryptionCACertificateFile: File? = null
+
     val authenticationType: AuthenticationType
     val authenticationUsername: String
     val authenticationPassword: String
     val authenticationRealm: String
     val authenticationKerberosTicket: String
+
     val serverUri: URI
-    var encryptionCACertificateFile: File? = null
     val connectionMaxConnectionLifetime: Long
     val connectionLifenessCheckTimeout: Long
     val connectionPoolMaxSize: Int
     val connectionAcquisitionTimeout: Long
     val loadBalancingStrategy: Config.LoadBalancingStrategy
+
     val batchTimeout: Long
     val batchSize: Int
 
@@ -42,31 +55,35 @@ class Neo4jSinkConnectorConfig(originals: Map<*, *>) : AbstractConfig(config(), 
     init {
         encryptionEnabled = getBoolean(ENCRYPTION_ENABLED)
         encryptionTrustStrategy = ConfigUtils
-                .getEnum(Config.TrustStrategy.Strategy::class.java, this, ENCRYPTION_TRUST_STRATEGY) as Config.TrustStrategy.Strategy
+                .getEnum(Config.TrustStrategy.Strategy::class.java, this, ENCRYPTION_TRUST_STRATEGY)
         val encryptionCACertificatePATH = getString(ENCRYPTION_CA_CERTIFICATE_PATH) ?: ""
-
         if (encryptionCACertificatePATH != "") {
             encryptionCACertificateFile = File(encryptionCACertificatePATH)
         }
 
         authenticationType = ConfigUtils
                 .getEnum(AuthenticationType::class.java, this, AUTHENTICATION_TYPE)
-        serverUri = ConfigUtils.uri(this, SERVER_URI)
         authenticationRealm = getString(AUTHENTICATION_BASIC_REALM)
         authenticationUsername = getString(AUTHENTICATION_BASIC_USERNAME)
         authenticationPassword = getPassword(AUTHENTICATION_BASIC_PASSWORD).value()
         authenticationKerberosTicket = getPassword(AUTHENTICATION_KERBEROS_TICKET).value()
+
+        serverUri = ConfigUtils.uri(this, SERVER_URI)
         connectionLifenessCheckTimeout = getLong(CONNECTION_LIVENESS_CHECK_TIMEOUT_MSECS)
         connectionMaxConnectionLifetime = getLong(CONNECTION_MAX_CONNECTION_LIFETIME_MSECS)
         connectionPoolMaxSize = getInt(CONNECTION_POOL_MAX_SIZE)
         connectionAcquisitionTimeout = getLong(CONNECTION_MAX_CONNECTION_ACQUISITION_TIMEOUT_MSECS)
-
         loadBalancingStrategy = ConfigUtils
-                .getEnum(Config.LoadBalancingStrategy::class.java, this, CONNECTION_LOAD_BALANCE_STRATEGY) as Config.LoadBalancingStrategy
-        batchTimeout = getLong(BATCH_TIMEOUT_MSEC)
+                .getEnum(Config.LoadBalancingStrategy::class.java, this, CONNECTION_LOAD_BALANCE_STRATEGY)
+
+        batchTimeout = getLong(BATCH_TIMEOUT_MSECS)
         batchSize = getInt(BATCH_SIZE)
 
-        topicMap = originals
+        topicMap = getTopics(originals)
+    }
+
+    private fun getTopics(originals: Map<*, *>): Map<String, String> {
+        val topicMap = originals
                 .filterKeys { it.toString().startsWith(TOPIC_CYPHER_PREFIX) }
                 .mapKeys { it.key.toString().replace(TOPIC_CYPHER_PREFIX, "") }
                 .mapValues { it.value.toString() }
@@ -77,140 +94,169 @@ class Neo4jSinkConnectorConfig(originals: Map<*, *>) : AbstractConfig(config(), 
             emptySet()
         }
         if (topics != topicMap.keys.toSet()) {
-            throw RuntimeException("There is a mismatch between provided Cypher queries (${topicMap.keys}) and configured topics ($topics)")
+            throw ConfigException("There is a mismatch between provided Cypher queries (${topicMap.keys}) and configured topics ($topics)")
         }
+        return topicMap
     }
 
     companion object {
         const val SERVER_URI = "neo4j.server.uri"
+
         const val AUTHENTICATION_TYPE = "neo4j.authentication.type"
-        const val BATCH_SIZE = "neo4j.batch.size"
-        const val BATCH_TIMEOUT_MSEC = "neo4j.batch.timeout.msec"
         const val AUTHENTICATION_BASIC_USERNAME = "neo4j.authentication.basic.username"
         const val AUTHENTICATION_BASIC_PASSWORD = "neo4j.authentication.basic.password"
         const val AUTHENTICATION_BASIC_REALM = "neo4j.authentication.basic.realm"
         const val AUTHENTICATION_KERBEROS_TICKET = "neo4j.authentication.kerberos.ticket"
+
         const val ENCRYPTION_ENABLED = "neo4j.encryption.enabled"
         const val ENCRYPTION_TRUST_STRATEGY = "neo4j.encryption.trust.strategy"
         const val ENCRYPTION_CA_CERTIFICATE_PATH = "neo4j.encryption.ca.certificate.path"
+
         const val CONNECTION_MAX_CONNECTION_LIFETIME_MSECS = "neo4j.connection.max.lifetime.msecs"
         const val CONNECTION_MAX_CONNECTION_ACQUISITION_TIMEOUT_MSECS = "neo4j.connection.acquisition.timeout.msecs"
         const val CONNECTION_LIVENESS_CHECK_TIMEOUT_MSECS = "neo4j.connection.liveness.check.timeout.msecs"
         const val CONNECTION_POOL_MAX_SIZE = "neo4j.connection.max.pool.size"
         const val CONNECTION_LOAD_BALANCE_STRATEGY = "neo4j.load.balance.strategy"
+
+        const val BATCH_SIZE = "neo4j.batch.size"
+        const val BATCH_TIMEOUT_MSECS = "neo4j.batch.timeout.msecs"
+
         const val TOPIC_CYPHER_PREFIX = "neo4j.topic.cypher."
-        const val GROUP_ENCRYPTION = "Encryption"
-        const val GROUP_CONNECTION = "Connection"
 
         const val CONNECTION_POOL_MAX_SIZE_DEFAULT = 100
-        val BATCH_TIMEOUT_MSEC_DEFAULT = TimeUnit.SECONDS.toMillis(30L)
+        val BATCH_TIMEOUT_DEFAULT = TimeUnit.SECONDS.toMillis(30L)
         const val BATCH_SIZE_DEFAULT = 1000
 
         fun config(): ConfigDef {
             return ConfigDef()
-                    .define(ConfigKeyBuilder.of(SERVER_URI, ConfigDef.Type.STRING)
-                            .documentation(SERVER_URI).importance(ConfigDef.Importance.HIGH)
-                            .defaultValue("bolt://localhost:7687").group(GROUP_CONNECTION)
-                            .validator(Validators.validURI("bolt", "bolt+routing"))
-                            .build())
-                    .define(ConfigKeyBuilder.of(AUTHENTICATION_TYPE, ConfigDef.Type.STRING)
-                            .documentation(AUTHENTICATION_TYPE)
+                    .define(ConfigKeyBuilder
+                            .of(AUTHENTICATION_TYPE, ConfigDef.Type.STRING)
+                            .documentation(PropertiesUtil.getProperty(AUTHENTICATION_TYPE))
                             .importance(ConfigDef.Importance.HIGH)
-                            .defaultValue(AuthenticationType.BASIC.toString()).group(GROUP_CONNECTION)
+                            .defaultValue(AuthenticationType.BASIC.toString())
+                            .group(ConfigGroup.AUTHENTICATION)
                             .validator(ValidEnum.of(AuthenticationType::class.java))
                             .build())
                     .define(ConfigKeyBuilder
                             .of(AUTHENTICATION_BASIC_USERNAME, ConfigDef.Type.STRING)
-                            .documentation(AUTHENTICATION_BASIC_USERNAME)
-                            .importance(ConfigDef.Importance.HIGH).defaultValue("").group(GROUP_CONNECTION)
-                            .recommender(Recommenders
-                                    .visibleIf(AUTHENTICATION_TYPE, AuthenticationType.BASIC.toString()))
+                            .documentation(PropertiesUtil.getProperty(AUTHENTICATION_BASIC_USERNAME))
+                            .importance(ConfigDef.Importance.HIGH)
+                            .defaultValue("")
+                            .group(ConfigGroup.AUTHENTICATION)
+                            .recommender(Recommenders.visibleIf(AUTHENTICATION_TYPE, AuthenticationType.BASIC.toString()))
                             .build())
                     .define(ConfigKeyBuilder
                             .of(AUTHENTICATION_BASIC_PASSWORD, ConfigDef.Type.PASSWORD)
-                            .documentation(AUTHENTICATION_BASIC_PASSWORD)
-                            .importance(ConfigDef.Importance.HIGH).defaultValue("").group(GROUP_CONNECTION)
-                            .recommender(Recommenders
-                                    .visibleIf(AUTHENTICATION_TYPE, AuthenticationType.BASIC.toString()))
+                            .documentation(PropertiesUtil.getProperty(AUTHENTICATION_BASIC_PASSWORD))
+                            .importance(ConfigDef.Importance.HIGH)
+                            .defaultValue("")
+                            .group(ConfigGroup.AUTHENTICATION)
+                            .recommender(Recommenders.visibleIf(AUTHENTICATION_TYPE, AuthenticationType.BASIC.toString()))
                             .build())
                     .define(ConfigKeyBuilder
                             .of(AUTHENTICATION_BASIC_REALM, ConfigDef.Type.STRING)
-                            .documentation(AUTHENTICATION_BASIC_REALM)
-                            .importance(ConfigDef.Importance.HIGH).defaultValue("").group(GROUP_CONNECTION)
-                            .recommender(Recommenders
-                                    .visibleIf(AUTHENTICATION_TYPE, AuthenticationType.BASIC.toString()))
+                            .documentation(PropertiesUtil.getProperty(AUTHENTICATION_BASIC_REALM))
+                            .importance(ConfigDef.Importance.HIGH)
+                            .defaultValue("")
+                            .group(ConfigGroup.AUTHENTICATION)
+                            .recommender(Recommenders.visibleIf(AUTHENTICATION_TYPE, AuthenticationType.BASIC.toString()))
                             .build())
                     .define(ConfigKeyBuilder
                             .of(AUTHENTICATION_KERBEROS_TICKET, ConfigDef.Type.PASSWORD)
-                            .documentation(AUTHENTICATION_KERBEROS_TICKET)
-                            .importance(ConfigDef.Importance.HIGH).defaultValue("").group(GROUP_CONNECTION)
-                            .recommender(Recommenders
-                                    .visibleIf(AUTHENTICATION_TYPE, AuthenticationType.KERBEROS.toString()))
+                            .documentation(PropertiesUtil.getProperty(AUTHENTICATION_KERBEROS_TICKET))
+                            .importance(ConfigDef.Importance.HIGH)
+                            .defaultValue("")
+                            .group(ConfigGroup.AUTHENTICATION)
+                            .recommender(Recommenders.visibleIf(AUTHENTICATION_TYPE, AuthenticationType.KERBEROS.toString()))
                             .build())
-                    .define(ConfigKeyBuilder.of(CONNECTION_POOL_MAX_SIZE, ConfigDef.Type.INT)
-                            .documentation(CONNECTION_POOL_MAX_SIZE)
-                            .importance(ConfigDef.Importance.LOW).defaultValue(CONNECTION_POOL_MAX_SIZE_DEFAULT)
-                            .group(GROUP_CONNECTION).validator(ConfigDef.Range.atLeast(1))
+                    .define(ConfigKeyBuilder
+                            .of(SERVER_URI, ConfigDef.Type.STRING)
+                            .documentation(PropertiesUtil.getProperty(SERVER_URI))
+                            .importance(ConfigDef.Importance.HIGH)
+                            .defaultValue("bolt://localhost:7687")
+                            .group(ConfigGroup.CONNECTION)
+                            .validator(Validators.validURI("bolt", "bolt+routing"))
+                            .build())
+                    .define(ConfigKeyBuilder
+                            .of(CONNECTION_POOL_MAX_SIZE, ConfigDef.Type.INT)
+                            .documentation(PropertiesUtil.getProperty(CONNECTION_POOL_MAX_SIZE))
+                            .importance(ConfigDef.Importance.LOW)
+                            .defaultValue(CONNECTION_POOL_MAX_SIZE_DEFAULT)
+                            .group(ConfigGroup.CONNECTION)
+                            .validator(ConfigDef.Range.atLeast(1))
                             .build())
                     .define(ConfigKeyBuilder
                             .of(CONNECTION_MAX_CONNECTION_LIFETIME_MSECS, ConfigDef.Type.LONG)
-                            .documentation(CONNECTION_MAX_CONNECTION_LIFETIME_MSECS)
+                            .documentation(PropertiesUtil.getProperty(CONNECTION_MAX_CONNECTION_LIFETIME_MSECS))
                             .importance(ConfigDef.Importance.LOW)
                             .defaultValue(PoolSettings.DEFAULT_MAX_CONNECTION_LIFETIME)
-                            .group(GROUP_CONNECTION).validator(ConfigDef.Range.atLeast(1))
+                            .group(ConfigGroup.CONNECTION)
+                            .validator(ConfigDef.Range.atLeast(1))
                             .build())
                     .define(ConfigKeyBuilder
                             .of(CONNECTION_LIVENESS_CHECK_TIMEOUT_MSECS, ConfigDef.Type.LONG)
-                            .documentation(CONNECTION_LIVENESS_CHECK_TIMEOUT_MSECS)
+                            .documentation(PropertiesUtil.getProperty(CONNECTION_LIVENESS_CHECK_TIMEOUT_MSECS))
                             .importance(ConfigDef.Importance.LOW)
                             .defaultValue(PoolSettings.DEFAULT_CONNECTION_ACQUISITION_TIMEOUT)
-                            .group(GROUP_CONNECTION).validator(ConfigDef.Range.atLeast(1))
+                            .group(ConfigGroup.CONNECTION)
+                            .validator(ConfigDef.Range.atLeast(1))
                             .build())
                     .define(ConfigKeyBuilder
                             .of(CONNECTION_MAX_CONNECTION_ACQUISITION_TIMEOUT_MSECS, ConfigDef.Type.LONG)
-                            .documentation(CONNECTION_MAX_CONNECTION_ACQUISITION_TIMEOUT_MSECS)
+                            .documentation(PropertiesUtil.getProperty(CONNECTION_MAX_CONNECTION_ACQUISITION_TIMEOUT_MSECS))
                             .importance(ConfigDef.Importance.LOW)
                             .defaultValue(PoolSettings.DEFAULT_CONNECTION_ACQUISITION_TIMEOUT)
-                            .group(GROUP_CONNECTION).validator(ConfigDef.Range.atLeast(1))
+                            .group(ConfigGroup.CONNECTION)
+                            .validator(ConfigDef.Range.atLeast(1))
                             .build())
-                    .define(ConfigKeyBuilder.of(CONNECTION_LOAD_BALANCE_STRATEGY, ConfigDef.Type.STRING)
-                            .documentation(CONNECTION_LOAD_BALANCE_STRATEGY)
+                    .define(ConfigKeyBuilder
+                            .of(CONNECTION_LOAD_BALANCE_STRATEGY, ConfigDef.Type.STRING)
+                            .documentation(PropertiesUtil.getProperty(CONNECTION_LOAD_BALANCE_STRATEGY))
                             .importance(ConfigDef.Importance.LOW)
                             .defaultValue(Config.LoadBalancingStrategy.LEAST_CONNECTED.toString())
-                            .group(GROUP_CONNECTION)
+                            .group(ConfigGroup.CONNECTION)
                             .validator(ValidEnum.of(Config.LoadBalancingStrategy::class.java))
                             .build())
-                    .define(ConfigKeyBuilder.of(ENCRYPTION_ENABLED, ConfigDef.Type.BOOLEAN)
-                            .documentation(ENCRYPTION_ENABLED)
-                            .importance(ConfigDef.Importance.HIGH).defaultValue(false)
-                            .group(GROUP_ENCRYPTION).build())
-                    .define(
-                            ConfigKeyBuilder.of(ENCRYPTION_TRUST_STRATEGY, ConfigDef.Type.STRING)
-                                    .documentation(ENCRYPTION_TRUST_STRATEGY)
-                                    .importance(ConfigDef.Importance.MEDIUM)
-                                    .defaultValue(Config.TrustStrategy.Strategy.TRUST_ALL_CERTIFICATES.toString())
-                                    .group(GROUP_ENCRYPTION)
-                                    .validator(ValidEnum.of(Config.TrustStrategy.Strategy::class.java))
-                                    .recommender(Recommenders.visibleIf(ENCRYPTION_ENABLED, true))
-                                    .build())
+                    .define(ConfigKeyBuilder
+                            .of(ENCRYPTION_ENABLED, ConfigDef.Type.BOOLEAN)
+                            .documentation(PropertiesUtil.getProperty(ENCRYPTION_ENABLED))
+                            .importance(ConfigDef.Importance.HIGH)
+                            .defaultValue(false)
+                            .group(ConfigGroup.ENCRYPTION).build())
+                    .define(ConfigKeyBuilder
+                            .of(ENCRYPTION_TRUST_STRATEGY, ConfigDef.Type.STRING)
+                            .documentation(PropertiesUtil.getProperty(ENCRYPTION_TRUST_STRATEGY))
+                            .importance(ConfigDef.Importance.MEDIUM)
+                            .defaultValue(Config.TrustStrategy.Strategy.TRUST_ALL_CERTIFICATES.toString())
+                            .group(ConfigGroup.ENCRYPTION)
+                            .validator(ValidEnum.of(Config.TrustStrategy.Strategy::class.java))
+                            .recommender(Recommenders.visibleIf(ENCRYPTION_ENABLED, true))
+                            .build())
                     .define(ConfigKeyBuilder
                             .of(ENCRYPTION_CA_CERTIFICATE_PATH, ConfigDef.Type.STRING)
-                            .documentation(ENCRYPTION_CA_CERTIFICATE_PATH)
-                            .importance(ConfigDef.Importance.MEDIUM).defaultValue("").group(GROUP_ENCRYPTION)
+                            .documentation(PropertiesUtil.getProperty(ENCRYPTION_CA_CERTIFICATE_PATH))
+                            .importance(ConfigDef.Importance.MEDIUM)
+                            .defaultValue("")
+                            .group(ConfigGroup.ENCRYPTION)
                             .validator(Validators.blankOr(ValidFile.of())) // TODO check
                             .recommender(Recommenders.visibleIf(
                                     ENCRYPTION_TRUST_STRATEGY,
                                     Config.TrustStrategy.Strategy.TRUST_CUSTOM_CA_SIGNED_CERTIFICATES.toString()))
                             .build())
-                    .define(ConfigKeyBuilder.of(BATCH_SIZE, ConfigDef.Type.INT)
-                            .documentation(BATCH_SIZE)
+                    .define(ConfigKeyBuilder
+                            .of(BATCH_SIZE, ConfigDef.Type.INT)
+                            .documentation(PropertiesUtil.getProperty(BATCH_SIZE))
                             .importance(ConfigDef.Importance.LOW)
-                            .defaultValue(BATCH_SIZE_DEFAULT).group(GROUP_CONNECTION)
+                            .defaultValue(BATCH_SIZE_DEFAULT)
+                            .group(ConfigGroup.BATCH)
+                            .validator(ConfigDef.Range.atLeast(1))
                             .build())
-                    .define(ConfigKeyBuilder.of(BATCH_TIMEOUT_MSEC, ConfigDef.Type.LONG)
-                            .documentation(BATCH_TIMEOUT_MSEC)
+                    .define(ConfigKeyBuilder
+                            .of(BATCH_TIMEOUT_MSECS, ConfigDef.Type.LONG)
+                            .documentation(PropertiesUtil.getProperty(BATCH_TIMEOUT_MSECS))
                             .importance(ConfigDef.Importance.LOW)
-                            .defaultValue(BATCH_TIMEOUT_MSEC_DEFAULT).group(GROUP_CONNECTION)
+                            .defaultValue(BATCH_TIMEOUT_DEFAULT)
+                            .group(ConfigGroup.BATCH)
                             .validator(ConfigDef.Range.atLeast(1)).build())
         }
     }

--- a/kafka-connect-neo4j/src/main/kotlin/streams/kafka/connect/sink/PropertiesUtil.kt
+++ b/kafka-connect-neo4j/src/main/kotlin/streams/kafka/connect/sink/PropertiesUtil.kt
@@ -12,7 +12,8 @@ class PropertiesUtil {
         private var VERSION: String? = null
         init {
             properties = Properties()
-            properties!!.load(PropertiesUtil::class.java.getResourceAsStream("/kafka-connect-neo4j.properties"))
+            properties!!.load(PropertiesUtil::class.java.getResourceAsStream("/kafka-connect-version.properties"))
+            properties!!.load(PropertiesUtil::class.java.getResourceAsStream("/kafka-connect-sink.properties"))
             VERSION = try {
                 properties!!.getProperty("version", DEFAULT_VERSION).trim()
             } catch (e: Exception) {
@@ -23,6 +24,10 @@ class PropertiesUtil {
 
         fun getVersion(): String {
             return VERSION!!
+        }
+
+        fun getProperty(key: String): String {
+            return properties!!.getProperty(key)
         }
     }
 }

--- a/kafka-connect-neo4j/src/main/resources/kafka-connect-sink.properties
+++ b/kafka-connect-neo4j/src/main/resources/kafka-connect-sink.properties
@@ -1,0 +1,31 @@
+##
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##
+
+neo4j.server.uri=Type: String;\nDescription: The Bolt URI (default bolt://localhost:7687)
+neo4j.authentication.type=Type: enum[NONE, BASIC, KERBEROS];\nDescription: The authentication type (default BASIC)
+neo4j.batch.size=Type: Int;\nDescription: The max number of events processed by the Cypher query (default 1000)
+neo4j.batch.timeout.msecs=Type: Long;\nDescription: The execution timeout for the cypher query (default 30000)
+neo4j.authentication.basic.username=Type: String;\nDescription: The authentication username
+neo4j.authentication.basic.password=Type: String;\nDescription: The authentication password
+neo4j.authentication.basic.realm=Type: String;\nDescription: The authentication realm
+neo4j.authentication.kerberos.ticket=Type: String;\nDescription: The Kerberos ticket
+neo4j.encryption.enabled=Type: Boolean;\nDescription: If the encryption is enabled (default false)
+neo4j.encryption.trust.strategy=Type: enum[TRUST_ALL_CERTIFICATES, TRUST_CUSTOM_CA_SIGNED_CERTIFICATES, TRUST_SYSTEM_CA_SIGNED_CERTIFICATES];\nDescription: The Neo4j trust strategy (default RUST_ALL_CERTIFICATES)
+neo4j.encryption.ca.certificate.path=Type: String;\nDescription: The path of the certificate
+neo4j.connection.max.lifetime.msecs=Type: Long;\nDescription: The max Neo4j connection lifetime (default 1 hour)
+neo4j.connection.acquisition.timeout.msecs=Type: Long;\nDescription: The max Neo4j acquisition timeout (default 1 hour)
+neo4j.connection.liveness.check.timeout.msecs=Type: Long;\nDescription: The max Neo4j liveness check timeout (default 1 hour)
+neo4j.connection.max.pool.size=Type: Int;\nDescription: The max pool size (default 100)
+neo4j.load.balance.strategy=Type: enum[ROUND_ROBIN, LEAST_CONNECTED];\nDescription: The Neo4j load balance strategy (default LEAST_CONNECTED)

--- a/kafka-connect-neo4j/src/main/resources/kafka-connect-version.properties
+++ b/kafka-connect-neo4j/src/main/resources/kafka-connect-version.properties
@@ -1,5 +1,4 @@
 ##
-# Copyright (c) 2017. Hans-Peter Grahsl (grahslhp@gmail.com)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/kafka-connect-neo4j/src/test/kotlin/streams/kafka/connect/sink/Neo4jSinkConnectorConfigTest.kt
+++ b/kafka-connect-neo4j/src/test/kotlin/streams/kafka/connect/sink/Neo4jSinkConnectorConfigTest.kt
@@ -7,7 +7,6 @@ import org.neo4j.driver.v1.Config
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNull
-import kotlin.test.assertTrue
 
 class Neo4jSinkConnectorConfigTest {
 
@@ -50,7 +49,7 @@ class Neo4jSinkConnectorConfigTest {
         assertEquals(Neo4jSinkConnectorConfig.CONNECTION_POOL_MAX_SIZE_DEFAULT, config.connectionPoolMaxSize)
         assertEquals(PoolSettings.DEFAULT_CONNECTION_ACQUISITION_TIMEOUT, config.connectionAcquisitionTimeout)
         assertEquals(Config.LoadBalancingStrategy.LEAST_CONNECTED, config.loadBalancingStrategy)
-        assertEquals(Neo4jSinkConnectorConfig.BATCH_TIMEOUT_MSEC_DEFAULT, config.batchTimeout)
+        assertEquals(Neo4jSinkConnectorConfig.BATCH_TIMEOUT_DEFAULT, config.batchTimeout)
     }
 
 }


### PR DESCRIPTION
Fixes #116 (for the Sink)

## Proposed Changes (Mandatory)

A brief list of proposed changes in order to fix the issue:

- the UI now shows the documentation for each paramter
- renamed `neo4j.batch.timeout.msec` into `neo4j.batch.timeout.msecs` in order to be compliant to the other similar properties (we need to manage the old version?)
