### PR TITLE
 fixes #147: Kafka Connect Sink Transient Error Mangement

### DIFF
--- a/common/src/main/kotlin/streams/utils/CoroutineUtils.kt
+++ b/common/src/main/kotlin/streams/utils/CoroutineUtils.kt
@@ -1,0 +1,17 @@
+package streams.utils
+
+import kotlinx.coroutines.delay
+
+suspend fun <T> retryForException(exceptions: Array<Class<out Throwable>>, retries: Int, delayTime: Long, action: () -> T): T {
+    return try {
+        action()
+    } catch (e: Exception) {
+        val isInstance = exceptions.any { it.isInstance(e) }
+        if (isInstance && retries > 0) {
+            delay(delayTime)
+            retryForException(exceptions = exceptions, retries = retries - 1, delayTime = delayTime, action = action)
+        } else {
+            throw e
+        }
+    }
+}

--- a/common/src/test/kotlin/streams/utils/CoroutineUtilsTest.kt
+++ b/common/src/test/kotlin/streams/utils/CoroutineUtilsTest.kt
@@ -1,0 +1,63 @@
+package streams.utils
+
+import kotlinx.coroutines.runBlocking
+import org.junit.Test
+import java.io.IOException
+import java.lang.ClassCastException
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class CoroutineUtilsTest {
+
+    @Test
+    fun `should success after retry for known exception`() = runBlocking {
+        var count = 0
+        var excuted = false
+        retryForException<Unit>(exceptions = arrayOf(RuntimeException::class.java),
+                retries = 4, delayTime = 100) {
+            if (count < 2) {
+                ++count
+                throw RuntimeException()
+            }
+            excuted = true
+        }
+
+        assertEquals(2, count)
+        assertTrue { excuted }
+    }
+
+    @Test(expected = RuntimeException::class)
+    fun `should fail after retry for known exception`() {
+        var retries = 3
+        runBlocking {
+            retryForException<Unit>(exceptions = arrayOf(RuntimeException::class.java),
+                    retries = 3, delayTime = 100) {
+                if (retries >= 0) {
+                    --retries
+                    throw RuntimeException()
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `should fail fast unknown exception`() {
+        var iteration = 0
+        var isIOException = false
+        try {
+            runBlocking {
+                retryForException<Unit>(exceptions = arrayOf(RuntimeException::class.java),
+                        retries = 3, delayTime = 100) {
+                    if (iteration >= 0) {
+                        ++iteration
+                        throw IOException()
+                    }
+                }
+            }
+        } catch (e: Exception) {
+            isIOException = e is IOException
+        }
+        assertTrue { isIOException }
+        assertEquals(1, iteration)
+    }
+}

--- a/kafka-connect-neo4j/src/main/kotlin/streams/kafka/connect/sink/Neo4jService.kt
+++ b/kafka-connect-neo4j/src/main/kotlin/streams/kafka/connect/sink/Neo4jService.kt
@@ -3,6 +3,7 @@ package streams.kafka.connect.sink
 import kotlinx.coroutines.async
 import kotlinx.coroutines.channels.ticker
 import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.selects.whileSelect
 import org.apache.kafka.common.config.ConfigException
 import org.apache.kafka.connect.sink.SinkRecord
@@ -10,9 +11,13 @@ import org.neo4j.driver.v1.AuthTokens
 import org.neo4j.driver.v1.Config
 import org.neo4j.driver.v1.Driver
 import org.neo4j.driver.v1.GraphDatabase
+import org.neo4j.driver.v1.exceptions.ClientException
+import org.neo4j.driver.v1.exceptions.TransientException
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import streams.utils.StreamsUtils
+import streams.utils.retryForException
+import org.apache.kafka.connect.errors.ConnectException
 import java.util.concurrent.TimeUnit
 
 
@@ -55,6 +60,7 @@ class Neo4jService(private val config: Neo4jSinkConnectorConfig) {
         configBuilder.withMaxConnectionLifetime(this.config.connectionMaxConnectionLifetime, TimeUnit.MILLISECONDS)
         configBuilder.withConnectionAcquisitionTimeout(this.config.connectionAcquisitionTimeout, TimeUnit.MILLISECONDS)
         configBuilder.withLoadBalancingStrategy(this.config.loadBalancingStrategy)
+        configBuilder.withMaxTransactionRetryTime(config.retryBackoff, TimeUnit.MILLISECONDS)
         val neo4jConfig = configBuilder.toConfig()
         this.driver = GraphDatabase.driver(this.config.serverUri, authToken, neo4jConfig)
     }
@@ -64,25 +70,28 @@ class Neo4jService(private val config: Neo4jSinkConnectorConfig) {
     }
 
     private fun write(topic: String, records: List<SinkRecord>) {
-        val session = driver.session()
         val query = "${StreamsUtils.UNWIND} ${config.topicMap[topic]}"
         val data = mapOf<String, Any>("events" to records.map { converter.convert(it.value()) })
-        session.writeTransaction {
+        driver.session().use { session ->
             try {
-                it.run(query, data)
-                it.success()
-                if (log.isDebugEnabled) {
-                    log.debug("Successfully executed query: `$query`, with data: `$data`")
+                runBlocking {
+                    retryForException<Unit>(exceptions = arrayOf(ClientException::class.java, TransientException::class.java),
+                            retries = config.retryMaxAttempts, delayTime = 0) { // we use the delayTime = 0, because we delegate the retryBackoff to the Neo4j Java Driver
+                        session.writeTransaction {
+                            val result = it.run(query, data)
+                            if (log.isDebugEnabled) {
+                                log.debug("Successfully executed query: `$query`. Summary: ${result.summary()}")
+                            }
+                        }
+                    }
                 }
             } catch (e: Exception) {
                 if (log.isDebugEnabled) {
                     log.debug("Exception `${e.message}` while executing query: `$query`, with data: `$data`")
                 }
-                it.failure()
+                throw e
             }
-            it.close()
         }
-        session.close()
     }
 
     suspend fun writeData(data: Map<String, List<List<SinkRecord>>>) = coroutineScope {
@@ -105,8 +114,12 @@ class Neo4jService(private val config: Neo4jSinkConnectorConfig) {
                 it.onAwait { !isAllCompleted } // Stops the whileSelect
             }
         }
+        val exceptionMessages = deferredList
+                .mapNotNull { it.getCompletionExceptionOrNull() }
+                .map { it.message }
+                .joinToString("\n")
+        if (exceptionMessages.isNotBlank()) {
+            throw ConnectException(exceptionMessages)
+        }
     }
-
-
-
 }

--- a/kafka-connect-neo4j/src/main/kotlin/streams/kafka/connect/sink/Neo4jSinkConnector.kt
+++ b/kafka-connect-neo4j/src/main/kotlin/streams/kafka/connect/sink/Neo4jSinkConnector.kt
@@ -5,6 +5,7 @@ import org.apache.kafka.common.config.ConfigDef
 import org.apache.kafka.connect.connector.Task
 import org.apache.kafka.connect.sink.SinkConnector
 import org.slf4j.LoggerFactory
+import streams.kafka.connect.utils.PropertiesUtil
 
 @Title("Neo4j Sink Connector")
 @Description("The Neo4j Sink connector reads data from Kafka and and writes the data to Neo4j using a Cypher Template")

--- a/kafka-connect-neo4j/src/main/kotlin/streams/kafka/connect/sink/Neo4jSinkTask.kt
+++ b/kafka-connect-neo4j/src/main/kotlin/streams/kafka/connect/sink/Neo4jSinkTask.kt
@@ -29,14 +29,12 @@ class Neo4jSinkTask : SinkTask() {
             return@runBlocking
         }
 
-        // TODO define a retry policy in that case we must throw `RetriableException`
         val data = EventBuilder()
                 .withBatchSize(config.batchSize)
                 .withTopics(config.topicMap.keys)
                 .withSinkRecords(collection)
                 .build()
         neo4jService.writeData(data)
-
     }
 
     override fun stop() {

--- a/kafka-connect-neo4j/src/main/kotlin/streams/kafka/connect/utils/PropertiesUtil.kt
+++ b/kafka-connect-neo4j/src/main/kotlin/streams/kafka/connect/utils/PropertiesUtil.kt
@@ -1,4 +1,4 @@
-package streams.kafka.connect.sink
+package streams.kafka.connect.utils
 
 import org.slf4j.LoggerFactory
 import java.util.*

--- a/kafka-connect-neo4j/src/main/resources/kafka-connect-sink.properties
+++ b/kafka-connect-neo4j/src/main/resources/kafka-connect-sink.properties
@@ -29,3 +29,5 @@ neo4j.connection.acquisition.timeout.msecs=Type: Long;\nDescription: The max Neo
 neo4j.connection.liveness.check.timeout.msecs=Type: Long;\nDescription: The max Neo4j liveness check timeout (default 1 hour)
 neo4j.connection.max.pool.size=Type: Int;\nDescription: The max pool size (default 100)
 neo4j.load.balance.strategy=Type: enum[ROUND_ROBIN, LEAST_CONNECTED];\nDescription: The Neo4j load balance strategy (default LEAST_CONNECTED)
+neo4j.retry.backoff.msecs=Type: Long;\nDescription: The time in milliseconds to wait following a transient error before a retry attempt is made (default 30000).
+neo4j.retry.max.attemps=Type: Int;\nDescription: The maximum number of times to retry on transient errors before failing the task (default 5).


### PR DESCRIPTION
Fixes #147

## Proposed Changes (Mandatory)

A brief list of proposed changes in order to fix the issue:

  - added a coroutine scoped function `retryForException` which retries for a set of exceptions
  - added property `neo4j.retry.backoff.msecs` used by the Neo4j java driver `withMaxTransactionRetryTime`
  - added property `neo4j.retry.max.attemps` used by `retryForException` in `Neo4jService`
 in order to retry the operation for transient errors