### PR TITLE
fixes issue #156; #158

### DIFF
--- a/producer/src/main/kotlin/streams/StreamsEventRouter.kt
+++ b/producer/src/main/kotlin/streams/StreamsEventRouter.kt
@@ -1,13 +1,17 @@
 package streams
 
+import org.apache.kafka.clients.producer.RecordMetadata
 import org.neo4j.kernel.configuration.Config
 import org.neo4j.kernel.impl.logging.LogService
 import streams.events.StreamsEvent
+import java.util.concurrent.Future
 
 
 abstract class StreamsEventRouter(val logService: LogService?, val config: Config?) {
 
-    abstract fun sendEvents(topic: String, transactionEvents: List<out StreamsEvent>)
+    abstract fun sendEvents(topic: String, transactionEvents: List<out StreamsEvent>): List<out Future<RecordMetadata>>
+
+    abstract fun sendEventsSync(topic: String, transactionEvents: List<out StreamsEvent>): List<out RecordMetadata>
 
     abstract fun start()
 

--- a/producer/src/main/kotlin/streams/procedures/StreamsProcedures.kt
+++ b/producer/src/main/kotlin/streams/procedures/StreamsProcedures.kt
@@ -7,6 +7,18 @@ import streams.StreamsEventRouter
 import streams.StreamsEventRouterConfiguration
 import streams.events.StreamsEventBuilder
 import java.lang.RuntimeException
+import java.util.stream.Stream
+
+class PublishResult {
+    @JvmField public var topic: String
+    @JvmField public var payload: Any
+    @JvmField public var config: Map<String,Any>?
+    constructor(topic: String, payload: Any, config: Map<String,Any>?) {
+        this.topic = topic;
+        this.payload = payload;
+        this.config = config;
+    }
+}
 
 class StreamsProcedures {
 
@@ -15,15 +27,15 @@ class StreamsProcedures {
     @Procedure(mode = Mode.SCHEMA, name = "streams.publish")
     @Description("streams.publish(topic, config) - Allows custom streaming from Neo4j to the configured stream environment")
     fun publish(@Name("topic") topic: String?, @Name("payload") payload: Any?,
-                @Name(value = "config", defaultValue = "{}") config: Map<String, Any>?) {
+                @Name(value = "config", defaultValue = "{}") config: Map<String, Any>?): Stream<PublishResult> {
         checkEnabled()
         if (topic.isNullOrEmpty()) {
             log?.info("Topic empty, no message sent")
-            return
+            return Stream.empty();
         }
         if (payload == null) {
             log?.info("Payload empty, no message sent")
-            return
+            return Stream.empty();
         }
         val streamsEvent = StreamsEventBuilder()
                 .withPayload(payload)
@@ -38,6 +50,8 @@ class StreamsProcedures {
                 .withTopic(topic)
                 .build()
         StreamsProcedures.eventRouter.sendEvents(topic, listOf(streamsEvent))
+
+        return Stream.of(PublishResult(topic, payload, config))
     }
 
     private fun checkEnabled() {

--- a/producer/src/main/kotlin/streams/procedures/StreamsProcedures.kt
+++ b/producer/src/main/kotlin/streams/procedures/StreamsProcedures.kt
@@ -35,7 +35,7 @@ class StreamsProcedures {
         }
         if (payload == null) {
             log?.info("Payload empty, no message sent")
-            return Stream.empty();
+            throw RuntimeException("Payload may not be null")
         }
         val streamsEvent = StreamsEventBuilder()
                 .withPayload(payload)

--- a/producer/src/test/kotlin/streams/integrations/KafkaEventRouterIT.kt
+++ b/producer/src/test/kotlin/streams/integrations/KafkaEventRouterIT.kt
@@ -164,6 +164,12 @@ class KafkaEventRouterIT {
         assertTrue { "$message".equals(resultMap.get("payload")) }
         assertTrue { "neo4j".equals(resultMap.get("topic")) }
 
+        assertTrue { resultMap.containsKey("offset") }
+        assertTrue { resultMap.containsKey("partition") }
+        assertTrue { resultMap.containsKey("keySize") }
+        assertTrue { resultMap.containsKey("valueSize") }
+        assertTrue { resultMap.containsKey("timestamp") }
+
         result.close()
         val records = consumer.poll(5000)
         assertEquals(1, records.count())

--- a/producer/src/test/kotlin/streams/integrations/KafkaEventRouterIT.kt
+++ b/producer/src/test/kotlin/streams/integrations/KafkaEventRouterIT.kt
@@ -17,6 +17,7 @@ import streams.procedures.StreamsProcedures
 import streams.serialization.JSONUtils
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
+import kotlin.test.assertFailsWith
 
 class KafkaEventRouterIT {
 
@@ -173,6 +174,17 @@ class KafkaEventRouterIT {
             }
         })
         consumer.close()
+    }
+
+    @Test
+    fun testCantPublishNull() {
+        val config = KafkaConfiguration(bootstrapServers = kafka.bootstrapServers)
+        val consumer = createConsumer(config)
+        consumer.subscribe(listOf("neo4j"))
+
+        assertFailsWith(RuntimeException::class) {
+            db.execute("CALL streams.publish('neo4j', null)")
+        }
     }
 
     private fun getRecordCount(config: KafkaConfiguration, topic: String): Int {

--- a/producer/src/test/kotlin/streams/mocks/MockStreamsEventRouter.kt
+++ b/producer/src/test/kotlin/streams/mocks/MockStreamsEventRouter.kt
@@ -1,15 +1,44 @@
 package streams.mocks
 
+import org.apache.kafka.clients.producer.RecordMetadata
+import org.apache.kafka.common.TopicPartition
 import org.neo4j.kernel.configuration.Config
 import org.neo4j.kernel.impl.logging.LogService
 import streams.StreamsEventRouter
 import streams.events.StreamsEvent
 import streams.events.StreamsTransactionEvent
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.Future
 
 class MockStreamsEventRouter(logService: LogService? = null, config: Config? = null): StreamsEventRouter(logService, config) {
 
-    override fun sendEvents(topic: String, streamsTransactionEvents: List<out StreamsEvent>) {
+    fun fakeRecordMetadata(topic: String): RecordMetadata {
+        return RecordMetadata(
+                TopicPartition(topic, 0),
+                0, 1, 2, 3, 4, 5)
+    }
+
+    override fun sendEvents(topic: String, streamsTransactionEvents: List<out StreamsEvent>): List<out Future<RecordMetadata>> {
         events.addAll(streamsTransactionEvents as List<StreamsTransactionEvent>)
+
+        val result = mutableListOf<Future<RecordMetadata>>()
+        streamsTransactionEvents.forEach {
+            val future = CompletableFuture<RecordMetadata>()
+            future.complete(fakeRecordMetadata(topic))
+            result.add(future)
+        }
+
+        return result
+    }
+
+    override fun sendEventsSync(topic: String, transactionEvents: List<out StreamsEvent>): List<out RecordMetadata> {
+        var result = mutableListOf<RecordMetadata>()
+
+        transactionEvents.forEach {
+            result.add(fakeRecordMetadata(topic))
+        }
+
+        return result
     }
 
     override fun start() {}


### PR DESCRIPTION
Fixes #156 
Fixes #158 

CALL streams.publish(a, b, c) returns its arguments when it is successful, allowing verification that the message was published, and chaining of arguments in cypher.

