### PR TITLE
fixes #162: Conversion error in case of nested field of array<Struct> records

### DIFF
--- a/kafka-connect-neo4j/src/main/kotlin/streams/kafka/connect/sink/ValueConverter.kt
+++ b/kafka-connect-neo4j/src/main/kotlin/streams/kafka/connect/sink/ValueConverter.kt
@@ -1,107 +1,130 @@
 package streams.kafka.connect.sink
 
 import com.github.jcustenborder.kafka.connect.utils.data.AbstractConverter
+import com.google.common.base.Preconditions
 import org.apache.kafka.connect.data.Schema
 import org.apache.kafka.connect.data.Struct
+import org.apache.kafka.connect.errors.DataException
 import org.neo4j.driver.v1.Values
 import java.math.BigDecimal
+import java.math.BigInteger
 import java.time.LocalTime
 import java.time.ZoneId
 import java.util.*
 import java.util.concurrent.TimeUnit
 
 
-class ValueConverter: AbstractConverter<MutableMap<String, Any>>() {
+class ValueConverter: AbstractConverter<MutableMap<String, Any?>>() {
 
     private val UTC = ZoneId.of("UTC")
 
-    private fun setValue(result: MutableMap<String, Any>?, fieldName: String?, value: Any?) {
-        if (result != null && fieldName != null && value != null) {
-            result[fieldName] = Values.value(value)
+    private fun setValue(result: MutableMap<String, Any?>?, fieldName: String?, value: Any?) {
+        if (result != null && fieldName != null) {
+            result[fieldName] = Values.value(value) ?: Values.NULL
         }
     }
 
-    override fun newValue(): MutableMap<String, Any> {
+    override fun newValue(): MutableMap<String, Any?> {
         return mutableMapOf()
     }
 
-    override fun setBytesField(result: MutableMap<String, Any>?, fieldName: String?, value: ByteArray?) {
+    override fun setBytesField(result: MutableMap<String, Any?>?, fieldName: String?, value: ByteArray?) {
         setValue(result, fieldName, value)
     }
 
-    override fun setStringField(result: MutableMap<String, Any>?, fieldName: String?, value: String?) {
+    override fun setStringField(result: MutableMap<String, Any?>?, fieldName: String?, value: String?) {
         setValue(result, fieldName, value)
     }
 
-    override fun setFloat32Field(result: MutableMap<String, Any>?, fieldName: String?, value: Float?) {
+    override fun setFloat32Field(result: MutableMap<String, Any?>?, fieldName: String?, value: Float?) {
         setValue(result, fieldName, value)
     }
 
-    override fun setInt32Field(result: MutableMap<String, Any>?, fieldName: String?, value: Int?) {
+    override fun setInt32Field(result: MutableMap<String, Any?>?, fieldName: String?, value: Int?) {
         setValue(result, fieldName, value)
     }
 
-    override fun setArray(result: MutableMap<String, Any>?, fieldName: String?, schema: Schema?, array: MutableList<Any?>?) {
-        setValue(result, fieldName, array)
+    override fun setArray(result: MutableMap<String, Any?>?, fieldName: String?, schema: Schema?, array: MutableList<Any?>?) {
+        val convertedArray = array?.map { convertInner(it) }
+        setValue(result, fieldName, convertedArray)
     }
 
-    override fun setTimestampField(result: MutableMap<String, Any>?, fieldName: String?, value: Date?) {
+    override fun setTimestampField(result: MutableMap<String, Any?>?, fieldName: String?, value: Date?) {
         if (value != null) {
             val localDate = value.toInstant().atZone(UTC).toLocalDateTime()
             setValue(result, fieldName, localDate)
+        } else {
+            setNullField(result, fieldName)
         }
 
     }
 
-    override fun setTimeField(result: MutableMap<String, Any>?, fieldName: String?, value: Date?) {
+    override fun setTimeField(result: MutableMap<String, Any?>?, fieldName: String?, value: Date?) {
         if (value != null) {
             val time = LocalTime.ofNanoOfDay(TimeUnit.MILLISECONDS.toNanos(value.time))
             setValue(result, fieldName, time)
+        } else {
+            setNullField(result, fieldName)
         }
     }
 
-    override fun setInt8Field(result: MutableMap<String, Any>?, fieldName: String?, value: Byte?) {
+    override fun setInt8Field(result: MutableMap<String, Any?>?, fieldName: String?, value: Byte?) {
         setValue(result, fieldName, value)
     }
 
-    override fun setStructField(result: MutableMap<String, Any>?, fieldName: String?, value: Struct?) {
+    override fun setStructField(result: MutableMap<String, Any?>?, fieldName: String?, value: Struct?) {
         if (value != null) {
-            val converted = convert(value) as Map<String, Any>
-            setValue(result, fieldName, converted)
+            val converted = convert(value) as MutableMap<Any?, Any?>
+            setMap(result, fieldName, null, converted)
+        } else {
+            setNullField(result, fieldName)
         }
     }
 
-    override fun setMap(result: MutableMap<String, Any>?, fieldName: String?, schema: Schema?, map: MutableMap<Any?, Any?>?) {
-        setValue(result, fieldName, map)
+    override fun setMap(result: MutableMap<String, Any?>?, fieldName: String?, schema: Schema?, map: MutableMap<Any?, Any?>?) {
+        val newMap = map
+                ?.mapKeys { it.key.toString() }
+                ?.mapValues { convertInner(it.value) }
+        setValue(result, fieldName, newMap)
     }
 
-    override fun setNullField(result: MutableMap<String, Any>?, fieldName: String?) {}
+    override fun setNullField(result: MutableMap<String, Any?>?, fieldName: String?) {
+        setValue(result, fieldName, null)
+    }
 
-    override fun setFloat64Field(result: MutableMap<String, Any>?, fieldName: String?, value: Double?) {
+    override fun setFloat64Field(result: MutableMap<String, Any?>?, fieldName: String?, value: Double?) {
         setValue(result, fieldName, value)
     }
 
-    override fun setInt16Field(result: MutableMap<String, Any>?, fieldName: String?, value: Short?) {
+    override fun setInt16Field(result: MutableMap<String, Any?>?, fieldName: String?, value: Short?) {
         setValue(result, fieldName, value)
     }
 
-    override fun setInt64Field(result: MutableMap<String, Any>?, fieldName: String?, value: Long?) {
+    override fun setInt64Field(result: MutableMap<String, Any?>?, fieldName: String?, value: Long?) {
         setValue(result, fieldName, value)
     }
 
-    override fun setBooleanField(result: MutableMap<String, Any>?, fieldName: String?, value: Boolean?) {
+    override fun setBooleanField(result: MutableMap<String, Any?>?, fieldName: String?, value: Boolean?) {
         setValue(result, fieldName, value)
     }
 
-    override fun setDecimalField(result: MutableMap<String, Any>?, fieldName: String?, value: BigDecimal?) {
+    override fun setDecimalField(result: MutableMap<String, Any?>?, fieldName: String?, value: BigDecimal?) {
         setValue(result, fieldName, value)
     }
 
-    override fun setDateField(result: MutableMap<String, Any>?, fieldName: String?, value: Date?) {
+    override fun setDateField(result: MutableMap<String, Any?>?, fieldName: String?, value: Date?) {
         if (value != null) {
             val localDate = value.toInstant().atZone(UTC).toLocalDate()
             setValue(result, fieldName, localDate)
+        } else {
+            setNullField(result, fieldName)
         }
     }
 
+    private fun convertInner(value: Any?): Any? {
+        return when (value) {
+            is Struct, is Map<*, *> -> convert(value)
+            else -> value
+        }
+    }
 }

--- a/kafka-connect-neo4j/src/test/kotlin/streams/kafka/connect/sink/ValueConverterTest.kt
+++ b/kafka-connect-neo4j/src/test/kotlin/streams/kafka/connect/sink/ValueConverterTest.kt
@@ -1,0 +1,121 @@
+package streams.kafka.connect.sink
+
+import org.apache.kafka.connect.data.Schema
+import org.apache.kafka.connect.data.SchemaBuilder
+import org.apache.kafka.connect.data.Struct
+import org.junit.Test
+import org.neo4j.driver.v1.Value
+import org.neo4j.driver.v1.Values
+import kotlin.test.assertEquals
+
+class ValueConverterTest {
+
+    @Test
+    fun `should convert tree struct into map of neo4j values`() {
+        // given
+        // this test generates a simple tree structure like this
+        //           body
+        //          /    \
+        //         p     ul
+        //               |
+        //               li
+        val body = getTreeStruct()
+
+        // when
+        val result = ValueConverter().convert(body) as Map<*, *>
+
+        // then
+        val expected = getExpectedMap()
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `should convert tree simple map into map of neo4j values`() {
+        // given
+        // this test generates a simple tree structure like this
+        //           body
+        //          /    \
+        //         p     ul
+        //               |
+        //               li
+        val body = getTreeMap()
+
+        // when
+        val result = ValueConverter().convert(body) as Map<*, *>
+
+        // then
+        val expected = getExpectedMap()
+        assertEquals(expected, result)
+    }
+
+    companion object {
+        private val LI_SCHEMA = SchemaBuilder.struct().name("org.neo4j.example.html.LI")
+                .field("value", Schema.OPTIONAL_STRING_SCHEMA)
+                .field("class", SchemaBuilder.array(Schema.STRING_SCHEMA).optional())
+                .build()
+
+        private val UL_SCHEMA = SchemaBuilder.struct().name("org.neo4j.example.html.UL")
+                .field("value", SchemaBuilder.array(LI_SCHEMA))
+                .build()
+
+        private val P_SCHEMA = SchemaBuilder.struct().name("org.neo4j.example.html.P")
+                .field("value", Schema.OPTIONAL_STRING_SCHEMA)
+                .build()
+
+        private val BODY_SCHEMA = SchemaBuilder.struct().name("org.neo4j.example.html.BODY")
+                .field("ul", SchemaBuilder.array(UL_SCHEMA).optional())
+                .field("p", SchemaBuilder.array(P_SCHEMA).optional())
+                .build()
+
+        fun getTreeStruct(): Struct? {
+            val firstUL = Struct(UL_SCHEMA).put("value", listOf(
+                    Struct(LI_SCHEMA).put("value", "First UL - First Element"),
+                    Struct(LI_SCHEMA).put("value", "First UL - Second Element")
+                            .put("class", listOf("ClassA", "ClassB"))
+            ))
+            val secondUL = Struct(UL_SCHEMA).put("value", listOf(
+                    Struct(LI_SCHEMA).put("value", "Second UL - First Element"),
+                    Struct(LI_SCHEMA).put("value", "Second UL - Second Element")
+            ))
+            val ulList = listOf(firstUL, secondUL)
+            val pList = listOf(
+                    Struct(P_SCHEMA).put("value", "First Paragraph"),
+                    Struct(P_SCHEMA).put("value", "Second Paragraph")
+            )
+            val body = Struct(BODY_SCHEMA)
+                    .put("ul", ulList)
+                    .put("p", pList)
+            return body
+        }
+
+        fun getExpectedMap(): Map<String, Value> {
+            val firstULMap = mapOf("value" to listOf(
+                    mapOf("value" to Values.value("First UL - First Element"), "class" to Values.NULL),
+                    mapOf("value" to Values.value("First UL - Second Element"), "class" to Values.value(listOf("ClassA", "ClassB")))))
+            val secondULMap = mapOf("value" to listOf(
+                    mapOf("value" to Values.value("Second UL - First Element"), "class" to Values.NULL),
+                    mapOf("value" to Values.value("Second UL - Second Element"), "class" to Values.NULL)))
+            val ulListMap = Values.value(listOf(firstULMap, secondULMap))
+            val pListMap = Values.value(listOf(mapOf("value" to Values.value("First Paragraph")),
+                    mapOf("value" to Values.value("Second Paragraph"))))
+            val bodyMap = mapOf("ul" to ulListMap, "p" to pListMap)
+            return bodyMap
+        }
+
+        fun getTreeMap(): Map<String, Any?> {
+            val firstULMap = mapOf("value" to listOf(
+                    mapOf("value" to "First UL - First Element", "class" to null),
+                    mapOf("value" to "First UL - Second Element", "class" to listOf("ClassA", "ClassB"))))
+            val secondULMap = mapOf("value" to listOf(
+                    mapOf("value" to "Second UL - First Element", "class" to null),
+                    mapOf("value" to "Second UL - Second Element", "class" to null)))
+            val ulListMap = listOf(firstULMap, secondULMap)
+            val pListMap = listOf(mapOf("value" to "First Paragraph"),
+                    mapOf("value" to "Second Paragraph"))
+            val bodyMap = mapOf("ul" to ulListMap, "p" to pListMap)
+            return bodyMap
+        }
+    }
+
+}
+


### PR DESCRIPTION
Fixes #162

Fixes the bug

## Proposed Changes (Mandatory)

A brief list of proposed changes in order to fix the issue:

  - fixed the bug into `ValueConverter` class
  - added log in case of Neo4j error code `listOf("Neo.ClientError.Statement.PropertyNotFound", "Neo.ClientError.Statement.SemanticError", "Neo.ClientError.Statement.ParameterMissing")` because throwing an exception in that case stops the connect plugin. We also need to investigate if there are some other errors that we want they don't cause a plugin stop.
