### PR TITLE
 fixes #154: provide a common pattern for ingestion

### DIFF
--- a/common/src/main/kotlin/streams/extensions/CommonExtensions.kt
+++ b/common/src/main/kotlin/streams/extensions/CommonExtensions.kt
@@ -13,6 +13,17 @@ fun String.toPointCase(): String {
     return this.split("(?<=[a-z])(?=[A-Z])".toRegex()).joinToString(separator = ".").toLowerCase()
 }
 
-fun String.quote(): String {
-    return if (SourceVersion.isIdentifier(this)) this else "`$this`"
+fun String.quote(): String = if (SourceVersion.isIdentifier(this)) this else "`$this`"
+
+fun Map<String, Any?>.flatten(map: Map<String, Any?> = this, prefix: String = ""): Map<String, Any?> {
+    return map.flatMap {
+        val key = it.key
+        val value = it.value
+        val newKey = if (prefix != "") "$prefix.$key" else key
+        if (value is Map<*, *>) {
+            flatten(value as Map<String, Any>, newKey).toList()
+        } else {
+            listOf(newKey to value)
+        }
+    }.toMap()
 }

--- a/common/src/main/kotlin/streams/service/StreamsSinkService.kt
+++ b/common/src/main/kotlin/streams/service/StreamsSinkService.kt
@@ -1,18 +1,19 @@
 package streams.service
 
 import streams.serialization.JSONUtils
-import streams.service.sink.strategy.IngestionStrategy
-import streams.service.sink.strategy.SourceIdIngestionStrategy
-import streams.service.sink.strategy.SchemaIngestionStrategy
+import streams.service.sink.strategy.*
+import java.util.concurrent.ConcurrentHashMap
 
 
 const val STREAMS_TOPIC_KEY: String = "streams.sink.topic"
 const val STREAMS_TOPIC_CDC_KEY: String = "streams.sink.topic.cdc"
 
-enum class TopicTypeGroup { CYPHER, CDC }
+enum class TopicTypeGroup { CYPHER, CDC, PATTERN }
 enum class TopicType(val group: TopicTypeGroup, val key: String) {
     CDC_SOURCE_ID(group = TopicTypeGroup.CDC, key = "$STREAMS_TOPIC_CDC_KEY.sourceId"),
     CYPHER(group = TopicTypeGroup.CYPHER, key = "$STREAMS_TOPIC_KEY.cypher"),
+    PATTERN_NODE(group = TopicTypeGroup.PATTERN, key = "$STREAMS_TOPIC_KEY.pattern.node"),
+    PATTERN_RELATIONSHIP(group = TopicTypeGroup.PATTERN, key = "$STREAMS_TOPIC_KEY.pattern.relationship"),
     CDC_SCHEMA(group = TopicTypeGroup.CDC, key = "$STREAMS_TOPIC_CDC_KEY.schema")
 }
 
@@ -22,10 +23,7 @@ abstract class StreamsSinkService(private val strategyMap: Map<TopicType, Any>) 
     abstract fun getCypherTemplate(topic: String): String?
     abstract fun write(query: String, events: Collection<Any>)
 
-    private fun writeWithStrategy(params: Collection<Any>, strategy: IngestionStrategy) {
-        val data = params
-                .map { JSONUtils.asStreamsTransactionEvent(it) }
-
+    private fun writeWithStrategy(data: Collection<Any>, strategy: IngestionStrategy) {
         strategy.mergeNodeEvents(data).forEach { write(it.query, it.events) }
         strategy.deleteNodeEvents(data).forEach { write(it.query, it.events) }
 
@@ -43,6 +41,10 @@ abstract class StreamsSinkService(private val strategyMap: Map<TopicType, Any>) 
         when (topicType.group) {
             TopicTypeGroup.CYPHER -> writeWithCypherTemplate(topic, params)
             TopicTypeGroup.CDC -> writeWithStrategy(params, strategyMap.getValue(topicType) as IngestionStrategy)
+            TopicTypeGroup.PATTERN -> {
+                val strategyMap = strategyMap[topicType] as Map<String, IngestionStrategy>
+                writeWithStrategy(params, strategyMap.getValue(topic))
+            }
         }
     }
 }

--- a/common/src/main/kotlin/streams/service/sink/strategy/IngestionStrategy.kt
+++ b/common/src/main/kotlin/streams/service/sink/strategy/IngestionStrategy.kt
@@ -8,10 +8,10 @@ import streams.utils.StreamsUtils
 data class QueryEvents(val query: String, val events: List<Map<String, Any?>>)
 
 interface IngestionStrategy {
-    fun mergeNodeEvents(events: List<StreamsTransactionEvent>): List<QueryEvents>
-    fun deleteNodeEvents(events: List<StreamsTransactionEvent>): List<QueryEvents>
-    fun mergeRelationshipEvents(events: List<StreamsTransactionEvent>): List<QueryEvents>
-    fun deleteRelationshipEvents(events: List<StreamsTransactionEvent>): List<QueryEvents>
+    fun mergeNodeEvents(events: Collection<Any>): List<QueryEvents>
+    fun deleteNodeEvents(events: Collection<Any>): List<QueryEvents>
+    fun mergeRelationshipEvents(events: Collection<Any>): List<QueryEvents>
+    fun deleteRelationshipEvents(events: Collection<Any>): List<QueryEvents>
 }
 
 data class RelationshipSchemaMetadata(val label: String,

--- a/common/src/main/kotlin/streams/service/sink/strategy/NodePatternIngestionStrategy.kt
+++ b/common/src/main/kotlin/streams/service/sink/strategy/NodePatternIngestionStrategy.kt
@@ -1,0 +1,71 @@
+package streams.service.sink.strategy
+
+import streams.extensions.flatten
+import streams.utils.IngestionUtils
+import streams.utils.IngestionUtils.containsProp
+import streams.utils.IngestionUtils.getLabelsAsString
+import streams.utils.IngestionUtils.getNodeMergeKeys
+import streams.utils.StreamsUtils
+
+class NodePatternIngestionStrategy(private val nodePatternConfiguration: NodePatternConfiguration): IngestionStrategy {
+
+    private val nodeTemplate: String = """
+                |${StreamsUtils.UNWIND}
+                |MERGE (n:${getLabelsAsString(nodePatternConfiguration.labels)}{${
+                    getNodeMergeKeys("keys", nodePatternConfiguration.keys)
+                }})
+                |SET n = event.properties
+                |SET n += event.keys
+            """.trimMargin()
+
+    override fun mergeNodeEvents(events: Collection<Any>): List<QueryEvents> {
+        if (events.isNullOrEmpty()) {
+            return emptyList()
+        }
+
+        val data = (events as List<Map<String, Any?>>)
+                .mapNotNull {
+                    toData(nodePatternConfiguration, it)
+                }
+        return listOf(QueryEvents(nodeTemplate, data))
+    }
+
+    override fun deleteNodeEvents(events: Collection<Any>): List<QueryEvents> {
+        return emptyList()
+    }
+
+    override fun mergeRelationshipEvents(events: Collection<Any>): List<QueryEvents> {
+        return emptyList()
+    }
+
+    override fun deleteRelationshipEvents(events: Collection<Any>): List<QueryEvents> {
+        return emptyList()
+    }
+
+    companion object {
+        fun toData(nodePatternConfiguration: NodePatternConfiguration, props: Map<String, Any?>): Map<String, Map<String, Any?>>? {
+            val properties = props.flatten()
+            val containsKeys = nodePatternConfiguration.keys.all { properties.containsKey(it) }
+            return if (containsKeys) {
+                val filteredProperties = when (nodePatternConfiguration.type) {
+                    PatternConfigurationType.ALL -> properties.filterKeys { !nodePatternConfiguration.keys.contains(it) }
+                    PatternConfigurationType.EXCLUDE -> properties.filterKeys { key ->
+                        val containsProp = containsProp(key, nodePatternConfiguration.properties)
+                        !nodePatternConfiguration.keys.contains(key) && !containsProp
+                    }
+                    PatternConfigurationType.INCLUDE -> properties.filterKeys { key ->
+                        val containsProp = containsProp(key, nodePatternConfiguration.properties)
+                        !nodePatternConfiguration.keys.contains(key) && containsProp
+                    }
+                }
+                mapOf("keys" to properties.filterKeys { nodePatternConfiguration.keys.contains(it) },
+                        "properties" to filteredProperties)
+            } else {
+                null
+            }
+        }
+
+
+    }
+
+}

--- a/common/src/main/kotlin/streams/service/sink/strategy/PatternConfiguration.kt
+++ b/common/src/main/kotlin/streams/service/sink/strategy/PatternConfiguration.kt
@@ -1,0 +1,200 @@
+package streams.service.sink.strategy
+
+import streams.extensions.quote
+
+enum class PatternConfigurationType { ALL, INCLUDE, EXCLUDE }
+
+private const val ID_PREFIX = "!"
+private const val MINUS_PREFIX = "-"
+private const val LABEL_SEPARATOR = ":"
+private const val PROPERTIES_SEPARATOR = ","
+
+private fun getPatternConfiguredType(properties: List<String>): PatternConfigurationType {
+    if (properties.isEmpty()) {
+        return PatternConfigurationType.ALL
+    }
+    return when (properties[0].trim()[0]) {
+        '*' -> PatternConfigurationType.ALL
+        '-' -> PatternConfigurationType.EXCLUDE
+        else -> PatternConfigurationType.INCLUDE
+    }
+}
+
+private fun isHomogeneousPattern(type: PatternConfigurationType, properties: List<String>, pattern: String, entityType: String) {
+    val isHomogeneous = when (type) {
+        PatternConfigurationType.INCLUDE -> properties.all { it.trim()[0].isJavaIdentifierStart() }
+        PatternConfigurationType.EXCLUDE -> properties.all { it.trim().startsWith(MINUS_PREFIX) }
+        PatternConfigurationType.ALL -> properties.isEmpty() || properties == listOf("*")
+    }
+    if (!isHomogeneous) {
+        throw IllegalArgumentException("The $entityType pattern $pattern is not homogeneous")
+    }
+}
+
+private fun cleanProperties(type: PatternConfigurationType, properties: List<String>): List<String> {
+    return when (type) {
+        PatternConfigurationType.INCLUDE -> properties.map { it.trim() }
+        PatternConfigurationType.EXCLUDE -> properties.map { it.trim().replace(MINUS_PREFIX, "") }
+        PatternConfigurationType.ALL -> emptyList()
+    }
+}
+
+interface PatternConfiguration
+
+data class NodePatternConfiguration(val keys: Set<String>, val type: PatternConfigurationType,
+                                    val labels: List<String>, val properties: List<String>): PatternConfiguration {
+    companion object {
+
+        // (:LabelA{!id,foo,bar})
+        @JvmStatic private val cypherNodePatternConfigured = """\((:\w+\s*(?::\s*(?:\w+)\s*)*)\s*(?:\{\s*(-?[\w!\.]+\s*(?:,\s*-?[!\w\*\.]+\s*)*)\})?\)$""".toRegex()
+        // LabelA{!id,foo,bar}
+        @JvmStatic private val simpleNodePatternConfigured = """^(\w+\s*(?::\s*(?:\w+)\s*)*)\s*(?:\{\s*(-?[\w!\.]+\s*(?:,\s*-?[!\w\*\.]+\s*)*)\})?$""".toRegex()
+        fun parse(pattern: String): NodePatternConfiguration {
+            val isCypherPattern = pattern.startsWith("(")
+            val regex = if (isCypherPattern) cypherNodePatternConfigured else simpleNodePatternConfigured
+            val matcher = regex.matchEntire(pattern)
+            if (matcher == null) {
+                throw IllegalArgumentException("The Node pattern $pattern is invalid")
+            } else {
+                val labels = matcher.groupValues[1]
+                        .split(LABEL_SEPARATOR)
+                        .let {
+                            if (isCypherPattern) it.drop(1) else it
+                        }
+                        .map { it.quote() }
+                val allProperties = matcher.groupValues[2].split(PROPERTIES_SEPARATOR)
+                val keys = allProperties
+                        .filter { it.startsWith(ID_PREFIX) }
+                        .map { it.trim().substring(1) }.toSet()
+                if (keys.isEmpty()) {
+                    throw IllegalArgumentException("The Node pattern $pattern must contains at lest one key")
+                }
+                val properties = allProperties.filter { !it.startsWith(ID_PREFIX) }
+                val type = getPatternConfiguredType(properties)
+                isHomogeneousPattern(type, properties, pattern, "Node")
+                val cleanedProperties = cleanProperties(type, properties)
+
+                return NodePatternConfiguration(keys = keys, type = type,
+                        labels = labels, properties = cleanedProperties)
+            }
+        }
+    }
+}
+
+
+data class RelationshipPatternConfiguration(val start: NodePatternConfiguration, val end: NodePatternConfiguration,
+                                            val relType: String, val type: PatternConfigurationType,
+                                            val properties: List<String>): PatternConfiguration {
+    companion object {
+
+        // we don't allow ALL for start/end nodes in rels
+        // it's public for testing purpose
+        fun getNodeConf(pattern: String): NodePatternConfiguration {
+            val start = NodePatternConfiguration.parse(pattern)
+            return if (start.type == PatternConfigurationType.ALL) {
+                NodePatternConfiguration(keys = start.keys, type = PatternConfigurationType.INCLUDE,
+                        labels = start.labels, properties = start.properties)
+            } else {
+                start
+            }
+        }
+
+        // (:Source{!id})-[:REL_TYPE{foo, -bar}]->(:Target{!targetId})
+        private val cypherRelationshipPatternConfigured = """^\(:(.*?)\)(<)?-\[(?::)([\w\_]+)(\{\s*(-?[\w\*\.]+\s*(?:,\s*-?[\w\*\.]+\s*)*)\})?\]-(>)?\(:(.*?)\)$""".toRegex()
+        // LabelA{!id} REL_TYPE{foo, -bar} LabelB{!targetId}
+        private val simpleRelationshipPatternConfigured =  """^(.*?) ([\w\_]+)(\{\s*(-?[\w\*\.]+\s*(?:,\s*-?[\w\*\.]+\s*)*)\})? (.*?)$""".toRegex() // """^\((.*?)\)-\[(?::)([\w\_]+)(\{\s*(-?[\w\*\.]+\s*(?:,\s*-?[\w\*\.]+\s*)*)\})?\]->\((.*?)\)$""".toRegex()
+
+        data class RelationshipPatternMetaData(val startPattern: String, val endPattern: String, val relType: String, val properties: List<String>) {
+            companion object {
+
+                private fun toProperties(propGroup: String): List<String> = if (propGroup.isNullOrBlank()) {
+                    emptyList()
+                } else {
+                    propGroup.split(PROPERTIES_SEPARATOR)
+                }
+
+                fun create(isCypherPattern: Boolean, isLeftToRight: Boolean, groupValues: List<String>): RelationshipPatternMetaData {
+                    lateinit var start: String
+                    lateinit var end: String
+                    lateinit var relType: String
+                    lateinit var props: List<String>
+
+                    if (isCypherPattern) {
+                        if (isLeftToRight) {
+                            start = groupValues[1]
+                            end = groupValues[7]
+                        } else {
+                            start = groupValues[7]
+                            end = groupValues[1]
+                        }
+                        relType = groupValues[3]
+                        props = toProperties(groupValues[5])
+                    } else {
+                        if (isLeftToRight) {
+                            start = groupValues[1]
+                            end = groupValues[5]
+                        } else {
+                            start = groupValues[5]
+                            end = groupValues[1]
+                        }
+                        relType = groupValues[2]
+                        props = toProperties(groupValues[4])
+                    }
+
+                    return RelationshipPatternMetaData(startPattern = start,
+                            endPattern = end, relType = relType,
+                            properties = props)
+                }
+            }
+        }
+
+        fun parse(pattern: String): RelationshipPatternConfiguration {
+            val isCypherPattern = pattern.startsWith("(")
+            val regex = if (isCypherPattern) {
+                cypherRelationshipPatternConfigured
+            } else {
+                simpleRelationshipPatternConfigured
+            }
+            val matcher = regex.matchEntire(pattern)
+            if (matcher == null) {
+                throw IllegalArgumentException("The Relationship pattern $pattern is invalid")
+            } else {
+                val isLeftToRight = (!isCypherPattern || isUndirected(matcher) || isDirectedToRigth(matcher))
+                val isRightToLeft = if (isCypherPattern) isDirectedToLeft(matcher) else false
+
+                if (!isLeftToRight && !isRightToLeft) {
+                    throw IllegalArgumentException("The Relationship pattern $pattern has an invalid direction")
+                }
+
+                val metadata = RelationshipPatternMetaData.create(isCypherPattern, isLeftToRight, matcher.groupValues)
+
+                val start = try {
+                    getNodeConf(metadata.startPattern)
+                } catch (e: Exception) {
+                    throw IllegalArgumentException("The Relationship pattern $pattern is invalid")
+                }
+                val end = try {
+                    getNodeConf(metadata.endPattern)
+                } catch (e: Exception) {
+                    throw IllegalArgumentException("The Relationship pattern $pattern is invalid")
+                }
+                val type = getPatternConfiguredType(metadata.properties)
+                isHomogeneousPattern(type, metadata.properties, pattern, "Relationship")
+                val cleanedProperties = cleanProperties(type, metadata.properties)
+                return RelationshipPatternConfiguration(start = start, end = end, relType = metadata.relType,
+                        properties = cleanedProperties, type = type)
+            }
+        }
+
+
+
+        private fun isDirectedToLeft(matcher: MatchResult) =
+                (matcher.groupValues[2] == "<" && matcher.groupValues[6] == "")
+
+        private fun isDirectedToRigth(matcher: MatchResult) =
+                (matcher.groupValues[2] == "" && matcher.groupValues[6] == ">")
+
+        private fun isUndirected(matcher: MatchResult) =
+                (matcher.groupValues[2] == "" && matcher.groupValues[6] == "")
+    }
+}

--- a/common/src/main/kotlin/streams/service/sink/strategy/RelationshipPatternIngestionStrategy.kt
+++ b/common/src/main/kotlin/streams/service/sink/strategy/RelationshipPatternIngestionStrategy.kt
@@ -1,0 +1,85 @@
+package streams.service.sink.strategy
+
+import streams.extensions.flatten
+import streams.utils.IngestionUtils.containsProp
+import streams.utils.IngestionUtils.getLabelsAsString
+import streams.utils.IngestionUtils.getNodeMergeKeys
+import streams.utils.StreamsUtils
+
+class RelationshipPatternIngestionStrategy(private val relationshipPatternConfiguration: RelationshipPatternConfiguration): IngestionStrategy {
+
+    private val relationshipTemplate: String = """
+                |${StreamsUtils.UNWIND}
+                |MERGE (start:${getLabelsAsString(relationshipPatternConfiguration.start.labels)}{${
+                    getNodeMergeKeys("start.keys", relationshipPatternConfiguration.start.keys)
+                }})
+                |SET start = event.start.properties
+                |SET start += event.start.keys
+                |MERGE (end:${getLabelsAsString(relationshipPatternConfiguration.end.labels)}{${
+                    getNodeMergeKeys("end.keys", relationshipPatternConfiguration.end.keys)
+                }})
+                |SET end = event.end.properties
+                |SET end += event.end.keys
+                |MERGE (start)-[r:${relationshipPatternConfiguration.relType}]->(end)
+                |SET r = event.properties
+            """.trimMargin()
+
+    private val needsToBeFlattened = relationshipPatternConfiguration.properties.isEmpty()
+            || relationshipPatternConfiguration.properties.any { it.contains(".") }
+
+
+    override fun mergeNodeEvents(events: Collection<Any>): List<QueryEvents> {
+        return emptyList()
+    }
+
+    override fun deleteNodeEvents(events: Collection<Any>): List<QueryEvents> {
+        return emptyList()
+    }
+
+    override fun mergeRelationshipEvents(events: Collection<Any>): List<QueryEvents> {
+        if (events.isNullOrEmpty()) {
+            return emptyList()
+        }
+        val data = (events as List<Map<String, Any?>>)
+                .mapNotNull { props ->
+                    val properties = props.flatten()
+                    val containsKeys = relationshipPatternConfiguration.start.keys.all { properties.containsKey(it) }
+                            && relationshipPatternConfiguration.end.keys.all { properties.containsKey(it) }
+                    if (containsKeys) {
+                        val filteredProperties = when (relationshipPatternConfiguration.type) {
+                            PatternConfigurationType.ALL -> properties.filterKeys { isRelationshipProperty(it) }
+                            PatternConfigurationType.EXCLUDE -> properties.filterKeys {
+                                val containsProp = containsProp(it, relationshipPatternConfiguration.properties)
+                                isRelationshipProperty(it) && !containsProp
+                            }
+                            PatternConfigurationType.INCLUDE -> properties.filterKeys {
+                                val containsProp = containsProp(it, relationshipPatternConfiguration.properties)
+                                isRelationshipProperty(it) && containsProp
+                            }
+                        }
+                        val startConf = relationshipPatternConfiguration.start
+                        val endConf = relationshipPatternConfiguration.end
+
+                        val start = NodePatternIngestionStrategy.toData(startConf, props)
+                        val end = NodePatternIngestionStrategy.toData(endConf, props)
+
+                        mapOf("start" to start, "end" to end, "properties" to filteredProperties)
+                    } else {
+                        null
+                    }
+                }
+        return listOf(QueryEvents(relationshipTemplate, data))
+    }
+
+    private fun isRelationshipProperty(propertyName: String): Boolean {
+        return (!relationshipPatternConfiguration.start.keys.contains(propertyName)
+                && !relationshipPatternConfiguration.start.properties.contains(propertyName)
+                && !relationshipPatternConfiguration.end.keys.contains(propertyName)
+                && !relationshipPatternConfiguration.end.properties.contains(propertyName))
+    }
+
+    override fun deleteRelationshipEvents(events: Collection<Any>): List<QueryEvents> {
+        return emptyList()
+    }
+
+}

--- a/common/src/main/kotlin/streams/utils/IngestionUtils.kt
+++ b/common/src/main/kotlin/streams/utils/IngestionUtils.kt
@@ -18,4 +18,17 @@ object IngestionUtils {
         val quoted = property.quote()
         return "$quoted: event.$prefix.$quoted"
     }
+
+    fun getNodeMergeKeys(prefix: String, keys: Set<String>): String = keys
+            .map {
+                val quoted = it.quote()
+                "$quoted: event.$prefix.$quoted"
+            }
+            .joinToString(keySeparator)
+
+    fun containsProp(key: String, properties: List<String>): Boolean = if (key.contains(".")) {
+        properties.contains(key) || properties.any { key.startsWith("$it.") }
+    } else {
+        properties.contains(key)
+    }
 }

--- a/common/src/main/kotlin/streams/utils/JSONUtils.kt
+++ b/common/src/main/kotlin/streams/utils/JSONUtils.kt
@@ -126,6 +126,9 @@ object JSONUtils {
 
     @Suppress("UNCHECKED_CAST")
     fun asStreamsTransactionEvent(obj: Any): StreamsTransactionEvent {
+        if (obj is StreamsTransactionEvent) {
+            return obj
+        }
         val value = when (obj) {
             is Map<*, *> -> obj as Map<String, Map<String, Any>>
             is String -> readValue(obj)

--- a/common/src/main/kotlin/streams/utils/ValidationUtils.kt
+++ b/common/src/main/kotlin/streams/utils/ValidationUtils.kt
@@ -1,0 +1,22 @@
+package streams.utils
+
+object ValidationUtils {
+
+    fun validateTopics(cdcMergeTopics: Set<String>, cdcSchemaTopics: Set<String>,
+                       cypherTopics: Set<String>, nodePatternTopics: Set<String>, relPatternTopics: Set<String>) {
+        val allTopicsLists = mutableListOf<String>()
+        allTopicsLists.addAll(cdcMergeTopics)
+        allTopicsLists.addAll(cdcSchemaTopics)
+        allTopicsLists.addAll(cypherTopics)
+        allTopicsLists.addAll(nodePatternTopics)
+        allTopicsLists.addAll(relPatternTopics)
+        val crossDefinedTopics = allTopicsLists.map { it to 1 }
+                .groupBy({ it.first }, { it.second })
+                .mapValues { it.value.reduce { acc, i -> acc + i } }
+                .filterValues { it > 1 }
+                .keys
+        if (crossDefinedTopics.isNotEmpty()) {
+            throw RuntimeException("The following topics are cross defined: $crossDefinedTopics")
+        }
+    }
+}

--- a/common/src/test/kotlin/streams/service/sink/strategy/NodePatternIngestionStrategyTest.kt
+++ b/common/src/test/kotlin/streams/service/sink/strategy/NodePatternIngestionStrategyTest.kt
@@ -1,0 +1,164 @@
+package streams.service.sink.strategy
+
+import org.junit.Test
+import streams.utils.StreamsUtils
+import kotlin.test.assertEquals
+
+class NodePatternIngestionStrategyTest {
+
+    @Test
+    fun `should get all properties`() {
+        // given
+        val config = NodePatternConfiguration.parse("(:LabelA:LabelB{!id})")
+        val strategy = NodePatternIngestionStrategy(config)
+        val data = mapOf("id" to 1, "foo" to "foo", "bar" to "bar", "foobar" to "foobar")
+
+        // when
+        val queryEvents = strategy.mergeNodeEvents(listOf(data))
+
+        // then
+        assertEquals("""
+                |${StreamsUtils.UNWIND}
+                |MERGE (n:LabelA:LabelB{id: event.keys.id})
+                |SET n = event.properties
+                |SET n += event.keys
+            """.trimMargin(), queryEvents[0].query)
+        assertEquals(listOf(mapOf("keys" to mapOf("id" to 1),
+                    "properties" to mapOf("foo" to "foo", "bar" to "bar", "foobar" to "foobar"))
+                ),
+                queryEvents[0].events)
+        assertEquals(emptyList(), strategy.deleteNodeEvents(emptyList()))
+        assertEquals(emptyList(), strategy.deleteRelationshipEvents(emptyList()))
+        assertEquals(emptyList(), strategy.mergeRelationshipEvents(emptyList()))
+    }
+
+    @Test
+    fun `should get nested properties`() {
+        // given
+        val config = NodePatternConfiguration.parse("(:LabelA:LabelB{!id, foo.bar})")
+        val strategy = NodePatternIngestionStrategy(config)
+        val data = mapOf("id" to 1, "foo" to mapOf("bar" to "bar", "foobar" to "foobar"))
+
+        // when
+        val queryEvents = strategy.mergeNodeEvents(listOf(data))
+
+        // then
+        assertEquals(1, queryEvents.size)
+        assertEquals("""
+                |${StreamsUtils.UNWIND}
+                |MERGE (n:LabelA:LabelB{id: event.keys.id})
+                |SET n = event.properties
+                |SET n += event.keys
+            """.trimMargin(),
+            queryEvents[0].query)
+        assertEquals(listOf(mapOf("keys" to mapOf("id" to 1),
+                "properties" to mapOf("foo.bar" to "bar"))),
+            queryEvents[0].events)
+        assertEquals(emptyList(), strategy.deleteNodeEvents(emptyList()))
+        assertEquals(emptyList(), strategy.deleteRelationshipEvents(emptyList()))
+        assertEquals(emptyList(), strategy.mergeRelationshipEvents(emptyList()))
+    }
+
+    @Test
+    fun `should exclude nested properties`() {
+        // given
+        val config = NodePatternConfiguration.parse("(:LabelA:LabelB{!id, -foo})")
+        val strategy = NodePatternIngestionStrategy(config)
+        val data = mapOf("id" to 1, "foo" to mapOf("bar" to "bar", "foobar" to "foobar"), "prop" to 100)
+
+        // when
+        val queryEvents = strategy.mergeNodeEvents(listOf(data))
+
+        // then
+        assertEquals(1, queryEvents.size)
+        assertEquals("""
+                |${StreamsUtils.UNWIND}
+                |MERGE (n:LabelA:LabelB{id: event.keys.id})
+                |SET n = event.properties
+                |SET n += event.keys
+            """.trimMargin(),
+                queryEvents[0].query)
+        assertEquals(listOf(mapOf("keys" to mapOf("id" to 1),
+                "properties" to mapOf("prop" to 100))),
+                queryEvents[0].events)
+        assertEquals(emptyList(), strategy.deleteNodeEvents(emptyList()))
+        assertEquals(emptyList(), strategy.deleteRelationshipEvents(emptyList()))
+        assertEquals(emptyList(), strategy.mergeRelationshipEvents(emptyList()))
+    }
+
+    @Test
+    fun `should include nested properties`() {
+        // given
+        val config = NodePatternConfiguration.parse("(:LabelA:LabelB{!id, foo})")
+        val strategy = NodePatternIngestionStrategy(config)
+        val data = mapOf("id" to 1, "foo" to mapOf("bar" to "bar", "foobar" to "foobar"), "prop" to 100)
+
+        // when
+        val queryEvents = strategy.mergeNodeEvents(listOf(data))
+
+        // then
+        assertEquals(1, queryEvents.size)
+        assertEquals("""
+                |${StreamsUtils.UNWIND}
+                |MERGE (n:LabelA:LabelB{id: event.keys.id})
+                |SET n = event.properties
+                |SET n += event.keys
+            """.trimMargin(),
+                queryEvents[0].query)
+        assertEquals(listOf(mapOf("keys" to mapOf("id" to 1),
+                "properties" to mapOf("foo.bar" to "bar", "foo.foobar" to "foobar"))),
+                queryEvents[0].events)
+        assertEquals(emptyList(), strategy.deleteNodeEvents(emptyList()))
+        assertEquals(emptyList(), strategy.deleteRelationshipEvents(emptyList()))
+        assertEquals(emptyList(), strategy.mergeRelationshipEvents(emptyList()))
+    }
+
+    @Test
+    fun `should exclude the properties`() {
+        // given
+        val config = NodePatternConfiguration.parse("(:LabelA:LabelB{!id,-foo,-bar})")
+        val strategy = NodePatternIngestionStrategy(config)
+        val data = mapOf("id" to 1, "foo" to "foo", "bar" to "bar", "foobar" to "foobar")
+
+        // when
+        val queryEvents = strategy.mergeNodeEvents(listOf(data))
+
+        // then
+        assertEquals(1, queryEvents.size)
+        assertEquals("""
+                |${StreamsUtils.UNWIND}
+                |MERGE (n:LabelA:LabelB{id: event.keys.id})
+                |SET n = event.properties
+                |SET n += event.keys
+            """.trimMargin(), queryEvents[0].query)
+        assertEquals(listOf(mapOf("keys" to mapOf("id" to 1), "properties" to mapOf("foobar" to "foobar"))), queryEvents[0].events)
+        assertEquals(emptyList(), strategy.deleteNodeEvents(emptyList()))
+        assertEquals(emptyList(), strategy.deleteRelationshipEvents(emptyList()))
+        assertEquals(emptyList(), strategy.mergeRelationshipEvents(emptyList()))
+    }
+
+    @Test
+    fun `should include the properties`() {
+        // given
+        val config = NodePatternConfiguration.parse("(:LabelA:LabelB{!id,foo,bar})")
+        val strategy = NodePatternIngestionStrategy(config)
+        val data = mapOf("id" to 1, "foo" to "foo", "bar" to "bar", "foobar" to "foobar")
+
+        // when
+        val queryEvents = strategy.mergeNodeEvents(listOf(data))
+
+        // then
+        assertEquals("""
+                |${StreamsUtils.UNWIND}
+                |MERGE (n:LabelA:LabelB{id: event.keys.id})
+                |SET n = event.properties
+                |SET n += event.keys
+            """.trimMargin(), queryEvents[0].query)
+        assertEquals(listOf(mapOf("keys" to mapOf("id" to 1), "properties" to mapOf("foo" to "foo", "bar" to "bar"))), queryEvents[0].events)
+        assertEquals(emptyList(), strategy.deleteNodeEvents(emptyList()))
+        assertEquals(emptyList(), strategy.deleteRelationshipEvents(emptyList()))
+        assertEquals(emptyList(), strategy.mergeRelationshipEvents(emptyList()))
+    }
+
+
+}

--- a/common/src/test/kotlin/streams/service/sink/strategy/PatternConfigurationTest.kt
+++ b/common/src/test/kotlin/streams/service/sink/strategy/PatternConfigurationTest.kt
@@ -1,0 +1,480 @@
+package streams.service.sink.strategy
+
+import org.junit.Test
+import kotlin.test.assertEquals
+
+class NodePatternConfigurationTest {
+
+    @Test
+    fun `should extract all params`() {
+        // given
+        val pattern = "(:LabelA:LabelB{!id,*})"
+
+        // when
+        val result = NodePatternConfiguration.parse(pattern)
+
+        // then
+        val expected = NodePatternConfiguration(keys = setOf("id"), type = PatternConfigurationType.ALL,
+                labels = listOf("LabelA", "LabelB"), properties = emptyList())
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `should extract all fixed params`() {
+        // given
+        val pattern = "(:LabelA{!id,foo,bar})"
+
+        // when
+        val result = NodePatternConfiguration.parse(pattern)
+
+        // then
+        val expected = NodePatternConfiguration(keys = setOf("id"), type = PatternConfigurationType.INCLUDE,
+                labels = listOf("LabelA"), properties = listOf("foo", "bar"))
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `should extract complex params`() {
+        // given
+        val pattern = "(:LabelA{!id,foo.bar})"
+
+        // when
+        val result = NodePatternConfiguration.parse(pattern)
+
+        // then
+        val expected = NodePatternConfiguration(keys = setOf("id"), type = PatternConfigurationType.INCLUDE,
+                labels = listOf("LabelA"), properties = listOf("foo.bar"))
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `should extract composite keys with fixed params`() {
+        // given
+        val pattern = "(:LabelA{!idA,!idB,foo,bar})"
+
+        // when
+        val result = NodePatternConfiguration.parse(pattern)
+
+        // then
+        val expected = NodePatternConfiguration(keys = setOf("idA", "idB"), type = PatternConfigurationType.INCLUDE,
+                labels = listOf("LabelA"), properties = listOf("foo", "bar"))
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `should extract all excluded params`() {
+        // given
+        val pattern = "(:LabelA{!id,-foo,-bar})"
+
+        // when
+        val result = NodePatternConfiguration.parse(pattern)
+
+        // then
+        val expected = NodePatternConfiguration(keys = setOf("id"), type = PatternConfigurationType.EXCLUDE,
+                labels = listOf("LabelA"), properties = listOf("foo", "bar"))
+        assertEquals(expected, result)
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `should throw an exception because of mixed configuration`() {
+        // given
+        val pattern = "(:LabelA{!id,-foo,bar})"
+
+        try {
+            // when
+            NodePatternConfiguration.parse(pattern)
+        } catch (e: IllegalArgumentException) {
+            // then
+            assertEquals("The Node pattern $pattern is not homogeneous", e.message)
+            throw e
+        }
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `should throw an exception because of invalid pattern`() {
+        // given
+        val pattern = "(LabelA{!id,-foo,bar})"
+
+        try {
+            // when
+            NodePatternConfiguration.parse(pattern)
+        } catch (e: IllegalArgumentException) {
+            // then
+            assertEquals("The Node pattern $pattern is invalid", e.message)
+            throw e
+        }
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `should throw an exception because the pattern should contains a key`() {
+        // given
+        val pattern = "(:LabelA{id,-foo,bar})"
+
+        try {
+            // when
+            NodePatternConfiguration.parse(pattern)
+        } catch (e: IllegalArgumentException) {
+            // then
+            assertEquals("The Node pattern $pattern must contains at lest one key", e.message)
+            throw e
+        }
+    }
+
+    @Test
+    fun `should extract all params - simple`() {
+        // given
+        val pattern = "LabelA:LabelB{!id,*}"
+
+        // when
+        val result = NodePatternConfiguration.parse(pattern)
+
+        // then
+        val expected = NodePatternConfiguration(keys = setOf("id"), type = PatternConfigurationType.ALL,
+                labels = listOf("LabelA", "LabelB"), properties = emptyList())
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `should extract all fixed params - simple`() {
+        // given
+        val pattern = "LabelA{!id,foo,bar}"
+
+        // when
+        val result = NodePatternConfiguration.parse(pattern)
+
+        // then
+        val expected = NodePatternConfiguration(keys = setOf("id"), type = PatternConfigurationType.INCLUDE,
+                labels = listOf("LabelA"), properties = listOf("foo", "bar"))
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `should extract complex params - simple`() {
+        // given
+        val pattern = "LabelA{!id,foo.bar}"
+
+        // when
+        val result = NodePatternConfiguration.parse(pattern)
+
+        // then
+        val expected = NodePatternConfiguration(keys = setOf("id"), type = PatternConfigurationType.INCLUDE,
+                labels = listOf("LabelA"), properties = listOf("foo.bar"))
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `should extract composite keys with fixed params - simple`() {
+        // given
+        val pattern = "LabelA{!idA,!idB,foo,bar}"
+
+        // when
+        val result = NodePatternConfiguration.parse(pattern)
+
+        // then
+        val expected = NodePatternConfiguration(keys = setOf("idA", "idB"), type = PatternConfigurationType.INCLUDE,
+                labels = listOf("LabelA"), properties = listOf("foo", "bar"))
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `should extract all excluded params - simple`() {
+        // given
+        val pattern = "LabelA{!id,-foo,-bar}"
+
+        // when
+        val result = NodePatternConfiguration.parse(pattern)
+
+        // then
+        val expected = NodePatternConfiguration(keys = setOf("id"), type = PatternConfigurationType.EXCLUDE,
+                labels = listOf("LabelA"), properties = listOf("foo", "bar"))
+        assertEquals(expected, result)
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `should throw an exception because of mixed configuration - simple`() {
+        // given
+        val pattern = "LabelA{!id,-foo,bar}"
+
+        try {
+            // when
+            NodePatternConfiguration.parse(pattern)
+        } catch (e: IllegalArgumentException) {
+            // then
+            assertEquals("The Node pattern $pattern is not homogeneous", e.message)
+            throw e
+        }
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `should throw an exception because the pattern should contains a key - simple`() {
+        // given
+        val pattern = "LabelA{id,-foo,bar}"
+
+        try {
+            // when
+            NodePatternConfiguration.parse(pattern)
+        } catch (e: IllegalArgumentException) {
+            // then
+            assertEquals("The Node pattern $pattern must contains at lest one key", e.message)
+            throw e
+        }
+    }
+}
+
+class RelationshipPatternConfigurationTest {
+
+    @Test
+    fun `should extract all params`() {
+        // given
+        val startPattern = "LabelA{!id,aa}"
+        val endPattern = "LabelB{!idB,bb}"
+        val pattern = "(:$startPattern)-[:REL_TYPE]->(:$endPattern)"
+
+        // when
+        val result = RelationshipPatternConfiguration.parse(pattern)
+
+        // then
+        val start = NodePatternConfiguration.parse(startPattern)
+        val end = NodePatternConfiguration.parse(endPattern)
+        val properties = emptyList<String>()
+        val relType = "REL_TYPE"
+        val expected = RelationshipPatternConfiguration(start = start, end = end, relType = relType,
+                properties = properties, type = PatternConfigurationType.ALL)
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `should extract all params with reverse source and target`() {
+        // given
+        val startPattern = "LabelA{!id,aa}"
+        val endPattern = "LabelB{!idB,bb}"
+        val pattern = "(:$startPattern)<-[:REL_TYPE]-(:$endPattern)"
+
+        // when
+        val result = RelationshipPatternConfiguration.parse(pattern)
+
+        // then
+        val start = NodePatternConfiguration.parse(startPattern)
+        val end = NodePatternConfiguration.parse(endPattern)
+        val properties = emptyList<String>()
+        val relType = "REL_TYPE"
+        val expected = RelationshipPatternConfiguration(start = end, end = start, relType = relType,
+                properties = properties, type = PatternConfigurationType.ALL)
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `should extract all fixed params`() {
+        // given
+        val startPattern = "LabelA{!id}"
+        val endPattern = "LabelB{!idB}"
+        val pattern = "(:$startPattern)-[:REL_TYPE{foo, BAR}]->(:$endPattern)"
+
+        // when
+        val result = RelationshipPatternConfiguration.parse(pattern)
+
+        // then
+        val start = RelationshipPatternConfiguration.getNodeConf(startPattern)
+        val end = RelationshipPatternConfiguration.getNodeConf(endPattern)
+        val properties = listOf("foo", "BAR")
+        val relType = "REL_TYPE"
+        val expected = RelationshipPatternConfiguration(start = start, end = end, relType = relType,
+                properties = properties, type = PatternConfigurationType.INCLUDE)
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `should extract complex params`() {
+        // given
+        val startPattern = "LabelA{!id}"
+        val endPattern = "LabelB{!idB}"
+        val pattern = "(:$startPattern)-[:REL_TYPE{foo.BAR, BAR.foo}]->(:$endPattern)"
+
+        // when
+        val result = RelationshipPatternConfiguration.parse(pattern)
+
+        // then
+        val start = RelationshipPatternConfiguration.getNodeConf(startPattern)
+        val end = RelationshipPatternConfiguration.getNodeConf(endPattern)
+        val properties = listOf("foo.BAR", "BAR.foo")
+        val relType = "REL_TYPE"
+        val expected = RelationshipPatternConfiguration(start = start, end = end, relType = relType,
+                properties = properties, type = PatternConfigurationType.INCLUDE)
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `should extract all excluded params`() {
+        // given
+        val startPattern = "LabelA{!id}"
+        val endPattern = "LabelB{!idB}"
+        val pattern = "(:$startPattern)-[:REL_TYPE{-foo, -BAR}]->(:$endPattern)"
+
+        // when
+        val result = RelationshipPatternConfiguration.parse(pattern)
+
+        // then
+        val start = RelationshipPatternConfiguration.getNodeConf(startPattern)
+        val end = RelationshipPatternConfiguration.getNodeConf(endPattern)
+        val properties = listOf("foo", "BAR")
+        val relType = "REL_TYPE"
+        val expected = RelationshipPatternConfiguration(start = start, end = end, relType = relType,
+                properties = properties, type = PatternConfigurationType.EXCLUDE)
+        assertEquals(expected, result)
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `should throw an exception because of mixed configuration`() {
+        // given
+        val pattern = "(:LabelA{!id})-[:REL_TYPE{foo, -BAR}]->(:LabelB{!idB})"
+
+        try {
+            // when
+            RelationshipPatternConfiguration.parse(pattern)
+        } catch (e: IllegalArgumentException) {
+            // then
+            assertEquals("The Relationship pattern $pattern is not homogeneous", e.message)
+            throw e
+        }
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `should throw an exception because the pattern should contains nodes with only ids`() {
+        // given
+        val pattern = "(:LabelA{id})-[:REL_TYPE{foo,BAR}]->(:LabelB{!idB})"
+
+        try {
+            // when
+            RelationshipPatternConfiguration.parse(pattern)
+        } catch (e: IllegalArgumentException) {
+            // then
+            assertEquals("The Relationship pattern $pattern is invalid", e.message)
+            throw e
+        }
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `should throw an exception because the pattern is invalid`() {
+        // given
+        val pattern = "(LabelA{!id})-[:REL_TYPE{foo,BAR}]->(:LabelB{!idB})"
+
+        try {
+            // when
+            RelationshipPatternConfiguration.parse(pattern)
+        } catch (e: IllegalArgumentException) {
+            // then
+            assertEquals("The Relationship pattern $pattern is invalid", e.message)
+            throw e
+        }
+    }
+
+    @Test
+    fun `should extract all params - simple`() {
+        // given
+        val startPattern = "LabelA{!id,aa}"
+        val endPattern = "LabelB{!idB,bb}"
+        val pattern = "$startPattern REL_TYPE $endPattern"
+
+        // when
+        val result = RelationshipPatternConfiguration.parse(pattern)
+
+        // then
+        val start = NodePatternConfiguration.parse(startPattern)
+        val end = NodePatternConfiguration.parse(endPattern)
+        val properties = emptyList<String>()
+        val relType = "REL_TYPE"
+        val expected = RelationshipPatternConfiguration(start = start, end = end, relType = relType,
+                properties = properties, type = PatternConfigurationType.ALL)
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `should extract all fixed params - simple`() {
+        // given
+        val startPattern = "LabelA{!id}"
+        val endPattern = "LabelB{!idB}"
+        val pattern = "$startPattern REL_TYPE{foo, BAR} $endPattern"
+
+        // when
+        val result = RelationshipPatternConfiguration.parse(pattern)
+
+        // then
+        val start = RelationshipPatternConfiguration.getNodeConf(startPattern)
+        val end = RelationshipPatternConfiguration.getNodeConf(endPattern)
+        val properties = listOf("foo", "BAR")
+        val relType = "REL_TYPE"
+        val expected = RelationshipPatternConfiguration(start = start, end = end, relType = relType,
+                properties = properties, type = PatternConfigurationType.INCLUDE)
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `should extract complex params - simple`() {
+        // given
+        val startPattern = "LabelA{!id}"
+        val endPattern = "LabelB{!idB}"
+        val pattern = "$startPattern REL_TYPE{foo.BAR, BAR.foo} $endPattern"
+
+        // when
+        val result = RelationshipPatternConfiguration.parse(pattern)
+
+        // then
+        val start = RelationshipPatternConfiguration.getNodeConf(startPattern)
+        val end = RelationshipPatternConfiguration.getNodeConf(endPattern)
+        val properties = listOf("foo.BAR", "BAR.foo")
+        val relType = "REL_TYPE"
+        val expected = RelationshipPatternConfiguration(start = start, end = end, relType = relType,
+                properties = properties, type = PatternConfigurationType.INCLUDE)
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `should extract all excluded params - simple`() {
+        // given
+        val startPattern = "LabelA{!id}"
+        val endPattern = "LabelB{!idB}"
+        val pattern = "$startPattern REL_TYPE{-foo, -BAR} $endPattern"
+
+        // when
+        val result = RelationshipPatternConfiguration.parse(pattern)
+
+        // then
+        val start = RelationshipPatternConfiguration.getNodeConf(startPattern)
+        val end = RelationshipPatternConfiguration.getNodeConf(endPattern)
+        val properties = listOf("foo", "BAR")
+        val relType = "REL_TYPE"
+        val expected = RelationshipPatternConfiguration(start = start, end = end, relType = relType,
+                properties = properties, type = PatternConfigurationType.EXCLUDE)
+        assertEquals(expected, result)
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `should throw an exception because of mixed configuration - simple`() {
+        // given
+        val pattern = "LabelA{!id} REL_TYPE{foo, -BAR} LabelB{!idB}"
+
+        try {
+            // when
+            RelationshipPatternConfiguration.parse(pattern)
+        } catch (e: IllegalArgumentException) {
+            // then
+            assertEquals("The Relationship pattern $pattern is not homogeneous", e.message)
+            throw e
+        }
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `should throw an exception because the pattern should contains nodes with only ids - simple`() {
+        // given
+        val pattern = "LabelA{id} REL_TYPE{foo,BAR} LabelB{!idB}"
+
+        try {
+            // when
+            RelationshipPatternConfiguration.parse(pattern)
+        } catch (e: IllegalArgumentException) {
+            // then
+            assertEquals("The Relationship pattern $pattern is invalid", e.message)
+            throw e
+        }
+    }
+}

--- a/common/src/test/kotlin/streams/service/sink/strategy/RelationshipPatternIngestionStrategyTest.kt
+++ b/common/src/test/kotlin/streams/service/sink/strategy/RelationshipPatternIngestionStrategyTest.kt
@@ -1,0 +1,159 @@
+package streams.service.sink.strategy
+
+import org.junit.Test
+import streams.utils.StreamsUtils
+import kotlin.test.assertEquals
+
+class RelationshipPatternIngestionStrategyTest {
+
+    @Test
+    fun `should get all properties`() {
+        // given
+        val startPattern = "LabelA{!idStart}"
+        val endPattern = "LabelB{!idEnd}"
+        val pattern = "(:$startPattern)-[:REL_TYPE]->(:$endPattern)"
+        val config = RelationshipPatternConfiguration.parse(pattern)
+        val strategy = RelationshipPatternIngestionStrategy(config)
+        val data = mapOf("idStart" to 1, "idEnd" to 2,
+                "foo" to "foo",
+                "bar" to "bar")
+
+        // when
+        val queryEvents = strategy.mergeRelationshipEvents(listOf(data))
+
+        // then
+        assertEquals(1, queryEvents.size)
+        assertEquals("""
+            |${StreamsUtils.UNWIND}
+            |MERGE (start:LabelA{idStart: event.start.keys.idStart})
+            |SET start = event.start.properties
+            |SET start += event.start.keys
+            |MERGE (end:LabelB{idEnd: event.end.keys.idEnd})
+            |SET end = event.end.properties
+            |SET end += event.end.keys
+            |MERGE (start)-[r:REL_TYPE]->(end)
+            |SET r = event.properties
+        """.trimMargin(), queryEvents[0].query)
+        assertEquals(listOf(mapOf("start" to mapOf("keys" to mapOf("idStart" to 1), "properties" to emptyMap()),
+                "end" to mapOf("keys" to mapOf("idEnd" to 2), "properties" to emptyMap()),
+                "properties" to mapOf("foo" to "foo", "bar" to "bar"))), queryEvents[0].events)
+        assertEquals(emptyList(), strategy.deleteNodeEvents(emptyList()))
+        assertEquals(emptyList(), strategy.deleteRelationshipEvents(emptyList()))
+        assertEquals(emptyList(), strategy.mergeNodeEvents(emptyList()))
+    }
+
+
+
+    @Test
+    fun `should get all properties - simple`() {
+        // given
+        val startPattern = "LabelA{!idStart}"
+        val endPattern = "LabelB{!idEnd}"
+        val pattern = "$startPattern REL_TYPE $endPattern"
+        val config = RelationshipPatternConfiguration.parse(pattern)
+        val strategy = RelationshipPatternIngestionStrategy(config)
+        val data = mapOf("idStart" to 1, "idEnd" to 2,
+                "foo" to "foo",
+                "bar" to "bar")
+
+        // when
+        val queryEvents = strategy.mergeRelationshipEvents(listOf(data))
+
+        // then
+        assertEquals(1, queryEvents.size)
+        assertEquals("""
+            |${StreamsUtils.UNWIND}
+            |MERGE (start:LabelA{idStart: event.start.keys.idStart})
+            |SET start = event.start.properties
+            |SET start += event.start.keys
+            |MERGE (end:LabelB{idEnd: event.end.keys.idEnd})
+            |SET end = event.end.properties
+            |SET end += event.end.keys
+            |MERGE (start)-[r:REL_TYPE]->(end)
+            |SET r = event.properties
+        """.trimMargin(), queryEvents[0].query)
+        assertEquals(listOf(mapOf("start" to mapOf("keys" to mapOf("idStart" to 1), "properties" to emptyMap()),
+                "end" to mapOf("keys" to mapOf("idEnd" to 2), "properties" to emptyMap()),
+                "properties" to mapOf("foo" to "foo", "bar" to "bar"))), queryEvents[0].events)
+        assertEquals(emptyList(), strategy.deleteNodeEvents(emptyList()))
+        assertEquals(emptyList(), strategy.deleteRelationshipEvents(emptyList()))
+        assertEquals(emptyList(), strategy.mergeNodeEvents(emptyList()))
+    }
+
+    @Test
+    fun `should get all properties with reverse start-end`() {
+        // given
+        val startPattern = "LabelA{!idStart}"
+        val endPattern = "LabelB{!idEnd}"
+        val pattern = "(:$endPattern)<-[:REL_TYPE]-(:$startPattern)"
+        val config = RelationshipPatternConfiguration.parse(pattern)
+        val strategy = RelationshipPatternIngestionStrategy(config)
+        val data = mapOf("idStart" to 1, "idEnd" to 2,
+                "foo" to "foo",
+                "bar" to "bar")
+
+        // when
+        val queryEvents = strategy.mergeRelationshipEvents(listOf(data))
+
+        // then
+        assertEquals(1, queryEvents.size)
+        assertEquals("""
+            |${StreamsUtils.UNWIND}
+            |MERGE (start:LabelA{idStart: event.start.keys.idStart})
+            |SET start = event.start.properties
+            |SET start += event.start.keys
+            |MERGE (end:LabelB{idEnd: event.end.keys.idEnd})
+            |SET end = event.end.properties
+            |SET end += event.end.keys
+            |MERGE (start)-[r:REL_TYPE]->(end)
+            |SET r = event.properties
+        """.trimMargin(), queryEvents[0].query)
+        assertEquals(listOf(mapOf("start" to mapOf("keys" to mapOf("idStart" to 1), "properties" to emptyMap()),
+                "end" to mapOf("keys" to mapOf("idEnd" to 2), "properties" to emptyMap()),
+                "properties" to mapOf("foo" to "foo", "bar" to "bar"))), queryEvents[0].events)
+        assertEquals(emptyList(), strategy.deleteNodeEvents(emptyList()))
+        assertEquals(emptyList(), strategy.deleteRelationshipEvents(emptyList()))
+        assertEquals(emptyList(), strategy.mergeNodeEvents(emptyList()))
+    }
+
+    @Test
+    fun `should get nested properties`() {
+        // given
+        val startPattern = "LabelA{!idStart, foo.mapFoo}"
+        val endPattern = "LabelB{!idEnd, bar.mapBar}"
+        val pattern = "(:$startPattern)-[:REL_TYPE]->(:$endPattern)"
+        val config = RelationshipPatternConfiguration.parse(pattern)
+        val strategy = RelationshipPatternIngestionStrategy(config)
+        val data = mapOf("idStart" to 1, "idEnd" to 2,
+                "foo" to mapOf("mapFoo" to "mapFoo"),
+                "bar" to mapOf("mapBar" to "mapBar"),
+                "rel" to 1,
+                "map" to mapOf("a" to "a", "inner" to mapOf("b" to "b")))
+
+        // when
+        val queryEvents = strategy.mergeRelationshipEvents(listOf(data))
+
+        // then
+        assertEquals(1, queryEvents.size)
+        assertEquals("""
+            |${StreamsUtils.UNWIND}
+            |MERGE (start:LabelA{idStart: event.start.keys.idStart})
+            |SET start = event.start.properties
+            |SET start += event.start.keys
+            |MERGE (end:LabelB{idEnd: event.end.keys.idEnd})
+            |SET end = event.end.properties
+            |SET end += event.end.keys
+            |MERGE (start)-[r:REL_TYPE]->(end)
+            |SET r = event.properties
+        """.trimMargin(), queryEvents[0].query)
+        assertEquals(listOf(
+                mapOf("start" to mapOf("keys" to mapOf("idStart" to 1), "properties" to mapOf("foo.mapFoo" to "mapFoo")),
+                "end" to mapOf("keys" to mapOf("idEnd" to 2), "properties" to mapOf("bar.mapBar" to "mapBar")),
+                "properties" to mapOf("rel" to 1, "map.a" to "a", "map.inner.b" to "b"))
+        ), queryEvents[0].events)
+        assertEquals(emptyList(), strategy.deleteNodeEvents(emptyList()))
+        assertEquals(emptyList(), strategy.deleteRelationshipEvents(emptyList()))
+        assertEquals(emptyList(), strategy.mergeNodeEvents(emptyList()))
+    }
+
+}

--- a/consumer/src/main/kotlin/streams/StreamsEventSinkExtensionFactory.kt
+++ b/consumer/src/main/kotlin/streams/StreamsEventSinkExtensionFactory.kt
@@ -10,8 +10,6 @@ import org.neo4j.kernel.lifecycle.Lifecycle
 import org.neo4j.kernel.lifecycle.LifecycleAdapter
 import streams.procedures.StreamsSinkProcedures
 import streams.service.TopicUtils
-import streams.service.sink.strategy.SchemaIngestionStrategy
-import streams.service.sink.strategy.SourceIdIngestionStrategy
 import streams.utils.Neo4jUtils
 import streams.utils.StreamsUtils
 

--- a/consumer/src/main/kotlin/streams/StreamsEventSinkQueryExecution.kt
+++ b/consumer/src/main/kotlin/streams/StreamsEventSinkQueryExecution.kt
@@ -4,8 +4,7 @@ import org.neo4j.kernel.internal.GraphDatabaseAPI
 import org.neo4j.logging.Log
 import streams.service.StreamsSinkService
 import streams.service.TopicType
-import streams.service.sink.strategy.SchemaIngestionStrategy
-import streams.service.sink.strategy.SourceIdIngestionStrategy
+import streams.service.sink.strategy.*
 import streams.utils.Neo4jUtils
 import streams.utils.StreamsUtils
 

--- a/consumer/src/main/kotlin/streams/StreamsSinkConfiguration.kt
+++ b/consumer/src/main/kotlin/streams/StreamsSinkConfiguration.kt
@@ -1,7 +1,6 @@
 package streams
 
 import org.neo4j.kernel.configuration.Config
-import streams.service.TopicType
 import streams.service.TopicUtils
 import streams.service.sink.strategy.SourceIdIngestionStrategyConfig
 import streams.service.Topics

--- a/consumer/src/test/kotlin/integrations/KafkaEventSinkIT.kt
+++ b/consumer/src/test/kotlin/integrations/KafkaEventSinkIT.kt
@@ -12,11 +12,14 @@ import org.apache.kafka.common.serialization.ByteArrayDeserializer
 import org.apache.kafka.common.serialization.ByteArraySerializer
 import org.apache.kafka.common.serialization.StringDeserializer
 import org.apache.kafka.common.serialization.StringSerializer
+import org.hamcrest.Matchers
 import org.hamcrest.Matchers.equalTo
 import org.junit.*
+import org.junit.rules.TestName
 import org.neo4j.function.ThrowingSupplier
 import org.neo4j.graphdb.Node
 import org.neo4j.graphdb.factory.GraphDatabaseBuilder
+import org.neo4j.graphdb.schema.ConstraintType
 import org.neo4j.kernel.internal.GraphDatabaseAPI
 import org.neo4j.test.TestGraphDatabaseFactory
 import org.neo4j.test.assertion.Assert.assertEventually
@@ -24,8 +27,14 @@ import org.testcontainers.containers.KafkaContainer
 import streams.events.*
 import streams.serialization.JSONUtils
 import streams.utils.StreamsUtils
+import java.io.File
+import java.io.IOException
+import java.io.UncheckedIOException
 import java.util.*
 import java.util.concurrent.TimeUnit
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 @Suppress("UNCHECKED_CAST", "DEPRECATION")
 class KafkaEventSinkIT {
@@ -350,5 +359,48 @@ class KafkaEventSinkIT {
         }, equalTo(true), 30, TimeUnit.SECONDS)
 
     }
+
+    @Test
+    fun shouldWorkWithNodePatternTopic() = runBlocking {
+        val topic = UUID.randomUUID().toString()
+        graphDatabaseBuilder.setConfig("streams.sink.topic.pattern.node.$topic",
+                "(:User{!userId,name,surname,address.city})")
+        db = graphDatabaseBuilder.newGraphDatabase() as GraphDatabaseAPI
+
+
+        val data = mapOf("userId" to 1, "name" to "Andrea", "surname" to "Santurbano",
+                "address" to mapOf("city" to "Venice", "CAP" to "30100"))
+
+        var producerRecord = ProducerRecord(topic, UUID.randomUUID().toString(), JSONUtils.writeValueAsBytes(data))
+        kafkaProducer.send(producerRecord).get()
+        assertEventually(ThrowingSupplier<Boolean, Exception> {
+            val query = "MATCH (n:User{name: 'Andrea', surname: 'Santurbano', userId: 1, `address.city`: 'Venice'}) RETURN count(n) AS count"
+            val result = db.execute(query).columnAs<Long>("count")
+            result.hasNext() && result.next() == 1L && !result.hasNext()
+        }, equalTo(true), 30, TimeUnit.SECONDS)
+    }
+
+    @Test
+    fun shouldWorkWithRelPatternTopic() = runBlocking {
+        val topic = UUID.randomUUID().toString()
+        graphDatabaseBuilder.setConfig("streams.sink.topic.pattern.relationship.$topic",
+                "(:User{!sourceId,sourceName,sourceSurname})-[:KNOWS]->(:User{!targetId,targetName,targetSurname})")
+        db = graphDatabaseBuilder.newGraphDatabase() as GraphDatabaseAPI
+        val data = mapOf("sourceId" to 1, "sourceName" to "Andrea", "sourceSurname" to "Santurbano",
+                "targetId" to 1, "targetName" to "Michael", "targetSurname" to "Hunger", "since" to 2014)
+
+        var producerRecord = ProducerRecord(topic, UUID.randomUUID().toString(), JSONUtils.writeValueAsBytes(data))
+        kafkaProducer.send(producerRecord).get()
+        assertEventually(ThrowingSupplier<Boolean, Exception> {
+            val query = """
+            MATCH p = (s:User{sourceName: 'Andrea', sourceSurname: 'Santurbano', sourceId: 1})-[:KNOWS{since: 2014}]->(e:User{targetName: 'Michael', targetSurname: 'Hunger', targetId: 1})
+            RETURN count(p) AS count
+        """.trimIndent()
+            val result = db.execute(query).columnAs<Long>("count")
+            result.hasNext() && result.next() == 1L && !result.hasNext()
+        }, equalTo(true), 30, TimeUnit.SECONDS)
+    }
+
+
 
 }

--- a/consumer/src/test/kotlin/streams/StreamsEventSinkQueryExecutionTest.kt
+++ b/consumer/src/test/kotlin/streams/StreamsEventSinkQueryExecutionTest.kt
@@ -8,8 +8,7 @@ import org.neo4j.kernel.internal.GraphDatabaseAPI
 import org.neo4j.logging.NullLog
 import org.neo4j.test.TestGraphDatabaseFactory
 import streams.kafka.KafkaSinkConfiguration
-import streams.service.sink.strategy.SchemaIngestionStrategy
-import streams.service.sink.strategy.SourceIdIngestionStrategy
+import streams.service.TopicType
 import streams.service.Topics
 import kotlin.test.assertEquals
 

--- a/consumer/src/test/kotlin/streams/StreamsSinkConfigurationTest.kt
+++ b/consumer/src/test/kotlin/streams/StreamsSinkConfigurationTest.kt
@@ -49,6 +49,7 @@ class StreamsSinkConfigurationTest {
         val config = Config.builder()
                 .withSetting("streams.sink.polling.interval", pollingInterval)
                 .withSetting(topicKey, topicValue)
+                .withSetting("streams.sink.topic.pattern.node.nodePatternTopic", "User{!userId,name,surname,address.city}")
                 .withSetting("streams.sink.enabled", "false")
                 .withSetting("streams.sink.topic.cdc.sourceId", topic)
                 .build()

--- a/doc/asciidoc/consumer/configuration.adoc
+++ b/doc/asciidoc/consumer/configuration.adoc
@@ -11,6 +11,8 @@ kafka.enable.auto.commit=true
 streams.sink.topic.cypher.<TOPIC_NAME>=<CYPHER_QUERY>
 streams.sink.topic.cdc.sourceId=<LIST_OF_TOPICS_SEPARATE_BY_SEMICOLON>
 streams.sink.topic.cdc.schema=<LIST_OF_TOPICS_SEPARATE_BY_SEMICOLON>
+streams.sink.topic.pattern.node.<TOPIC_NAME>=<NODE_EXTRACTION_PATTERN>
+streams.sink.topic.pattern.relationship.<TOPIC_NAME>=<RELATIONSHIP_EXTRACTION_PATTERN>
 streams.sink.enabled=<true/false, default=true>
 ----
 

--- a/doc/asciidoc/consumer/index.adoc
+++ b/doc/asciidoc/consumer/index.adoc
@@ -37,8 +37,9 @@ For this event
 {
  "id": 42,
  "properties": {
- "title": "Answer to anyting",
- "description": "It depends."}
+   "title": "Answer to anyting",
+   "description": "It depends."
+ }
 }
 ----
 
@@ -150,6 +151,162 @@ include::../producer/data/relationship.created.json[]
 ----
 
 the `Schema` strategy leverages the `ids` fields in order to insert/update the relationships so no extra fields will be created.
+
+===== The `Pattern` strategy
+
+The `Pattern` strategy allows you to extract nodes and relationships from a json by providing a extraction pattern
+
+Each property can be prefixed with:
+
+* `!`: identify the id (could be more than one property), it's *mandatory*
+* `-`: exclude the property from the extraction
+If no prefix is specified this means that the property will be included
+
+*Note*: you cannot mix inclusion and exclusion so if your pattern must contains all exclusion
+or inclusion properties
+
+Labels can be chained via `:`
+
+====== The `Node Pattern` configuration
+
+You can configure the node pattern extraction in the following way:
+
+```
+streams.sink.topic.pattern.node.<TOPIC_NAME>=<NODE_EXTRACTION_PATTERN>
+```
+
+So for instance, given the following `json` published via the `user` topic:
+
+[source,json]
+----
+{"userId": 1, "name": "Andrea", "surname": "Santurbano", "address": {"city": "Venice", "cap": "30100"}}
+----
+
+You can transform it into a node by providing the following configuration:
+
+
+by specifying a simpler pattern:
+
+```
+streams.sink.topic.pattern.node.user=User{!userId}
+```
+
+or by specifying a Cypher like node pattern:
+
+```
+streams.sink.topic.pattern.node.user=(:User{!userId})
+```
+
+Similar to the CDC pattern you can provide:
+
+[cols="1m,3a",opts=header]
+|===
+| pattern
+| meaning
+
+| User:Actor{!userId} or User:Actor{!userId,*}
+| the userId will be used as ID field and all properties of the json will be attached to the node with the provided
+labels (`User` and `Actor`) so the persisted node will be: *(User:Actor{userId: 1, name: 'Andrea', surname: 'Santurbano', `address.city`: 'Venice', `address.cap`: 30100})*
+
+| User{!userId, surname}
+| the userId will be used as ID field and *only* the surname property of the json will be attached to the node with the provided
+labels (`User`) so the persisted node will be: *(User:Actor{userId: 1, surname: 'Santurbano'})*
+
+| User{!userId, surname, address.city}
+| the userId will be used as ID field and *only* the surname and the `address.city` property of the json will be attached to the node with the provided
+labels (`User`) so the persisted node will be: *(User:Actor{userId: 1, surname: 'Santurbano', `address.city`: 'Venice'})*
+
+| User{!userId,-address}
+| the userId will be used as ID field and the `address` property will be excluded
+so the persisted node will be: *(User:Actor{userId: 1, name: 'Andrea', surname: 'Santurbano'})*
+
+|===
+
+====== The `Relationship Pattern` configuration
+
+You can configure the relationship pattern extraction in the following way:
+
+```
+streams.sink.topic.pattern.relationship.<TOPIC_NAME>=<RELATIONSHIP_EXTRACTION_PATTERN>
+```
+
+So for instance, given the following `json` published via the `user` topic:
+
+[source,json]
+----
+{"userId": 1, "productId": 100, "price": 10, "currency": "€", "shippingAddress": {"city": "Venice", cap: "30100"}}
+----
+
+You can transform it into a node by providing the following configuration:
+
+By specifying a simpler pattern:
+
+```
+streams.sink.topic.pattern.relationship.user=User{!userId} BOUGHT{price, currency} Product{!productId}
+```
+
+or by specifying a Cypher like node pattern:
+
+```
+streams.sink.topic.pattern.relationship.user=(:User{!userId})-[:BOUGHT{price, currency}]->(:Product{!productId})
+```
+
+in this last case the we assume that `User` is the source node and `Product` the target node
+
+
+Similar to the CDC pattern you can provide:
+
+[cols="1m,3a",opts=header]
+|===
+| pattern
+| meaning
+
+| (User{!userId})-[:BOUGHT]->(Product{!productId}) or (User{!userId})-[:BOUGHT{price, currency}]->(Product{!productId})
+| this will merge fetch/create the two nodes by the provided identifier and the `BOUGHT` relationship between them. And then set all the other json properties on them so the persisted data will be:
+*(User{userId: 1})-[:BOUGHT{price: 10, currency: '€', `shippingAddress.city`: 'Venice', `shippingAddress.cap`: 30100}]->(Product{productId: 100})*
+
+| (User{!userId})-[:BOUGHT{price}]->(Product{!productId})
+| this will merge fetch/create the two nodes by the provided identifier and the `BOUGHT` relationship between them. And then set all the specified json properties so the persisted pattern will be:
+*(User{userId: 1})-[:BOUGHT{price: 10}]->(Product{productId: 100})*
+
+| (User{!userId})-[:BOUGHT{-shippingAddress}]->(Product{!productId})
+| this will merge fetch/create the two nodes by the provided identifier and the `BOUGHT` relationship between them. And then set all the specified json properties (by the exclusion) so the persisted pattern will be:
+*(User{userId: 1})-[:BOUGHT{price: 10, currency: '€'}]->(Product{productId: 100})*
+
+| (User{!userId})-[:BOUGHT{price,currency, shippingAddress.city}]->(Product{!productId})
+| this will merge fetch/create the two nodes by the provided identifier and the `BOUGHT` relationship between them. And then set all the specified json properties so the persisted pattern will be:
+*(User{userId: 1})-[:BOUGHT{price: 10, currency: '€', `shippingAddress.city`: 'Venice'}]->(Product{productId: 100})*
+
+|===
+
+
+*Attach properties to node*
+
+By default no properties will be attached to the edge nodes but you can specify which property attach to each node. Given the following `json` published via the `user` topic:
+
+[source,json]
+----
+{
+    "userId": 1,
+    "userName": "Andrea",
+    "userSurname": "Santurbano",
+    "productId": 100,
+    "productName": "My Awesome Product!",
+    "price": 10,
+    "currency": "€"
+}
+----
+
+[cols="1m,3a",opts=header]
+|===
+| pattern
+| meaning
+
+| (User{!userId, userName, userSurname})-[:BOUGHT]->(Product{!productId, productName})
+| this will merge two nodes and the `BOUGHT` relationship between with all json properties them so the persisted pattern will be:
+*(User{userId: 1, userName: 'Andrea', userSurname: 'Santurbano'})-[:BOUGHT{price: 10, currency: '€'}]->(Product{productId: 100, name: 'My Awesome Product!'})*
+
+|===
 
 === Configuration
 

--- a/kafka-connect-neo4j/docker/readme.adoc
+++ b/kafka-connect-neo4j/docker/readme.adoc
@@ -183,14 +183,14 @@ You can configure the topic in the following way:
 
 [source,ini]
 ----
-streams.sink.topic.cdc.sourceId=<list of topics separated by semicolon>
-streams.sink.topic.cdc.sourceId.labelName=<the label attached to the node, default=SourceEvent>
-streams.sink.topic.cdc.sourceId.idName=<the id name given to the CDC id field, default=sourceId>
+neo4j.topic.cdc.sourceId=<list of topics separated by semicolon>
+neo4j.topic.cdc.sourceId.labelName=<the label attached to the node, default=SourceEvent>
+neo4j.topic.cdc.sourceId.idName=<the id name given to the CDC id field, default=sourceId>
 ----
 
 [source,ini]
 ----
-streams.sink.topic.cdc.sourceId=my-topic;my-other.topic
+neo4j.topic.cdc.sourceId=my-topic;my-other.topic
 ----
 
 Each streams event will be projected into the related graph entity, for instance the following event:
@@ -219,12 +219,12 @@ You can configure the topic in the following way:
 
 [source,ini]
 ----
-streams.sink.topic.cdc.schema=<LIST_OF_TOPICS_SEPARATE_BY_SEMICOLON>
+neo4j.topic.cdc.schema=<LIST_OF_TOPICS_SEPARATE_BY_SEMICOLON>
 ----
 
 [source,ini]
 ----
-streams.sink.topic.cdc.schema=my-topic;my-other.topic
+neo4j.topic.cdc.schema=my-topic;my-other.topic
 ----
 
 Each streams event will be projected into the related graph entity, for instance the following event:
@@ -338,6 +338,162 @@ In case of relationship
 ----
 
 the `Schema` strategy leverages the `ids` fields in order to insert/update the relationships so no extra fields will be created.
+
+===== The `Pattern` strategy
+
+The `Pattern` strategy allows you to extract nodes and relationships from a json by providing a extraction pattern
+
+Each property can be prefixed with:
+
+* `!`: identify the id (could be more than one property), it's *mandatory*
+* `-`: exclude the property from the extraction
+If no prefix is specified this means that the property will be included
+
+*Note*: you cannot mix inclusion and exclusion so if your pattern must contains all exclusion
+or inclusion properties
+
+Labels can be chained via `:`
+
+====== The `Node Pattern` configuration
+
+You can configure the node pattern extraction in the following way:
+
+```
+neo4j.topic.pattern.node.<TOPIC_NAME>=<NODE_EXTRACTION_PATTERN>
+```
+
+So for instance, given the following `json` published via the `user` topic:
+
+[source,json]
+----
+{"userId": 1, "name": "Andrea", "surname": "Santurbano", "address": {"city": "Venice", cap: "30100"}}
+----
+
+You can transform it into a node by providing the following configuration:
+
+
+by specifying a simpler pattern:
+
+```
+neo4j.topic.pattern.node.user=User{!userId}
+```
+
+or by specifying a Cypher like node pattern:
+
+```
+neo4j.topic.pattern.node.user=(:User{!userId})
+```
+
+Similar to the CDC pattern you can provide:
+
+[cols="1m,3a",opts=header]
+|===
+| pattern
+| meaning
+
+| User:Actor{!userId} or User:Actor{!userId,*}
+| the userId will be used as ID field and all properties of the json will be attached to the node with the provided
+labels (`User` and `Actor`) so the persisted node will be: *(User:Actor{userId: 1, name: 'Andrea', surname: 'Santurbano', `address.city`: 'Venice', `address.cap`: 30100})*
+
+| User{!userId, surname}
+| the userId will be used as ID field and *only* the surname property of the json will be attached to the node with the provided
+labels (`User`) so the persisted node will be: *(User:Actor{userId: 1, surname: 'Santurbano'})*
+
+| User{!userId, surname, address.city}
+| the userId will be used as ID field and *only* the surname and the `address.city` property of the json will be attached to the node with the provided
+labels (`User`) so the persisted node will be: *(User:Actor{userId: 1, surname: 'Santurbano', `address.city`: 'Venice'})*
+
+| User{!userId,-address}
+| the userId will be used as ID field and the `address` property will be excluded
+so the persisted node will be: *(User:Actor{userId: 1, name: 'Andrea', surname: 'Santurbano'})*
+
+|===
+
+====== The `Relationship Pattern` configuration
+
+You can configure the relationship pattern extraction in the following way:
+
+```
+neo4j.topic.pattern.relationship.<TOPIC_NAME>=<RELATIONSHIP_EXTRACTION_PATTERN>
+```
+
+So for instance, given the following `json` published via the `user` topic:
+
+[source,json]
+----
+{"userId": 1, "productId": 100, "price": 10, "currency": "€", "shippingAddress": {"city": "Venice", cap: "30100"}}
+----
+
+You can transform it into a node by providing the following configuration:
+
+by specifying a simpler pattern:
+
+```
+neo4j.topic.pattern.relationship.user=User{!userId} BOUGHT{price, currency} Product{!productId}
+```
+
+or specifying a Cypher like node pattern:
+
+```
+neo4j.topic.pattern.relationship.user=(:User{!userId})-[:BOUGHT{price, currency}]->(:Product{!productId})
+```
+
+in this last case the we assume that `User` is the source node and `Product` the target node
+
+
+Similar to the CDC pattern you can provide:
+
+[cols="1m,3a",opts=header]
+|===
+| pattern
+| meaning
+
+| (User{!userId})-[:BOUGHT]->(Product{!productId}) or (User{!userId})-[:BOUGHT{price, currency}]->(Product{!productId})
+| this will merge fetch/create the two nodes by the provided identifier and the `BOUGHT` relationship between them. And then set all the other json properties on them so the persisted data will be:
+*(User{userId: 1})-[:BOUGHT{price: 10, currency: '€', `shippingAddress.city`: 'Venice', `shippingAddress.cap`: 30100}]->(Product{productId: 100})*
+
+| (User{!userId})-[:BOUGHT{price}]->(Product{!productId})
+| this will merge fetch/create the two nodes by the provided identifier and the `BOUGHT` relationship between them. And then set all the specified json properties so the persisted pattern will be:
+*(User{userId: 1})-[:BOUGHT{price: 10}]->(Product{productId: 100})*
+
+| (User{!userId})-[:BOUGHT{-shippingAddress}]->(Product{!productId})
+| this will merge fetch/create the two nodes by the provided identifier and the `BOUGHT` relationship between them. And then set all the specified json properties (by the exclusion) so the persisted pattern will be:
+*(User{userId: 1})-[:BOUGHT{price: 10, currency: '€'}]->(Product{productId: 100})*
+
+| (User{!userId})-[:BOUGHT{price,currency, shippingAddress.city}]->(Product{!productId})
+| this will merge fetch/create the two nodes by the provided identifier and the `BOUGHT` relationship between them. And then set all the specified json properties so the persisted pattern will be:
+*(User{userId: 1})-[:BOUGHT{price: 10, currency: '€', `shippingAddress.city`: 'Venice'}]->(Product{productId: 100})*
+
+|===
+
+
+*Attach properties to node*
+
+By default no properties will be attached to the edge nodes but you can specify which property attach to each node. Given the following `json` published via the `user` topic:
+
+[source,json]
+----
+{
+    "userId": 1,
+    "userName": "Andrea",
+    "userSurname": "Santurbano",
+    "productId": 100,
+    "productName": "My Awesome Product!",
+    "price": 10,
+    "currency": "€"
+}
+----
+
+[cols="1m,3a",opts=header]
+|===
+| pattern
+| meaning
+
+| (User{!userId, userName, userSurname})-[:BOUGHT]->(Product{!productId, productName})
+| this will merge fetch/create the two nodes by the provided identifier (in case of creation also the declared properties are created) and the `BOUGHT` relationship between with all json properties them so the persisted pattern will be:
+*(User{userId: 1, userName: 'Andrea', userSurname: 'Santurbano'})-[:BOUGHT{price: 10, currency: '€'}]->(Product{productId: 100, name: 'My Awesome Product!'})*
+
+|===
 
 ==== Use the data generator
 

--- a/kafka-connect-neo4j/src/main/kotlin/streams/kafka/connect/sink/Neo4jService.kt
+++ b/kafka-connect-neo4j/src/main/kotlin/streams/kafka/connect/sink/Neo4jService.kt
@@ -18,8 +18,7 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import streams.service.StreamsSinkService
 import streams.service.TopicType
-import streams.service.sink.strategy.SchemaIngestionStrategy
-import streams.service.sink.strategy.SourceIdIngestionStrategy
+import streams.service.TopicTypeGroup
 import streams.utils.StreamsUtils
 import streams.utils.retryForException
 import java.util.concurrent.TimeUnit
@@ -74,23 +73,19 @@ class Neo4jService(private val config: Neo4jSinkConnectorConfig):
         driver.close()
     }
 
-    override fun getTopicType(topic: String): TopicType? {
-        val isCDCMerge = config.topics.cdcSourceIdTopics.contains(topic) ?: false
-        val isCDCSchema = config.topics.cdcSchemaTopics.contains(topic) ?: false
-        return if (isCDCMerge) {
-            TopicType.CDC_SOURCE_ID
-        } else if (isCDCSchema) {
-            TopicType.CDC_SCHEMA
-        } else if (config.topics.cypherTopics.containsKey(topic)) {
-            TopicType.CYPHER
-        } else {
-            null
-        }
-    }
+    override fun getTopicType(topic: String): TopicType? = TopicType.values()
+            .filter { topicType ->
+                when (topicType.group) {
+                    TopicTypeGroup.CDC -> (config.topics.cdcSourceIdTopics.contains(topic))
+                            || (config.topics.cdcSchemaTopics.contains(topic))
+                    TopicTypeGroup.CYPHER -> config.topics.cypherTopics.containsKey(topic)
+                    TopicTypeGroup.PATTERN -> (topicType == TopicType.PATTERN_NODE && config.topics.nodePatternTopics.containsKey(topic))
+                            || (topicType == TopicType.PATTERN_RELATIONSHIP && config.topics.relPatternTopics.containsKey(topic))
+                }
+            }
+            .firstOrNull()
 
-    override fun getCypherTemplate(topic: String): String? {
-        return "${StreamsUtils.UNWIND} ${config.topics.cypherTopics[topic]}"
-    }
+    override fun getCypherTemplate(topic: String): String? = "${StreamsUtils.UNWIND} ${config.topics.cypherTopics[topic]}"
 
     override fun write(query: String, events: Collection<Any>) {
         val session = driver.session()

--- a/kafka-connect-neo4j/src/main/kotlin/streams/kafka/connect/sink/Neo4jSinkConnectorConfig.kt
+++ b/kafka-connect-neo4j/src/main/kotlin/streams/kafka/connect/sink/Neo4jSinkConnectorConfig.kt
@@ -15,8 +15,8 @@ import org.neo4j.driver.v1.Config
 import streams.kafka.connect.utils.PropertiesUtil
 import streams.service.TopicType
 import streams.service.TopicUtils
-import streams.service.sink.strategy.SourceIdIngestionStrategyConfig
 import streams.service.Topics
+import streams.service.sink.strategy.SourceIdIngestionStrategyConfig
 import java.io.File
 import java.net.URI
 import java.util.concurrent.TimeUnit
@@ -115,10 +115,9 @@ class Neo4jSinkConnectorConfig(originals: Map<*, *>): AbstractConfig(config(), o
         }
         val allTopics = this.topics.allTopics()
         if (topics != allTopics) {
-            throw ConfigException("There is a mismatch between provided Cypher queries + CDC topics ($allTopics) and configured topics ($topics)")
+            throw ConfigException("There is a mismatch between topics defined into the property `${SinkTask.TOPICS_CONFIG}` and configured topics ($topics)")
         }
     }
-
 
     companion object {
         const val SERVER_URI = "neo4j.server.uri"
@@ -149,6 +148,8 @@ class Neo4jSinkConnectorConfig(originals: Map<*, *>): AbstractConfig(config(), o
         const val TOPIC_CDC_SOURCE_ID = "neo4j.topic.cdc.sourceId"
         const val TOPIC_CDC_SOURCE_ID_LABEL_NAME = "neo4j.topic.cdc.sourceId.labelName"
         const val TOPIC_CDC_SOURCE_ID_ID_NAME = "neo4j.topic.cdc.sourceId.idName"
+        const val TOPIC_PATTERN_NODE_PREFIX = "neo4j.topic.pattern.node."
+        const val TOPIC_PATTERN_RELATIONSHIP_PREFIX = "neo4j.topic.pattern.relationship."
         const val TOPIC_CDC_SCHEMA = "neo4j.topic.cdc.schema"
 
         const val CONNECTION_POOL_MAX_SIZE_DEFAULT = 100

--- a/kafka-connect-neo4j/src/test/kotlin/streams/kafka/connect/sink/Neo4jSinkConnectorConfigTest.kt
+++ b/kafka-connect-neo4j/src/test/kotlin/streams/kafka/connect/sink/Neo4jSinkConnectorConfigTest.kt
@@ -15,10 +15,10 @@ class Neo4jSinkConnectorConfigTest {
    fun `should throw a ConfigException because of mismatch`() {
        try {
            val originals = mapOf(SinkConnector.TOPICS_CONFIG to "foo, bar",
-                   "${Neo4jSinkConnectorConfig.TOPIC_CYPHER_PREFIX}foo" to "CREATE (p:Person{name: event.firsName})")
+                   "${Neo4jSinkConnectorConfig.TOPIC_CYPHER_PREFIX}foo" to "CREATE (p:Person{name: event.firstName})")
            Neo4jSinkConnectorConfig(originals)
        } catch (e: ConfigException) {
-           assertEquals("There is a mismatch between provided Cypher queries + CDC topics ([foo]) and configured topics ([foo, bar])", e.message)
+           assertEquals("There is a mismatch between topics defined into the property `topics` and configured topics ([foo, bar])", e.message)
            throw e
        }
    }
@@ -27,12 +27,12 @@ class Neo4jSinkConnectorConfigTest {
     fun `should throw a ConfigException because of cross defined topics`() {
         try {
             val originals = mapOf(SinkConnector.TOPICS_CONFIG to "foo, bar",
-                    "${Neo4jSinkConnectorConfig.TOPIC_CYPHER_PREFIX}foo" to "CREATE (p:Person{name: event.firsName})",
-                    "${Neo4jSinkConnectorConfig.TOPIC_CYPHER_PREFIX}bar" to "CREATE (p:Person{name: event.firsName})",
-                    "${Neo4jSinkConnectorConfig.TOPIC_CDC_SOURCE_ID}" to "foo")
+                    "${Neo4jSinkConnectorConfig.TOPIC_CYPHER_PREFIX}foo" to "CREATE (p:Person{name: event.firstName})",
+                    "${Neo4jSinkConnectorConfig.TOPIC_CYPHER_PREFIX}bar" to "CREATE (p:Person{name: event.firstName})",
+                    Neo4jSinkConnectorConfig.TOPIC_CDC_SOURCE_ID to "foo")
             Neo4jSinkConnectorConfig(originals)
         } catch (e: ConfigException) {
-            assertEquals("The following topics are cross defined between Cypher template configuration and CDC configuration: [foo]", e.message)
+            assertEquals("The following topics are cross defined: [foo]", e.message)
             throw e
         }
     }
@@ -40,7 +40,7 @@ class Neo4jSinkConnectorConfigTest {
     @Test
     fun `should return the configuration`() {
         val originals = mapOf(SinkConnector.TOPICS_CONFIG to "foo",
-                "${Neo4jSinkConnectorConfig.TOPIC_CYPHER_PREFIX}foo" to "CREATE (p:Person{name: event.firsName})",
+                "${Neo4jSinkConnectorConfig.TOPIC_CYPHER_PREFIX}foo" to "CREATE (p:Person{name: event.firstName})",
                 Neo4jSinkConnectorConfig.SERVER_URI to "bolt://neo4j:7687",
                 Neo4jSinkConnectorConfig.BATCH_SIZE to 10,
                 Neo4jSinkConnectorConfig.AUTHENTICATION_BASIC_USERNAME to "FOO",

--- a/kafka-connect-neo4j/src/test/kotlin/streams/kafka/connect/sink/Neo4jSinkTaskTest.kt
+++ b/kafka-connect-neo4j/src/test/kotlin/streams/kafka/connect/sink/Neo4jSinkTaskTest.kt
@@ -10,7 +10,6 @@ import org.apache.kafka.connect.sink.SinkTaskContext
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
-import org.mockito.Mockito
 import org.mockito.Mockito.mock
 import org.neo4j.graphdb.Label
 import org.neo4j.graphdb.Node
@@ -142,7 +141,7 @@ class Neo4jSinkTaskTest {
                 .put("modified", Date(1474661402123L))
 
         val task = Neo4jSinkTask()
-        task.initialize(Mockito.mock(SinkTaskContext::class.java))
+        task.initialize(mock(SinkTaskContext::class.java))
         task.start(props)
         val input = listOf(SinkRecord(firstTopic, 1, null, null, PERSON_SCHEMA, struct, 42),
                 SinkRecord(firstTopic, 1, null, null, PERSON_SCHEMA, struct, 42),
@@ -214,7 +213,7 @@ class Neo4jSinkTaskTest {
         )
 
         val task = Neo4jSinkTask()
-        task.initialize(Mockito.mock(SinkTaskContext::class.java))
+        task.initialize(mock(SinkTaskContext::class.java))
         task.start(props)
         val input = listOf(SinkRecord(firstTopic, 1, null, null, null, cdcDataStart, 42),
                 SinkRecord(firstTopic, 1, null, null, null, cdcDataEnd, 43),
@@ -286,7 +285,7 @@ class Neo4jSinkTaskTest {
         )
 
         val task = Neo4jSinkTask()
-        task.initialize(Mockito.mock(SinkTaskContext::class.java))
+        task.initialize(mock(SinkTaskContext::class.java))
         task.start(props)
         val input = listOf(SinkRecord(firstTopic, 1, null, null, null, cdcDataStart, 42),
                 SinkRecord(firstTopic, 1, null, null, null, cdcDataRelationship, 43))
@@ -338,7 +337,7 @@ class Neo4jSinkTaskTest {
             schema = Schema()
         )
         val task = Neo4jSinkTask()
-        task.initialize(Mockito.mock(SinkTaskContext::class.java))
+        task.initialize(mock(SinkTaskContext::class.java))
         task.start(props)
         val input = listOf(SinkRecord(firstTopic, 1, null, null, null, cdcDataStart, 42))
         task.put(input)
@@ -371,7 +370,7 @@ class Neo4jSinkTaskTest {
                 .put("longitude", -122.3255254.toFloat())
 
         val task = Neo4jSinkTask()
-        task.initialize(Mockito.mock(SinkTaskContext::class.java))
+        task.initialize(mock(SinkTaskContext::class.java))
         task.start(props)
         task.put(listOf(SinkRecord(topic, 1, null, null, PERSON_SCHEMA, struct, 42)))
         db.graph().beginTx().use {
@@ -379,4 +378,64 @@ class Neo4jSinkTaskTest {
             assertTrue { node == null }
         }
     }
+
+    @Test
+    fun `should work with node pattern topic`() {
+        val topic = "neotopic"
+        val props = mutableMapOf<String, String>()
+        props[Neo4jSinkConnectorConfig.SERVER_URI] = db.boltURI().toString()
+        props["${Neo4jSinkConnectorConfig.TOPIC_PATTERN_NODE_PREFIX}$topic"] = "User{!userId,name,surname,address.city}"
+        props[Neo4jSinkConnectorConfig.AUTHENTICATION_TYPE] = AuthenticationType.NONE.toString()
+        props[SinkTask.TOPICS_CONFIG] = topic
+
+        val data = mapOf("userId" to 1, "name" to "Andrea", "surname" to "Santurbano",
+                "address" to mapOf("city" to "Venice", "CAP" to "30100"))
+
+        val task = Neo4jSinkTask()
+        task.initialize(mock(SinkTaskContext::class.java))
+        task.start(props)
+        val input = listOf(SinkRecord(topic, 1, null, null, null, data, 42))
+        task.put(input)
+        db.graph().beginTx().use {
+            db.graph().execute("MATCH (n:User{name: 'Andrea', surname: 'Santurbano', userId: 1, `address.city`: 'Venice'}) RETURN count(n) AS count")
+                    .columnAs<Long>("count").use {
+                        assertTrue { it.hasNext() }
+                        val count = it.next()
+                        assertEquals(1, count)
+                        assertFalse { it.hasNext() }
+                    }
+        }
+    }
+
+    @Test
+    fun `should work with relationship pattern topic`() {
+        val topic = "neotopic"
+        val props = mutableMapOf<String, String>()
+        props[Neo4jSinkConnectorConfig.SERVER_URI] = db.boltURI().toString()
+        props["${Neo4jSinkConnectorConfig.TOPIC_PATTERN_RELATIONSHIP_PREFIX}$topic"] = "(:User{!sourceId,sourceName,sourceSurname})-[:KNOWS]->(:User{!targetId,targetName,targetSurname})"
+        props[Neo4jSinkConnectorConfig.AUTHENTICATION_TYPE] = AuthenticationType.NONE.toString()
+        props[SinkTask.TOPICS_CONFIG] = topic
+
+        val data = mapOf("sourceId" to 1, "sourceName" to "Andrea", "sourceSurname" to "Santurbano",
+                "targetId" to 1, "targetName" to "Michael", "targetSurname" to "Hunger", "since" to 2014)
+
+        val task = Neo4jSinkTask()
+        task.initialize(mock(SinkTaskContext::class.java))
+        task.start(props)
+        val input = listOf(SinkRecord(topic, 1, null, null, null, data, 42))
+        task.put(input)
+        db.graph().beginTx().use {
+            db.graph().execute("""
+                MATCH p = (s:User{sourceName: 'Andrea', sourceSurname: 'Santurbano', sourceId: 1})-[:KNOWS{since: 2014}]->(e:User{targetName: 'Michael', targetSurname: 'Hunger', targetId: 1})
+                RETURN count(p) AS count
+            """.trimIndent())
+                    .columnAs<Long>("count").use {
+                        assertTrue { it.hasNext() }
+                        val count = it.next()
+                        assertEquals(1, count)
+                        assertFalse { it.hasNext() }
+                    }
+        }
+    }
+
 }


### PR DESCRIPTION
Fixes #154 

Added the new `Pattern` strategy

```
streams.sink.topic.pattern.node.<TOPIC_NAME>=<NODE_EXTRACTION_PATTERN>
streams.sink.topic.pattern.relationship.<TOPIC_NAME>=<RELATIONSHIP_EXTRACTION_PATTERN>
```

Example:

```
streams.sink.topic.pattern.node.user=User{!userId}
streams.sink.topic.pattern.relationship.bought=(User{!userId})-[:BOUGHT{price, currency}]->(Product{!productId})
```

More details about how it works in the documentation.

## Proposed Changes (Mandatory)

A brief list of proposed changes in order to fix the issue:
  - Created the pattern parser
  - Created the new strategy
  - updated the documentation
