### PR TITLE
 fixes #102: Manual commit behavior for handling errors and retrievals

### DIFF
--- a/common/src/main/kotlin/streams/utils/JSONUtils.kt
+++ b/common/src/main/kotlin/streams/utils/JSONUtils.kt
@@ -2,10 +2,7 @@ package streams.serialization
 
 import com.fasterxml.jackson.core.JsonGenerator
 import com.fasterxml.jackson.core.JsonProcessingException
-import com.fasterxml.jackson.databind.JsonSerializer
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.databind.SerializationFeature
-import com.fasterxml.jackson.databind.SerializerProvider
+import com.fasterxml.jackson.databind.*
 import com.fasterxml.jackson.databind.module.SimpleModule
 import com.fasterxml.jackson.module.kotlin.convertValue
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
@@ -91,6 +88,7 @@ object JSONUtils {
         module.addSerializer(TemporalAccessor::class.java, TemporalAccessorSerializer())
         OBJECT_MAPPER.registerModule(module)
         OBJECT_MAPPER.disable(SerializationFeature.FAIL_ON_EMPTY_BEANS)
+        OBJECT_MAPPER.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
     }
 
     fun getObjectMapper(): ObjectMapper {

--- a/consumer/src/main/kotlin/streams/StreamsEventSink.kt
+++ b/consumer/src/main/kotlin/streams/StreamsEventSink.kt
@@ -18,20 +18,20 @@ abstract class StreamsEventSink(private val config: Config,
 
 }
 
-abstract class StreamsEventConsumer<T>(private val consumer: T, config: StreamsSinkConfiguration, private val log: Log) {
+abstract class StreamsEventConsumer(private val log: Log) {
 
     abstract fun stop()
 
-    abstract fun withTopics(topics: Set<String>): StreamsEventConsumer<T>
+    abstract fun withTopics(topics: Set<String>): StreamsEventConsumer
 
     abstract fun start()
 
-    abstract fun read(): Map<String, List<Any>>?
+    abstract fun read(topicConfig: Map<String, Any> = emptyMap(), action: (String, List<Any>) -> Unit)
 
 }
 
 abstract class StreamsEventConsumerFactory {
-    abstract fun createStreamsEventConsumer(config: Map<String, String>, log: Log): StreamsEventConsumer<*>
+    abstract fun createStreamsEventConsumer(config: Map<String, String>, log: Log): StreamsEventConsumer
 }
 
 object StreamsEventSinkFactory {

--- a/consumer/src/main/kotlin/streams/procedures/StreamsSinkProcedures.kt
+++ b/consumer/src/main/kotlin/streams/procedures/StreamsSinkProcedures.kt
@@ -2,6 +2,7 @@ package streams.procedures
 
 import org.neo4j.logging.Log
 import org.neo4j.procedure.*
+import streams.StreamsEventConsumer
 import streams.StreamsEventConsumerFactory
 import streams.StreamsEventSinkConfigMapper
 import streams.StreamsSinkConfiguration
@@ -15,7 +16,8 @@ class StreamsSinkProcedures {
     var log: Log? = null
 
     @Procedure(mode = Mode.SCHEMA, name = "streams.consume")
-    @Description("streams.consume(topic, {timeout: <long value>, from: <string>}) YIELD event - Allows to consume custom topics")
+    @Description("streams.consume(topic, {timeout: <long value>, from: <string>, groupId: <string>, commit: <boolean>, partitions:[{partition: <number>, offset: <number>}]}) " +
+            "YIELD event - Allows to consume custom topics")
     fun consume(@Name("topic") topic: String?,
                 @Name(value = "config", defaultValue = "{}") config: Map<String, Any>?): Stream<StreamResult> {
         checkEnabled()
@@ -27,25 +29,40 @@ class StreamsSinkProcedures {
         val properties = config?.mapValues { it.value.toString() } ?: emptyMap()
         val configuration = StreamsSinkProcedures.streamsEventSinkConfigMapper.convert(config = properties)
 
-        val consumer = StreamsSinkProcedures
-                .streamsEventConsumerFactory
-                .createStreamsEventConsumer(configuration, log!!)
-                .withTopics(setOf(topic))
+        val data = readData(topic, config ?: emptyMap(), configuration)
+
+        return data.map { StreamResult(mapOf("data" to it)) }.stream()
+    }
+
+    private fun readData(topic: String, procedureConfig: Map<String, Any>, consumerConfig: Map<String, String>): List<Any> {
+        val cfg = procedureConfig.mapValues { if (it.key != "partitions") it.value else mapOf(topic to it.value) }
+        val timeout = cfg.getOrDefault("timeout", 1000).toString().toLong()
+        val consumer = createConsumer(consumerConfig, topic)
         consumer.start()
-        val data = try {
-            consumer.read()
+        val data = mutableListOf<Any>()
+        try {
+            val start = System.currentTimeMillis()
+            while ((System.currentTimeMillis() - start) < timeout) {
+                consumer.read(cfg) { _, topicData ->
+                    data.addAll(topicData)
+                }
+            }
         } catch (e: Exception) {
             if (log?.isDebugEnabled!!) {
                 log?.error("Error while consuming data", e)
             }
-            emptyMap<String, List<Any>>()
+        }
+        if (log?.isDebugEnabled!!) {
+            log?.debug("Data retrieved from topic $topic after $timeout milliseconds: $data")
         }
         consumer.stop()
+        return data
+    }
 
-        if (log?.isDebugEnabled!!) {
-            log?.debug("Data retrieved from topic $topic after ${configuration["streams.sink.polling.interval"]} milliseconds: $data")
-        }
-        return data?.values?.flatMap { list -> list.map { StreamResult(mapOf("data" to it)) } }?.stream() ?: Stream.empty()
+    private fun createConsumer(consumerConfig: Map<String, String>, topic: String): StreamsEventConsumer {
+        return streamsEventConsumerFactory
+                .createStreamsEventConsumer(consumerConfig, log!!)
+                .withTopics(setOf(topic))
     }
 
     private fun checkEnabled() {

--- a/doc/asciidoc/consumer/configuration.adoc
+++ b/doc/asciidoc/consumer/configuration.adoc
@@ -6,8 +6,8 @@ kafka.zookeeper.connect=localhost:2181
 kafka.bootstrap.servers=localhost:9092
 kafka.auto.offset.reset=earliest
 kafka.group.id=neo4j
+kafka.enable.auto.commit=true
 
-streams.sink.polling.interval=<The time, in milliseconds, spent waiting in poll if data is not available in the buffer. default=Long.MAX_VALUE>
 streams.sink.topic.cypher.<TOPIC_NAME>=<CYPHER_QUERY>
 streams.sink.topic.cdc.sourceId=<LIST_OF_TOPICS_SEPARATE_BY_SEMICOLON>
 streams.sink.topic.cdc.schema=<LIST_OF_TOPICS_SEPARATE_BY_SEMICOLON>

--- a/doc/asciidoc/procedures/index.adoc
+++ b/doc/asciidoc/procedures/index.adoc
@@ -69,10 +69,19 @@ Uses:
 Example:
 Imagine you have a producer that publish events like this `{"name": "Andrea", "surname": "Santurbano"}`, we can create user nodes in this way:
 
-```
-CALL streams.consume('my-topic', {<config>}) YIELD event
+[source,cypher]
+----
+CALL streams.consume('my-topic') YIELD event
 CREATE (p:Person{firstName: event.data.name, lastName: event.data.surname})
-```
+----
+
+In case you want to read a specific offset of a topic partition you can do it by executing the following query:
+
+[source,cypher]
+----
+CALL streams.consume('my-topic', {timeout: 5000, partitions: [{partition: 0, offset: 30}]}) YIELD event
+CREATE (p:Person{firstName: event.data.name, lastName: event.data.surname})
+----
 
 Input Parameters:
 
@@ -87,7 +96,7 @@ Input Parameters:
 |The topic where you want to publish the data
 
 |`config`
-|Object
+|Map<K,V>
 |The configuration parameters
 
 |===
@@ -101,11 +110,59 @@ Input Parameters:
 |Description
 
 |`timeout`
-|Long
-|It's the value passed to Kafka https://kafka.apache.org/10/javadoc/org/apache/kafka/clients/consumer/KafkaConsumer.html#poll-long-[`Consumer#poll`] method (milliseconds). Default 1000
+|Number (default `1000`)
+|Define the time that the procedure should be listen the topic
 
 |`from`
 |String
-|It's the Kafka configuration parameter `auto.offset.reset`
+|It's the Kafka configuration parameter `auto.offset.reset`.
+If not specified it inherits the underlying `kafka.auto.offset.reset` value
+
+|`groupId`
+|String
+|It's the Kafka configuration parameter `group.id`.
+If not specified it inherits the underlying `kafka.group.id` value
+
+|`autoCommit`
+|Boolean (default `true`)
+|It's the Kafka configuration parameter `enable.auto.commit`.
+If not specified it inherits the underlying `kafka.enable.auto.commit` value
+
+|`commit`
+|Boolean (default `true`)
+|In case of `autoCommit` is set to `false` you can decide if you want to commit the data.
+
+|`zookeeper`
+|String
+|The comma separated string of Zookeeper nodes url.
+If not specified it inherits the underlying `kafka.zookeeper.connect` value
+
+|`broker`
+|String
+|The comma separated string of Kafka nodes url.
+If not specified it inherits the underlying `kafka.bootstrap.servers` value
+
+|`partitions`
+|List<Map<K,V>>
+|The map contains the information about partition and offset in order to start reading from a
 
 |===
+
+===== Partitions
+
+[cols="3*",options="header"]
+|===
+|Variable Name
+|Type
+|Description
+
+|`partition`
+|Number
+|It's the Kafka partition number to read
+
+|`offset`
+|Number
+|It's the offset to start to read the topic partition
+
+|===
+

--- a/doc/asciidoc/producer/index.adoc
+++ b/doc/asciidoc/producer/index.adoc
@@ -233,7 +233,7 @@ We must distinguish two cases:
 |List of properties attached to the entity, where the `K` is the property name and the `V` is the class type
 |===
 
-====== Constraints
+===== Constraints
 
 Nodes and Relationships can have a list of constraints attached to them:
 


### PR DESCRIPTION
Fixes #102 

Added Manual commit behaviour for handling errors and retrievals.
In case the property `kafka.enable.auto.commit` is set to false the consumer will be configured in order to manually commit the offsets.

## Proposed Changes (Mandatory)

A brief list of proposed changes in order to fix the issue:

  - Added new class `KafkaManualCommitEventConsumer` that manually commits the consumers
  - Added a new method in `StreamsEventConsumer`: `abstract fun read(topicConfig: Map<String, Any> = emptyMap(), action: (String, List<Any>) -> Unit)` that allow to pass a config map about reading a specific partition and starting offset and providing decision if commit or not the reading
  - added new configuraration parameters into the `streams.consume` procedure that allow more finegraded control over kafka connection