### PR TITLE
Issue 195: High CPU usage when kafka even sink is enabled

### DIFF
--- a/common/src/main/kotlin/streams/utils/Neo4jUtils.kt
+++ b/common/src/main/kotlin/streams/utils/Neo4jUtils.kt
@@ -41,12 +41,10 @@ object Neo4jUtils {
                 .resolveDependency(LogService::class.java)
     }
 
-    fun isEnterpriseEdition(db: GraphDatabaseAPI): Boolean {
+    fun isCluster(db: GraphDatabaseAPI): Boolean {
         try {
-            return db.execute("""
-                CALL dbms.components() YIELD edition
-                RETURN edition = "enterprise" AS isEnterprise
-            """.trimIndent()).columnAs<Boolean>("isEnterprise").next()
+            db.execute("CALL dbms.cluster.role()").columnAs<String>("role").next()
+            return true
         } catch (e: QueryExecutionException) {
             if (e.statusCode.equals("Neo.ClientError.Procedure.ProcedureNotFound", ignoreCase = true)) {
                 return false

--- a/common/src/test/kotlin/streams/utils/Neo4jUtilsTest.kt
+++ b/common/src/test/kotlin/streams/utils/Neo4jUtilsTest.kt
@@ -1,7 +1,6 @@
 package streams.utils
 
 import org.junit.*
-import org.neo4j.kernel.impl.logging.LogService
 import org.neo4j.kernel.internal.GraphDatabaseAPI
 import org.neo4j.test.TestGraphDatabaseFactory
 import kotlin.test.assertFalse
@@ -33,8 +32,8 @@ class Neo4jUtilsTest {
     }
 
     @Test
-    fun shouldCheckIfIsEnterpriseEdition() {
-        val isEnterprise = Neo4jUtils.isEnterpriseEdition(db)
+    fun shouldCheckIfIsACluster() {
+        val isEnterprise = Neo4jUtils.isCluster(db)
         assertFalse { isEnterprise }
     }
 

--- a/consumer/src/main/kotlin/streams/StreamsEventSink.kt
+++ b/consumer/src/main/kotlin/streams/StreamsEventSink.kt
@@ -30,6 +30,8 @@ abstract class StreamsEventConsumer(private val log: Log) {
 
     abstract fun read(topicConfig: Map<String, Any> = emptyMap(), action: (String, List<Any>) -> Unit)
 
+    abstract fun read(action: (String, List<Any>) -> Unit)
+
 }
 
 abstract class StreamsEventConsumerFactory {

--- a/consumer/src/main/kotlin/streams/StreamsEventSinkExtensionFactory.kt
+++ b/consumer/src/main/kotlin/streams/StreamsEventSinkExtensionFactory.kt
@@ -76,7 +76,6 @@ class StreamsEventSinkExtensionFactory : KernelExtensionFactory<StreamsEventSink
 
                 })
             } catch (e: Exception) {
-                e.printStackTrace()
                 streamsLog.error("Error initializing the streaming sink", e)
             }
         }

--- a/consumer/src/main/kotlin/streams/StreamsEventSinkExtensionFactory.kt
+++ b/consumer/src/main/kotlin/streams/StreamsEventSinkExtensionFactory.kt
@@ -60,8 +60,8 @@ class StreamsEventSinkExtensionFactory : KernelExtensionFactory<StreamsEventSink
                                         log,
                                         db)
                         // start the Sink
-                        if (Neo4jUtils.isEnterpriseEdition(db)) {
-                            log.info("The Sink module is running in an enterprise edition, checking for the ${Neo4jUtils.LEADER}")
+                        if (Neo4jUtils.isCluster(db)) {
+                            log.info("The Sink module is running in a cluster, checking for the ${Neo4jUtils.LEADER}")
                             Neo4jUtils.executeInLeader(db, log) { initSinkModule() }
                         } else {
                             // check if is writeable instance


### PR DESCRIPTION
Fixes #195

Fixed the bug after profiling it with VisualVM

## Proposed Changes (Mandatory)

A brief list of proposed changes in order to fix the issue:

- added a new method `abstract fun read(action: (String, List<Any>) -> Unit)` used by the daemon job, I realized in the profiling that with the other method a lot of time was spent in two activities:
  - convert the config to `KafkaTopicConfig` with the default values
  - the `consumer.poll(0)` which seems to be an high-CPU-consuming operation 