### PR TITLE
fixes #199: Refactor the KafkaConsumer record Management

### DIFF
--- a/common/src/main/kotlin/streams/extensions/CommonExtensions.kt
+++ b/common/src/main/kotlin/streams/extensions/CommonExtensions.kt
@@ -1,5 +1,8 @@
 package streams.extensions
 
+import org.apache.kafka.clients.consumer.ConsumerRecord
+import org.apache.kafka.clients.consumer.OffsetAndMetadata
+import org.apache.kafka.common.TopicPartition
 import org.neo4j.graphdb.Node
 import javax.lang.model.SourceVersion
 
@@ -27,3 +30,5 @@ fun Map<String, Any?>.flatten(map: Map<String, Any?> = this, prefix: String = ""
         }
     }.toMap()
 }
+fun <K, V> ConsumerRecord<K, V>.topicPartition() = TopicPartition(this.topic(), this.partition())
+fun <K, V> ConsumerRecord<K, V>.offsetAndMetadata(metadata: String = "") = OffsetAndMetadata(this.offset() + 1, metadata)

--- a/common/src/main/kotlin/streams/utils/Neo4jUtils.kt
+++ b/common/src/main/kotlin/streams/utils/Neo4jUtils.kt
@@ -89,4 +89,16 @@ object Neo4jUtils {
         }
     }
 
+    fun waitForTheLeader(db: GraphDatabaseAPI, log: Log, timeout: Long = 120000, action: () -> Unit) {
+        GlobalScope.launch(Dispatchers.IO) {
+            val start = System.currentTimeMillis()
+            val delay: Long = 2000
+            while (!clusterHasLeader(db) && System.currentTimeMillis() - start < timeout) {
+                log.info("$LEADER not found, new check comes in $delay milliseconds...")
+                delay(delay)
+            }
+            action()
+        }
+    }
+
 }

--- a/consumer/src/main/kotlin/streams/StreamsEventSinkExtensionFactory.kt
+++ b/consumer/src/main/kotlin/streams/StreamsEventSinkExtensionFactory.kt
@@ -45,8 +45,6 @@ class StreamsEventSinkExtensionFactory : KernelExtensionFactory<StreamsEventSink
                         streamsLog.info("Initialising the Streams Sink module")
                         val streamsSinkConfiguration = StreamsSinkConfiguration.from(configuration)
                         val streamsTopicService = StreamsTopicService(db)
-                        streamsTopicService.clearAll()
-                        streamsTopicService.setAll(streamsSinkConfiguration.topics)
                         val strategyMap = TopicUtils.toStrategyMap(streamsSinkConfiguration.topics,
                                 streamsSinkConfiguration.sourceIdStrategyConfig)
                         val streamsQueryExecution = StreamsEventSinkQueryExecution(streamsTopicService, db,
@@ -64,10 +62,10 @@ class StreamsEventSinkExtensionFactory : KernelExtensionFactory<StreamsEventSink
                         // start the Sink
                         if (Neo4jUtils.isCluster(db)) {
                             log.info("The Sink module is running in a cluster, checking for the ${Neo4jUtils.LEADER}")
-                            Neo4jUtils.executeInLeader(db, log) { initSinkModule() }
+                            Neo4jUtils.waitForTheLeader(db, log) { initSinkModule(streamsTopicService, streamsSinkConfiguration) }
                         } else {
                             // check if is writeable instance
-                            Neo4jUtils.executeInWriteableInstance(db) { initSinkModule() }
+                            Neo4jUtils.executeInWriteableInstance(db) { initSinkModule(streamsTopicService, streamsSinkConfiguration) }
                         }
 
                         // Register required services for the Procedures
@@ -82,7 +80,9 @@ class StreamsEventSinkExtensionFactory : KernelExtensionFactory<StreamsEventSink
             }
         }
 
-        private fun initSinkModule() {
+        private fun initSinkModule(streamsTopicService: StreamsTopicService, streamsSinkConfiguration: StreamsSinkConfiguration) {
+            streamsTopicService.clearAll()
+            streamsTopicService.setAll(streamsSinkConfiguration.topics)
             eventSink.start()
             streamsLog.info("Streams Sink module initialised")
         }

--- a/consumer/src/main/kotlin/streams/StreamsEventSinkQueryExecution.kt
+++ b/consumer/src/main/kotlin/streams/StreamsEventSinkQueryExecution.kt
@@ -24,15 +24,11 @@ class StreamsEventSinkQueryExecution(private val streamsTopicService: StreamsTop
 
     override fun write(query: String, params: Collection<Any>) {
         if (Neo4jUtils.isWriteableInstance(db)) {
-            try {
-                val result = db.execute(query, mapOf("events" to params))
-                if (log.isDebugEnabled) {
-                    log.debug("Query statistics:\n${result.queryStatistics}")
-                }
-                result.close()
-            } catch (e: Exception) {
-                log.error("Error while executing the query", e)
+            val result = db.execute(query, mapOf("events" to params))
+            if (log.isDebugEnabled) {
+                log.debug("Query statistics:\n${result.queryStatistics}")
             }
+            result.close()
         } else {
             if (log.isDebugEnabled) {
                 log.debug("Not writeable instance")


### PR DESCRIPTION
Fixes #199 

Simplified the KafkaConsumer code in order to prepare it for the #177 

## Proposed Changes (Mandatory)

A brief list of proposed changes in order to fix the issue:
  - simplified the code in order to prepare it for the #177 by adding two points for the `Dead Letter Queue`:
    - when we convert the record
    - when we interact with the DB
  - removed the StreamsConsumerRebalanceListener, because if we use the commitSync method Kafka manages automatically the rebalancing, so we can delegate. We can resume it in case we want to store, for instance, the committed offset instead of Kafka into Neo4j (as a optional feature)
