### PR TITLE
 fixes #177: Create a Dead Letter Queue

### DIFF
--- a/common/src/main/kotlin/streams/extensions/CommonExtensions.kt
+++ b/common/src/main/kotlin/streams/extensions/CommonExtensions.kt
@@ -1,5 +1,8 @@
 package streams.extensions
 
+import org.apache.kafka.clients.consumer.ConsumerRecord
+import org.apache.kafka.clients.consumer.OffsetAndMetadata
+import org.apache.kafka.common.TopicPartition
 import org.neo4j.graphdb.Node
 import javax.lang.model.SourceVersion
 
@@ -27,3 +30,5 @@ fun Map<String, Any?>.flatten(map: Map<String, Any?> = this, prefix: String = ""
         }
     }.toMap()
 }
+fun <K, V> ConsumerRecord<K, V>.topicPartition() = TopicPartition(this.topic(), this.partition())
+fun <K, V> ConsumerRecord<K, V>.offsetAndMetadata(metadata: String = "") = OffsetAndMetadata(this.offset() + 1, metadata)

--- a/common/src/main/kotlin/streams/service/dlq/DeadLetterQueueService.kt
+++ b/common/src/main/kotlin/streams/service/dlq/DeadLetterQueueService.kt
@@ -1,0 +1,43 @@
+package streams.service.dlq
+
+import org.apache.kafka.clients.consumer.ConsumerRecord
+
+
+data class DLQData(val originalTopic: String,
+                   val timestamp: Long,
+                   val key: ByteArray,
+                   val value: ByteArray,
+                   val partition: String,
+                   val offset: String,
+                   val executingClass: Class<*>?,
+                   val exception: Exception?) {
+
+    companion object {
+        fun from(consumerRecord: ConsumerRecord<String, ByteArray>, exception: Exception?, executingClass: Class<*>?): DLQData {
+            return DLQData(offset = consumerRecord.offset().toString(),
+                    originalTopic = consumerRecord.topic(),
+                    partition = consumerRecord.partition().toString(),
+                    timestamp = consumerRecord.timestamp(),
+                    exception = exception,
+                    executingClass = executingClass,
+                    key = consumerRecord.key().toByteArray(),
+                    value = consumerRecord.value())
+        }
+    }
+}
+
+abstract class DeadLetterQueueService(private val config: Map<String, Any>,
+                                             headerPrefix: String) {
+
+    val ERROR_HEADER_ORIG_TOPIC = headerPrefix + "topic"
+    val ERROR_HEADER_ORIG_PARTITION = headerPrefix + "partition"
+    val ERROR_HEADER_ORIG_OFFSET = headerPrefix + "offset"
+    val ERROR_HEADER_EXECUTING_CLASS = headerPrefix + "class.name"
+    val ERROR_HEADER_EXCEPTION = headerPrefix + "exception.class.name"
+    val ERROR_HEADER_EXCEPTION_MESSAGE = headerPrefix + "exception.message"
+    val ERROR_HEADER_EXCEPTION_STACK_TRACE = headerPrefix + "exception.stacktrace"
+
+    abstract fun send(deadLetterQueueTopic: String, dlqData: DLQData)
+
+    abstract fun close()
+}

--- a/common/src/main/kotlin/streams/service/dlq/KafkaDLQService.kt
+++ b/common/src/main/kotlin/streams/service/dlq/KafkaDLQService.kt
@@ -1,0 +1,67 @@
+package streams.service.dlq
+
+import org.apache.commons.lang3.exception.ExceptionUtils
+import org.apache.kafka.clients.producer.KafkaProducer
+import org.apache.kafka.clients.producer.Producer
+import org.apache.kafka.clients.producer.ProducerConfig
+import org.apache.kafka.clients.producer.ProducerRecord
+import org.apache.kafka.common.record.RecordBatch
+import org.apache.kafka.common.serialization.ByteArraySerializer
+import org.neo4j.util.VisibleForTesting
+import java.util.*
+
+class KafkaDLQService: DeadLetterQueueService {
+
+    private var producer: Producer<ByteArray, ByteArray>
+
+    constructor(config: Map<String, Any>,
+                headerPrefix: String): super(config, headerPrefix) { // "__connect.errors."
+        val props = Properties()
+        props.putAll(config)
+        props[ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG] = ByteArraySerializer::class.java.name
+        props[ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG] = ByteArraySerializer::class.java.name
+        producer = KafkaProducer(props)
+    }
+
+    @VisibleForTesting
+    constructor(producer: Producer<ByteArray, ByteArray>, headerPrefix: String = ""): super(emptyMap(), headerPrefix) {
+        this.producer = producer
+    }
+
+    override fun send(deadLetterQueueTopic: String, dlqData: DLQData) {
+        val producerRecord = if (dlqData.timestamp == RecordBatch.NO_TIMESTAMP) {
+            ProducerRecord(deadLetterQueueTopic, null,
+                    dlqData.key, dlqData.value)
+        } else {
+            ProducerRecord(deadLetterQueueTopic, null, dlqData.timestamp,
+                    dlqData.key, dlqData.value)
+        }
+        val producerHeader = producerRecord.headers()
+        populateContextHeaders(dlqData).forEach { key, value -> producerHeader.add(key, value) }
+        producer.send(producerRecord)
+    }
+
+    @VisibleForTesting
+    fun populateContextHeaders(dlqData: DLQData): Map<String, ByteArray> {
+        val headers = mutableMapOf<String, ByteArray>()
+        headers[ERROR_HEADER_ORIG_TOPIC] = dlqData.originalTopic.toByteArray()
+        headers[ERROR_HEADER_ORIG_PARTITION] = dlqData.partition.toByteArray()
+        headers[ERROR_HEADER_ORIG_OFFSET] = dlqData.offset.toByteArray()
+        if (dlqData.executingClass != null) {
+            headers[ERROR_HEADER_EXECUTING_CLASS] = dlqData.executingClass.name.toByteArray()
+        }
+        if (dlqData.exception != null) {
+            headers[ERROR_HEADER_EXCEPTION] = dlqData.exception.javaClass.name.toByteArray()
+            if (dlqData.exception.message != null) {
+                headers[ERROR_HEADER_EXCEPTION_MESSAGE] = dlqData.exception.message.toString().toByteArray()
+            }
+            headers[ERROR_HEADER_EXCEPTION_STACK_TRACE] = ExceptionUtils.getStackTrace(dlqData.exception).toByteArray()
+        }
+        return headers
+    }
+
+    override fun close() {
+        this.producer.close()
+    }
+
+}

--- a/common/src/main/kotlin/streams/utils/Neo4jUtils.kt
+++ b/common/src/main/kotlin/streams/utils/Neo4jUtils.kt
@@ -89,4 +89,16 @@ object Neo4jUtils {
         }
     }
 
+    fun waitForTheLeader(db: GraphDatabaseAPI, log: Log, timeout: Long = 120000, action: () -> Unit) {
+        GlobalScope.launch(Dispatchers.IO) {
+            val start = System.currentTimeMillis()
+            val delay: Long = 2000
+            while (!clusterHasLeader(db) && System.currentTimeMillis() - start < timeout) {
+                log.info("$LEADER not found, new check comes in $delay milliseconds...")
+                delay(delay)
+            }
+            action()
+        }
+    }
+
 }

--- a/common/src/test/kotlin/streams/service/sink/dlq/KafkaDLQServiceTest.kt
+++ b/common/src/test/kotlin/streams/service/sink/dlq/KafkaDLQServiceTest.kt
@@ -1,0 +1,78 @@
+package streams.service.sink.dlq
+
+import org.apache.commons.lang3.exception.ExceptionUtils
+import org.apache.kafka.clients.producer.MockProducer
+import org.apache.kafka.clients.producer.ProducerRecord
+import org.apache.kafka.clients.producer.internals.FutureRecordMetadata
+import org.apache.kafka.common.record.RecordBatch
+import org.junit.Test
+import org.mockito.ArgumentMatchers
+import org.mockito.Mockito
+import streams.service.dlq.DLQData
+import streams.service.dlq.KafkaDLQService
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.test.assertEquals
+
+class KafkaDLQServiceTest {
+    @Test
+    fun `should send the data to the DLQ`() {
+        val producer: MockProducer<ByteArray, ByteArray> = Mockito.mock(MockProducer::class.java) as MockProducer<ByteArray, ByteArray>
+        val counter = AtomicInteger(0)
+        Mockito.`when`(producer.send(ArgumentMatchers.any<ProducerRecord<ByteArray, ByteArray>>())).then {
+            counter.incrementAndGet()
+            FutureRecordMetadata(null, 0, RecordBatch.NO_TIMESTAMP, 0L, 0, 0)
+        }
+        val dlqService = KafkaDLQService(producer)
+        val offset = "0"
+        val originalTopic = "topicName"
+        val partition = "1"
+        val timestamp = System.currentTimeMillis()
+        val exception = RuntimeException("Test")
+        val key = "KEY"
+        val value = "VALUE"
+        val dlqData = DLQData(offset = offset,
+                originalTopic = originalTopic,
+                partition = partition,
+                timestamp = timestamp,
+                exception = exception,
+                executingClass = KafkaDLQServiceTest::class.java,
+                key = key.toByteArray(),
+                value = value.toByteArray())
+        dlqService.send("dlqTopic", dlqData)
+        assertEquals(1, counter.get())
+        dlqService.close()
+    }
+
+
+    @Test
+    fun `should create the header map`() {
+        val producer: MockProducer<ByteArray, ByteArray> = Mockito.mock(MockProducer::class.java) as MockProducer<ByteArray, ByteArray>
+        val dlqService = KafkaDLQService(producer)
+        val offset = "0"
+        val originalTopic = "topicName"
+        val partition = "1"
+        val timestamp = System.currentTimeMillis()
+        val exception = RuntimeException("Test")
+        val key = "KEY"
+        val value = "VALUE"
+        val dlqData = DLQData(
+                offset = offset,
+                originalTopic = originalTopic,
+                partition = partition,
+                timestamp = timestamp,
+                exception = exception,
+                executingClass = KafkaDLQServiceTest::class.java,
+                key = key.toByteArray(),
+                value = value.toByteArray()
+        )
+        val map = dlqService.populateContextHeaders(dlqData)
+        assertEquals(String(map["topic"]!!), originalTopic)
+        assertEquals(String(map["partition"]!!), partition)
+        assertEquals(String(map["offset"]!!), offset)
+        assertEquals(String(map["class.name"]!!), KafkaDLQServiceTest::class.java.name)
+        assertEquals(String(map["exception.class.name"]!!), exception::class.java.name)
+        assertEquals(String(map["exception.message"]!!), exception.message)
+        assertEquals(String(map["exception.stacktrace"]!!), ExceptionUtils.getStackTrace(exception))
+
+    }
+}

--- a/consumer/src/main/kotlin/streams/StreamsEventSink.kt
+++ b/consumer/src/main/kotlin/streams/StreamsEventSink.kt
@@ -3,6 +3,7 @@ package streams
 import org.neo4j.kernel.configuration.Config
 import org.neo4j.kernel.internal.GraphDatabaseAPI
 import org.neo4j.logging.Log
+import streams.service.dlq.DeadLetterQueueService
 
 abstract class StreamsEventSink(private val config: Config,
                                 private val queryExecution: StreamsEventSinkQueryExecution,
@@ -20,7 +21,7 @@ abstract class StreamsEventSink(private val config: Config,
 
 }
 
-abstract class StreamsEventConsumer(private val log: Log) {
+abstract class StreamsEventConsumer(private val log: Log, private val dlqService: DeadLetterQueueService?) {
 
     abstract fun stop()
 

--- a/consumer/src/main/kotlin/streams/StreamsEventSinkExtensionFactory.kt
+++ b/consumer/src/main/kotlin/streams/StreamsEventSinkExtensionFactory.kt
@@ -45,8 +45,6 @@ class StreamsEventSinkExtensionFactory : KernelExtensionFactory<StreamsEventSink
                         streamsLog.info("Initialising the Streams Sink module")
                         val streamsSinkConfiguration = StreamsSinkConfiguration.from(configuration)
                         val streamsTopicService = StreamsTopicService(db)
-                        streamsTopicService.clearAll()
-                        streamsTopicService.setAll(streamsSinkConfiguration.topics)
                         val strategyMap = TopicUtils.toStrategyMap(streamsSinkConfiguration.topics,
                                 streamsSinkConfiguration.sourceIdStrategyConfig)
                         val streamsQueryExecution = StreamsEventSinkQueryExecution(streamsTopicService, db,
@@ -64,10 +62,10 @@ class StreamsEventSinkExtensionFactory : KernelExtensionFactory<StreamsEventSink
                         // start the Sink
                         if (Neo4jUtils.isCluster(db)) {
                             log.info("The Sink module is running in a cluster, checking for the ${Neo4jUtils.LEADER}")
-                            Neo4jUtils.executeInLeader(db, log) { initSinkModule() }
+                            Neo4jUtils.waitForTheLeader(db, log) { initSinkModule(streamsTopicService, streamsSinkConfiguration) }
                         } else {
                             // check if is writeable instance
-                            Neo4jUtils.executeInWriteableInstance(db) { initSinkModule() }
+                            Neo4jUtils.executeInWriteableInstance(db) { initSinkModule(streamsTopicService, streamsSinkConfiguration) }
                         }
 
                         // Register required services for the Procedures
@@ -82,7 +80,9 @@ class StreamsEventSinkExtensionFactory : KernelExtensionFactory<StreamsEventSink
             }
         }
 
-        private fun initSinkModule() {
+        private fun initSinkModule(streamsTopicService: StreamsTopicService, streamsSinkConfiguration: StreamsSinkConfiguration) {
+            streamsTopicService.clearAll()
+            streamsTopicService.setAll(streamsSinkConfiguration.topics)
             eventSink.start()
             streamsLog.info("Streams Sink module initialised")
         }

--- a/consumer/src/main/kotlin/streams/StreamsEventSinkQueryExecution.kt
+++ b/consumer/src/main/kotlin/streams/StreamsEventSinkQueryExecution.kt
@@ -24,15 +24,11 @@ class StreamsEventSinkQueryExecution(private val streamsTopicService: StreamsTop
 
     override fun write(query: String, params: Collection<Any>) {
         if (Neo4jUtils.isWriteableInstance(db)) {
-            try {
-                val result = db.execute(query, mapOf("events" to params))
-                if (log.isDebugEnabled) {
-                    log.debug("Query statistics:\n${result.queryStatistics}")
-                }
-                result.close()
-            } catch (e: Exception) {
-                log.error("Error while executing the query", e)
+            val result = db.execute(query, mapOf("events" to params))
+            if (log.isDebugEnabled) {
+                log.debug("Query statistics:\n${result.queryStatistics}")
             }
+            result.close()
         } else {
             if (log.isDebugEnabled) {
                 log.debug("Not writeable instance")

--- a/consumer/src/main/kotlin/streams/StreamsSinkConfiguration.kt
+++ b/consumer/src/main/kotlin/streams/StreamsSinkConfiguration.kt
@@ -16,6 +16,7 @@ data class StreamsSinkConfiguration(val enabled: Boolean = false,
                                     val proceduresEnabled: Boolean = true,
                                     val sinkPollingInterval: Long = 10000,
                                     val topics: Topics = Topics(),
+                                    val dlqTopic: String = "",
                                     val sourceIdStrategyConfig: SourceIdIngestionStrategyConfig = SourceIdIngestionStrategyConfig()) {
 
     companion object {
@@ -39,11 +40,14 @@ data class StreamsSinkConfiguration(val enabled: Boolean = false,
                     config.getOrDefault("sink.topic.cdc.sourceId.labelName", defaultSourceIdStrategyConfig.labelName),
                     config.getOrDefault("sink.topic.cdc.sourceId.idName", defaultSourceIdStrategyConfig.idName))
 
+            val dlqTopic = config.getOrDefault("sink.dlq", "")
+
             return default.copy(enabled = config.getOrDefault(StreamsSinkConfigurationConstants.ENABLED, default.enabled).toString().toBoolean(),
                     proceduresEnabled = config.getOrDefault(StreamsSinkConfigurationConstants.PROCEDURES_ENABLED, default.proceduresEnabled)
                             .toString().toBoolean(),
                     sinkPollingInterval = config.getOrDefault("sink.polling.interval", default.sinkPollingInterval).toString().toLong(),
                     topics = topics,
+                    dlqTopic = dlqTopic,
                     sourceIdStrategyConfig = sourceIdStrategyConfig)
         }
 

--- a/consumer/src/test/kotlin/integrations/KafkaEventSinkIT.kt
+++ b/consumer/src/test/kotlin/integrations/KafkaEventSinkIT.kt
@@ -447,6 +447,70 @@ class KafkaEventSinkIT {
         }, equalTo(true), 30, TimeUnit.SECONDS)
     }
 
+    @Test
+    fun `should send data to the DLQ because of QueryExecutionException`() {
+        val topic = UUID.randomUUID().toString()
+        val dlqTopic = UUID.randomUUID().toString()
+        graphDatabaseBuilder.setConfig("streams.sink.topic.cypher.$topic","MERGE (c:Customer {id: event.id})")
+        graphDatabaseBuilder.setConfig("streams.sink.dlq", dlqTopic)
+        db = graphDatabaseBuilder.newGraphDatabase() as GraphDatabaseAPI
+        val data = mapOf("id" to null, "name" to "Andrea", "surname" to "Santurbano")
+
+        var producerRecord = ProducerRecord(topic, UUID.randomUUID().toString(), JSONUtils.writeValueAsBytes(data))
+        kafkaProducer.send(producerRecord).get()
+        assertEventually(ThrowingSupplier<Boolean, Exception> {
+            val query = """
+                MATCH (c:Customer)
+                RETURN count(c) AS count
+            """.trimIndent()
+            val result = db.execute(query).columnAs<Long>("count")
+
+            val dlqConsumer = createConsumer<ByteArray, ByteArray>(ByteArrayDeserializer::class.java.name,
+                    ByteArrayDeserializer::class.java.name,
+                    dlqTopic)
+            val records = dlqConsumer.poll(5000)
+            val record = if (records.isEmpty) null else records.records(dlqTopic).iterator().next()
+            val headers = record?.headers()?.map { it.key() to String(it.value()) }?.toMap().orEmpty()
+            val value = if (record != null) JSONUtils.readValue<Any>(record.value()!!) else emptyMap<String, Any>()
+            dlqConsumer.close()
+            !records.isEmpty && headers.size == 7 && value == data && result.hasNext() && result.next() == 0L && !result.hasNext()
+                    && headers["__streams.errorsexception.class.name"] == "org.neo4j.graphdb.QueryExecutionException"
+        }, equalTo(true), 30, TimeUnit.SECONDS)
+    }
+
+    @Test
+    fun `should send data to the DLQ because of JsonParseException`() {
+        val topic = UUID.randomUUID().toString()
+        val dlqTopic = UUID.randomUUID().toString()
+        graphDatabaseBuilder.setConfig("streams.sink.topic.cypher.$topic","MERGE (c:Customer {id: event.id})")
+        graphDatabaseBuilder.setConfig("streams.sink.dlq", dlqTopic)
+        db = graphDatabaseBuilder.newGraphDatabase() as GraphDatabaseAPI
+
+        val data = """{id: 1, "name": "Andrea", "surname": "Santurbano"}"""
+
+        var producerRecord = ProducerRecord(topic, UUID.randomUUID().toString(),
+                data.toByteArray())
+        kafkaProducer.send(producerRecord).get()
+        assertEventually(ThrowingSupplier<Boolean, Exception> {
+            val query = """
+                MATCH (c:Customer)
+                RETURN count(c) AS count
+            """.trimIndent()
+            val result = db.execute(query).columnAs<Long>("count")
+
+            val dlqConsumer = createConsumer<ByteArray, ByteArray>(ByteArrayDeserializer::class.java.name,
+                    ByteArrayDeserializer::class.java.name,
+                    dlqTopic)
+            val records = dlqConsumer.poll(5000)
+            val record = if (records.isEmpty) null else records.records(dlqTopic).iterator().next()
+            val headers = record?.headers()?.map { it.key() to String(it.value()) }?.toMap().orEmpty()
+            val value = if (record != null) String(record.value()) else emptyMap<String, Any>()
+            dlqConsumer.close()
+            !records.isEmpty && headers.size == 7 && data == value && result.hasNext() && result.next() == 0L && !result.hasNext()
+                    && headers["__streams.errorsexception.class.name"] == "com.fasterxml.jackson.core.JsonParseException"
+        }, equalTo(true), 30, TimeUnit.SECONDS)
+    }
+
     private fun <K, V> createConsumer(keyDeserializer: String = StringDeserializer::class.java.name,
                                valueDeserializer: String = ByteArrayDeserializer::class.java.name,
                                vararg topics: String): KafkaConsumer<K, V> {

--- a/doc/asciidoc/consumer/index.adoc
+++ b/doc/asciidoc/consumer/index.adoc
@@ -308,6 +308,53 @@ By default no properties will be attached to the edge nodes but you can specify 
 
 |===
 
+=== How deal with bad data
+
+The Neo4j Streams Plugin provides a way to re-route all the data that for something reason it wasn't able to ingest to a `Dead Letter Queue`.
+You can active the feature by setting the following property:
+
+```
+streams.sink.dlq=<TOPIC_NAME>
+```
+
+So given:
+
+```
+streams.sink.dlq=my-dlq-topic
+```
+
+the Neo4j Streams plugin will re-route all the data to the the `my-dlq-topic` topic.
+
+Every published record in the `Dead Letter Queue` contains the original record `Key` and `Value` pairs and the following headers:
+
+[cols="1m,3a",opts=header]
+|===
+| Header key
+| Description
+
+| "__streams.errorstopic"
+| The topic where the data is published
+
+| "__streams.errorspartition"
+| The topic partition where the data is published
+
+| "__streams.errorsoffset"
+| The offset of the data into the topic partition
+
+| "__streams.errorsclass.name"
+| The class that generated the error
+
+| "__streams.errorsexception.class.name
+| The exception that generated the error
+
+| "__streams.errorsexception.message"
+| The exception message
+
+| "__streams.errorsexception.stacktrace"
+| The exception stack trace
+|===
+
+
 === Configuration
 
 include::configuration.adoc[]


### PR DESCRIPTION
Fixes #177

Unfortunately it's not possible to provide this behaviour to the Kafka Connect Plugin because there is no way to get the Kafka Cluster configuration from the Connect plugin. I had a chat about that with Jeff Bean of Confluent and he suggests that to require ad additionally information the cluster info in the Plugin configuration. Let's discuss that.

## Proposed Changes (Mandatory)

A brief list of proposed changes in order to fix the issue:

  - Implemented the Dead Letter Queue mechanism
  - Updated the documentation