### PR TITLE
Documentation improvements

### DIFF
--- a/doc/asciidoc/consumer/index.adoc
+++ b/doc/asciidoc/consumer/index.adoc
@@ -1,10 +1,11 @@
 [[consumer]]
-== Neo4j Streams Consumer
+== Consumer: Kafka -> Neo4j
 
 ifdef::env-docs[]
 [abstract]
 --
-This chapter describes the Neo4j Streams Consumer in the Neo4j Streams Library.
+This chapter describes the Neo4j Streams Consumer in the Neo4j Streams Library. Use this section
+to configure Neo4j to consume data from Kafka and create new nodes and relationships.
 --
 endif::env-docs[]
 

--- a/doc/asciidoc/developing/index.adoc
+++ b/doc/asciidoc/developing/index.adoc
@@ -1,0 +1,28 @@
+[[developing]]
+== Developing Neo4j Streams
+
+ifdef::env-docs[]
+[abstract]
+--
+This chapter describes setting up Neo4j Streams for local development.
+--
+endif::env-docs[]
+
+[[build-locally]]
+=== Build locally
+
+----
+mvn clean install
+----
+
+1. Copy `<project_dir>/target/neo4j-streams-<VERSION>.jar` into `$NEO4J_HOME/plugins`
+2. Restart Neo4j
+
+[[gendocs]]
+=== Generating this Documentation
+
+1. `cd docs && ./gradlew clean packageHTML`
+2. `cd build/html && python3 -m http.server`
+3. Browse to http://localhost:8000/
+
+

--- a/doc/asciidoc/index.adoc
+++ b/doc/asciidoc/index.adoc
@@ -129,14 +129,39 @@ Download the latest release jar from https://github.com/neo4j-contrib/neo4j-stre
 
 Copy it into `$NEO4J_HOME/plugins` and configure the relevant connections.
 
-The minimal setup in your `neo4j.conf` is:
+[[configuration]]
+=== Configuration
+
+Configuring neo4j-streams comes in three different parts, depending on your need:
+
+. *Required*: Configuring a connection to Kafka
+. _Optional_: Configuring Neo4j to ingest from Kafka (link:/consumer[Consumer])
+. _Optional_: Configuring Neo4j to produce records to Kafka (link:/producer[Producer])
+
+This section will deal with configuring the plugin's connection to Kafka.  See the links above
+in the sub-sections for link:/consumer[Consumer] and link:/producer[Producer] for documentation
+on how to configure those aspects.
+
+==== When Running Neo4j in Docker
+
+When Neo4j is run in a docker, some special considerations apply; please see 
+link:https://neo4j.com/docs/operations-manual/current/docker/configuration/[Neo4j Docker Configuration]
+for more information.  In particular, the configuration format used in `neo4j.conf` looks like this:
 
 ----
 kafka.zookeeper.connect=localhost:2181
-kafka.bootstrap.servers=localhost:9092
+kafka.bootstrap.servers=broker:9093
 ----
 
-For each module there are additional configs that are explained in the individual sections.
+Where the same configuration for Neo4j running in docker would be done by environment variables,
+like this:
+
+----
+NEO4J_kafka_zookeeper_connect: zookeeper:2181
+NEO4J_kafka_bootstrap_servers: broker:9093
+----
+
+Note the configuration style that you need, and adapt examples in this documentation accordingly.
 
 include::producer/index.adoc[]
 

--- a/doc/asciidoc/index.adoc
+++ b/doc/asciidoc/index.adoc
@@ -253,4 +253,6 @@ include::docker/index.adoc[]
 
 include::kafka-connect/index.adoc[]
 
+include::neo4j-cluster/index.adoc[]
+
 include::developing/index.adoc[]

--- a/doc/asciidoc/index.adoc
+++ b/doc/asciidoc/index.adoc
@@ -24,8 +24,10 @@ The guide covers the following areas:
 * <<producer>> -- Sends transaction event handler events to a Kafka topic
 * <<consumer>> -- Ingests events from a Kafka topic into Neo4j
 * <<procedures>> -- Procedures for consuming and producing Kafka events
-* <<docker>> -- Docker Compose files for local testing
+* <<docker>> -- Docker Compose files for local testing; example configurations
 * <<kafka-connect>> -- Kafka Connect Sink plugin
+* <<cluster>> -- Using with Neo4j Causal Cluster
+* <<developing>> -- Developing Neo4j Streams
 
 [[quickstart]]
 == Quick Start
@@ -37,12 +39,17 @@ Get started fast for common scenarios, using neo4j-streams as a plugin.
 --
 endif::env-docs[]
 
-1. Download the latest release jar from https://github.com/neo4j-contrib/neo4j-streams/releases/latest
-2. Copy it into `$NEO4J_HOME/plugins` and configure the relevant connections
-3. Configure the plugin to connect to your kafka instance.
+=== Install the Plugin
 
-If you are managing Kafka yourself, the simple setup is as follows:
+* Download the latest release jar from https://github.com/neo4j-contrib/neo4j-streams/releases/latest
+* Copy it into `$NEO4J_HOME/plugins` and configure the relevant connections
 
+=== Configure Kafka Connection 
+
+If you are running Kafka locally, the simplest setup is:
+
+.neo4j.conf
+[source,ini]
 ----
 kafka.zookeeper.connect=localhost:2181
 kafka.bootstrap.servers=localhost:9092
@@ -51,6 +58,8 @@ kafka.bootstrap.servers=localhost:9092
 If you are using Confluent Cloud (managed Kafka), you can connect to Kafka in this way, filling 
 in your own `CONFLUENT_CLOUD_ENDPOINT`, `CONFLUENT_API_KEY`, and `CONFLUENT_API_SECRET`
 
+.neo4j.conf
+[source,ini]
 ----
 kafka.bootstrap.servers: <<CONFLUENT_CLOUD_ENDPOINT_HERE>>
 kafka.sasl.jaas.config: org.apache.kafka.common.security.plain.PlainLoginModule required username="<<CONFLUENT_API_KEY HERE>>" password="<<CONFLUENT_API_SECRET HERE>>";
@@ -61,10 +70,13 @@ kafka.request.timeout_ms: 20000
 kafka.retry.backoff.ms: 500
 ----
 
-4. Decide if you want to save data to Neo4j using the plugin, produce data from Neo4j, or both
-and then follow these extra steps accordingly:
+=== Decide: Consumer, Producer, or Both
 
-5. (Optional) Take data from Kafka and store it in Neo4j (Neo4j as a data sink) by adding configuration such as:
+Follow one or both subsections according to your use case and need:
+
+==== Consumer
+
+Take data from Kafka and store it in Neo4j (Neo4j as a data sink) by adding configuration such as:
 
 .neo4j.conf
 [source,ini]
@@ -80,7 +92,9 @@ properties in the source message.
 
 For full details on what you can do here, see the link:/consumer[Consumer Section] of the documentation.
 
-6. (Optional) Produce data from Neo4j and send it to a Kafka topic (Neo4j as a source) by adding configuration such as:
+==== Producer
+
+Produce data from Neo4j and send it to a Kafka topic (Neo4j as a source) by adding configuration such as:
 
 .neo4j.conf
 ----
@@ -204,6 +218,11 @@ how much memory the plugin may require to hold messages not yet delivered to Neo
 |A unique string that identifies the consumer group this consumer belongs to.
 |N/A
 |===
+
+=== Restart Neo4j
+
+Once the plugin is installed and configured, restarting the database will make it active.
+If you have configured Neo4j to consume from kafka, it will begin immediately processing messages.
 
 ==== Confluent Cloud
 

--- a/doc/asciidoc/index.adoc
+++ b/doc/asciidoc/index.adoc
@@ -142,6 +142,36 @@ This section will deal with configuring the plugin's connection to Kafka.  See t
 in the sub-sections for link:/consumer[Consumer] and link:/producer[Producer] for documentation
 on how to configure those aspects.
 
+==== Kafka Configuration Settings
+
+Neo4j streams uses the official Confluent Kafka producer and consumer java clients.  This means that
+configuration settings which are valid for those connectors will also work for Neo4j Streams.  Any
+configuration option that starts with `kafka.` will be passed to the driver.  For example, in the
+kafka documentation linked below, the configuration setting named `batch.size` should be stated as
+`kafka.batch.size` in Neo4j Streams.
+
+The following are a couple of common configuration settings you may wish to use.  _This is not a complete
+list_.  See the references at the bottom of this section for a full reference table of available configuration
+options.
+
+.Common Configuration Settings
+|===
+|Setting Name |Description |Default Value
+
+|kafka.max.poll.records
+|The maximum number of records to pull per batch from Kafka. Increasing this number will mean
+larger transactions in Neo4j memory and may improve throughput.
+|500
+
+|Cell in column 1, row 2
+|Cell in column 2, row 2
+|Cell in column 3, row 2
+|===
+
+Important further configuration references:
+* link:https://docs.confluent.io/current/installation/configuration/consumer-configs.html#cp-config-consumer[Consumer Configurations]
+* link:https://docs.confluent.io/current/installation/configuration/producer-configs.html#cp-config-producer[Producer Configurations]
+
 ==== When Running Neo4j in Docker
 
 When Neo4j is run in a docker, some special considerations apply; please see 

--- a/doc/asciidoc/index.adoc
+++ b/doc/asciidoc/index.adoc
@@ -1,7 +1,7 @@
 = Neo4j Streaming Data Integrations User Guide v{docs-version}
 :toc: left
 :experimental:
-:toclevels: 2
+:toclevels: 3
 :sectid:
 :sectlinks:
 :img: https://github.com/neo4j-contrib/neo4j-streams/raw/gh-pages/3.4/images
@@ -10,7 +10,6 @@
 ifdef::backend-html5[(C) {copyright}]
 
 License: link:{common-license-page-uri}[Creative Commons 4.0]
-
 
 [abstract]
 --
@@ -46,7 +45,7 @@ endif::env-docs[]
 
 === Configure Kafka Connection 
 
-If you are running Kafka locally, the simplest setup is:
+If you are running locally or against a standalone machine, configure `neo4j.conf` to point to that server:
 
 .neo4j.conf
 [source,ini]
@@ -113,154 +112,7 @@ these in the link:/producer/#_patterns[Patterns section].
 
 For full details on what you can do here, see the link:/producer[Producer Section] of the documentation.
 
-[[introduction]]
-== Introduction
-
-ifdef::env-docs[]
-[abstract]
---
-This chapter provides an introduction to the Neo4j Streams Library, and instructions for installation.
---
-endif::env-docs[]
-
-Many user and customers want to integrate Kafka and other streaming solutions with Neo4j.
-Either to ingest data into the graph from other sources.
-Or to send update events (change data capture - CDC) to the event log for later consumption.
-
-This extension was developed to satisfy all these use-cases and more to come.
-
-The project is composed of several parts:
-
-* Neo4j Streams Procedure: a procedure to send a payload to a topic
-* Neo4j Streams Producer: a transaction event handler events that sends data to a Kafka topic
-* Neo4j Streams Consumer: a Neo4j application that ingest data from Kafka topics into Neo4j via templated Cypher Statements
-* Kafka-Connect Plugin: a plugin for the Confluent Platform that allows to ingest data into Neo4j, from Kafka topics, via Cypher queries.
-
-[[before_begin]]
-=== Before you Begin
-
-Neo4j streams can run in two modes:
-
-* As a **Neo4j plugin**, neo4j-streams runs inside of the database, and can both consume and produce messages
-to Kafka.
-* As a **Kafka Connect worker**, neo4j-streams is deployed separately from the Neo4j database.  At this time,
-the connect worker can be used to push data to Neo4j (Neo4j as the consumer) but does not yet support
-change data capture (CDC) coming _from_ Neo4j.
-
-Experienced Neo4j users will likely prefer running the software as a Neo4j Plugin.  Kafka administrators
-may prefer using the Kafka Connect method.
-
-The remainder of the introduction section assumes you are running Neo4j Streams as a Neo4j plugin. 
-More information on the alternative Kafka Connect method can be link:/kafka-connect/[found in this section].
-
-[[installation]]
-=== Installation
-
-Download the latest release jar from https://github.com/neo4j-contrib/neo4j-streams/releases/latest
-
-Copy it into `$NEO4J_HOME/plugins` and configure the relevant connections.
-
-[[configuration]]
-=== Configuration
-
-Configuring neo4j-streams comes in three different parts, depending on your need:
-
-. *Required*: Configuring a connection to Kafka
-. _Optional_: Configuring Neo4j to ingest from Kafka (link:/consumer[Consumer])
-. _Optional_: Configuring Neo4j to produce records to Kafka (link:/producer[Producer])
-
-This section will deal with configuring the plugin's connection to Kafka.  See the links above
-in the sub-sections for link:/consumer[Consumer] and link:/producer[Producer] for documentation
-on how to configure those aspects.
-
-==== Kafka Configuration Settings
-
-Any configuration option that starts with `kafka.` will be passed to the underlying Kafka driver. Neo4j 
-streams uses the official Confluent Kafka producer and consumer java clients.
-Configuration settings which are valid for those connectors will also work for Neo4j Streams.  
-
-For example, in the
-kafka documentation linked below, the configuration setting named `batch.size` should be stated as
-`kafka.batch.size` in Neo4j Streams.
-
-The following are common configuration settings you may wish to use.  _This is not a complete
-list_.  The full list of configuration options and reference material is available from Confluent's
-site for link:https://docs.confluent.io/current/installation/configuration/consumer-configs.html#cp-config-consumer[consumer configurations] and
-link:https://docs.confluent.io/current/installation/configuration/producer-configs.html#cp-config-producer[producer configurations]
-
-.Most Common Needed Configuration Settings
-|===
-|Setting Name |Description |Default Value
-
-|kafka.max.poll.records
-|The maximum number of records to pull per batch from Kafka. Increasing this number will mean
-larger transactions in Neo4j memory and may improve throughput.
-|500
-
-|kafka.buffer.memory
-|The total bytes of memory the producer can use to buffer records waiting.  Use this to adjust
-how much memory the plugin may require to hold messages not yet delivered to Neo4j
-|33554432
-
-|kafka.batch.size
-|(Producer only) The producer will attempt to batch records together into fewer requests whenever multiple records are being sent to the same partition. This helps performance on both the client and the server. This configuration controls the default batch size in bytes.
-|16384
-
-|kafka.batch.size
-|(Producer only) The producer will attempt to batch records together into fewer requests whenever multiple records are being sent to the same partition. This helps performance on both the client and the server. This configuration controls the default batch size in bytes.
-|16384
-
-|kafka.max.partition.fetch.bytes
-|(Consumer only) The maximum amount of data per-partition the server will return. Records are fetched in batches by the consumer. If the first record batch in the first non-empty partition of the fetch is larger than this limit, the batch will still be returned to ensure that the consumer can make progress. 
-|1048576
-
-|kafka.group.id
-|A unique string that identifies the consumer group this consumer belongs to.
-|N/A
-|===
-
-=== Restart Neo4j
-
-Once the plugin is installed and configured, restarting the database will make it active.
-If you have configured Neo4j to consume from kafka, it will begin immediately processing messages.
-
-==== Confluent Cloud
-
-Configuring a connection to a Confluent Cloud instance should follow 
-link:https://docs.confluent.io/current/cloud/using/config-client.html#java-client[Confluent's Java Client]
-configuration advice, and the advice just above.  At a minimum, to configure this, you will need:
-
-* `bootstrap_server_url`
-* `api-key`
-* `api-secret`
-
-==== Plugin Configuration
-
-Any configuration option that starts with `streams.` controls how the plugin itself behaves.  For a full
-list of options available, see the documentation subsections on the producer and consumer.
-
-==== A Note on Running Neo4j in Docker
-
-When Neo4j is run in a docker, some special considerations apply; please see 
-link:https://neo4j.com/docs/operations-manual/current/docker/configuration/[Neo4j Docker Configuration]
-for more information.  In particular, the configuration format used in `neo4j.conf` looks like this:
-
-----
-kafka.zookeeper.connect=localhost:2181
-kafka.bootstrap.servers=broker:9093
-----
-
-Where the same configuration for Neo4j running in docker would be done by environment variables,
-like this:
-
-----
-NEO4J_kafka_zookeeper_connect: zookeeper:2181
-NEO4J_kafka_bootstrap_servers: broker:9093
-----
-
-Note the configuration style that you need, and adapt examples in this documentation accordingly.
-
-For more information and examples see the link:/docker[Docker section] of the documentation.
+include::introduction/index.adoc[]
 
 include::producer/index.adoc[]
 

--- a/doc/asciidoc/index.adoc
+++ b/doc/asciidoc/index.adoc
@@ -144,17 +144,20 @@ on how to configure those aspects.
 
 ==== Kafka Configuration Settings
 
-Neo4j streams uses the official Confluent Kafka producer and consumer java clients.  This means that
-configuration settings which are valid for those connectors will also work for Neo4j Streams.  Any
-configuration option that starts with `kafka.` will be passed to the driver.  For example, in the
+Any configuration option that starts with `kafka.` will be passed to the underlying Kafka driver. Neo4j 
+streams uses the official Confluent Kafka producer and consumer java clients.
+Configuration settings which are valid for those connectors will also work for Neo4j Streams.  
+
+For example, in the
 kafka documentation linked below, the configuration setting named `batch.size` should be stated as
 `kafka.batch.size` in Neo4j Streams.
 
-The following are a couple of common configuration settings you may wish to use.  _This is not a complete
-list_.  See the references at the bottom of this section for a full reference table of available configuration
-options.
+The following are common configuration settings you may wish to use.  _This is not a complete
+list_.  The full list of configuration options and reference material is available from Confluent's
+site for link:https://docs.confluent.io/current/installation/configuration/consumer-configs.html#cp-config-consumer[consumer configurations] and
+link:https://docs.confluent.io/current/installation/configuration/producer-configs.html#cp-config-producer[producer configurations]
 
-.Common Configuration Settings
+.Most Common Needed Configuration Settings
 |===
 |Setting Name |Description |Default Value
 
@@ -163,16 +166,34 @@ options.
 larger transactions in Neo4j memory and may improve throughput.
 |500
 
-|Cell in column 1, row 2
-|Cell in column 2, row 2
-|Cell in column 3, row 2
+|kafka.buffer.memory
+|The total bytes of memory the producer can use to buffer records waiting.  Use this to adjust
+how much memory the plugin may require to hold messages not yet delivered to Neo4j
+|33554432
+
+|kafka.batch.size
+|(Producer only) The producer will attempt to batch records together into fewer requests whenever multiple records are being sent to the same partition. This helps performance on both the client and the server. This configuration controls the default batch size in bytes.
+|16384
+
+|kafka.batch.size
+|(Producer only) The producer will attempt to batch records together into fewer requests whenever multiple records are being sent to the same partition. This helps performance on both the client and the server. This configuration controls the default batch size in bytes.
+|16384
+
+|kafka.max.partition.fetch.bytes
+|(Consumer only) The maximum amount of data per-partition the server will return. Records are fetched in batches by the consumer. If the first record batch in the first non-empty partition of the fetch is larger than this limit, the batch will still be returned to ensure that the consumer can make progress. 
+|1048576
+
+|kafka.group.id
+|A unique string that identifies the consumer group this consumer belongs to.
+|N/A
 |===
 
-Important further configuration references:
-* link:https://docs.confluent.io/current/installation/configuration/consumer-configs.html#cp-config-consumer[Consumer Configurations]
-* link:https://docs.confluent.io/current/installation/configuration/producer-configs.html#cp-config-producer[Producer Configurations]
+==== Plugin Configuration
 
-==== When Running Neo4j in Docker
+Any configuration option that starts with `streams.` controls how the plugin itself behaves.  For a full
+list of options available, see the documentation subsections on the producer and consumer.
+
+==== A Note on Running Neo4j in Docker
 
 When Neo4j is run in a docker, some special considerations apply; please see 
 link:https://neo4j.com/docs/operations-manual/current/docker/configuration/[Neo4j Docker Configuration]

--- a/doc/asciidoc/index.adoc
+++ b/doc/asciidoc/index.adoc
@@ -214,6 +214,8 @@ NEO4J_kafka_bootstrap_servers: broker:9093
 
 Note the configuration style that you need, and adapt examples in this documentation accordingly.
 
+For more information and examples see the link:/docker[Docker section] of the documentation.
+
 include::producer/index.adoc[]
 
 include::consumer/index.adoc[]

--- a/doc/asciidoc/index.adoc
+++ b/doc/asciidoc/index.adoc
@@ -122,6 +122,23 @@ The project is composed of several parts:
 * Neo4j Streams Consumer: a Neo4j application that ingest data from Kafka topics into Neo4j via templated Cypher Statements
 * Kafka-Connect Plugin: a plugin for the Confluent Platform that allows to ingest data into Neo4j, from Kafka topics, via Cypher queries.
 
+[[before_begin]]
+=== Before you Begin
+
+Neo4j streams can run in two modes:
+
+* As a **Neo4j plugin**, neo4j-streams runs inside of the database, and can both consume and produce messages
+to Kafka.
+* As a **Kafka Connect worker**, neo4j-streams is deployed separately from the Neo4j database.  At this time,
+the connect worker can be used to push data to Neo4j (Neo4j as the consumer) but does not yet support
+change data capture (CDC) coming _from_ Neo4j.
+
+Experienced Neo4j users will likely prefer running the software as a Neo4j Plugin.  Kafka administrators
+may prefer using the Kafka Connect method.
+
+The remainder of the introduction section assumes you are running Neo4j Streams as a Neo4j plugin. 
+More information on the alternative Kafka Connect method can be link:/kafka-connect/[found in this section].
+
 [[installation]]
 === Installation
 
@@ -187,6 +204,16 @@ how much memory the plugin may require to hold messages not yet delivered to Neo
 |A unique string that identifies the consumer group this consumer belongs to.
 |N/A
 |===
+
+==== Confluent Cloud
+
+Configuring a connection to a Confluent Cloud instance should follow 
+link:https://docs.confluent.io/current/cloud/using/config-client.html#java-client[Confluent's Java Client]
+configuration advice, and the advice just above.  At a minimum, to configure this, you will need:
+
+* `bootstrap_server_url`
+* `api-key`
+* `api-secret`
 
 ==== Plugin Configuration
 

--- a/doc/asciidoc/index.adoc
+++ b/doc/asciidoc/index.adoc
@@ -19,6 +19,7 @@ This is the user guide for Neo4j Streams version {docs-version}, authored by the
 
 The guide covers the following areas:
 
+* <<quickstart>> -- Get Started Fast with the most Common Scenarios
 * <<introduction>> -- An introduction to Neo4j Streams
 * <<producer>> -- Sends transaction event handler events to a Kafka topic
 * <<consumer>> -- Ingests events from a Kafka topic into Neo4j
@@ -26,6 +27,77 @@ The guide covers the following areas:
 * <<docker>> -- Docker Compose files for local testing
 * <<kafka-connect>> -- Kafka Connect Sink plugin
 
+[[quickstart]]
+== Quick Start
+
+ifdef::env-docs[]
+[abstract]
+--
+Get started fast for common scenarios, using neo4j-streams as a plugin.
+--
+endif::env-docs[]
+
+1. Download the latest release jar from https://github.com/neo4j-contrib/neo4j-streams/releases/latest
+2. Copy it into `$NEO4J_HOME/plugins` and configure the relevant connections
+3. Configure the plugin to connect to your kafka instance.
+
+If you are managing Kafka yourself, the simple setup is as follows:
+
+----
+kafka.zookeeper.connect=localhost:2181
+kafka.bootstrap.servers=localhost:9092
+----
+
+If you are using Confluent Cloud (managed Kafka), you can connect to Kafka in this way, filling 
+in your own `CONFLUENT_CLOUD_ENDPOINT`, `CONFLUENT_API_KEY`, and `CONFLUENT_API_SECRET`
+
+----
+kafka.bootstrap.servers: <<CONFLUENT_CLOUD_ENDPOINT_HERE>>
+kafka.sasl.jaas.config: org.apache.kafka.common.security.plain.PlainLoginModule required username="<<CONFLUENT_API_KEY HERE>>" password="<<CONFLUENT_API_SECRET HERE>>";
+kafka.ssl.endpoint.identification.algorithm: https
+kafka.security.protocol: SASL_SSL
+kafka.sasl.mechanism: PLAIN
+kafka.request.timeout_ms: 20000
+kafka.retry.backoff.ms: 500
+----
+
+4. Decide if you want to save data to Neo4j using the plugin, produce data from Neo4j, or both
+and then follow these extra steps accordingly:
+
+5. (Optional) Take data from Kafka and store it in Neo4j (Neo4j as a data sink) by adding configuration such as:
+
+.neo4j.conf
+[source,ini]
+----
+streams.sink.enabled=true
+streams.sink.topic.cypher.my-ingest-topic=MERGE (n:Label {id: event.id}) ON CREATE SET n += event.properties
+----
+
+This will process every message that comes in on `my-ingest-topic` with the given cypher statement.  When
+that cypher statement executes, the `event` variable that is referenced will be set to the message received,
+so this sample cypher will create a `(:Label)` node in the graph with the given ID, copying all of the
+properties in the source message.
+
+For full details on what you can do here, see the link:/consumer[Consumer Section] of the documentation.
+
+6. (Optional) Produce data from Neo4j and send it to a Kafka topic (Neo4j as a source) by adding configuration such as:
+
+.neo4j.conf
+----
+streams.source.topic.nodes.my-nodes-topic=Person{*}
+streams.source.topic.relationships.my-rels-topic=KNOWS{*}
+streams.source.enabled=true
+streams.source.schema.polling.interval=10000
+----
+
+This will produce all graph nodes labeled `(:Person)` on to the topic `my-nodes-topic` and all
+relationships of type `-[:KNOWS]->` to the topic named `my-rels-topic`.  Further, schema changes will
+be polled every 10,000 ms, which affects how quickly the database picks up new indexes/schema changes.
+
+The expressions `Person{\*}` and `KNOWS{*}` are _patterns_.  You can find documentation on how to change
+these in the link:/producer/#_patterns[Patterns section].
+
+For full details on what you can do here, see the link:/producer[Producer Section] of the documentation.
 
 [[introduction]]
 == Introduction
@@ -36,7 +108,6 @@ ifdef::env-docs[]
 This chapter provides an introduction to the Neo4j Streams Library, and instructions for installation.
 --
 endif::env-docs[]
-
 
 Many user and customers want to integrate Kafka and other streaming solutions with Neo4j.
 Either to ingest data into the graph from other sources.
@@ -67,18 +138,6 @@ kafka.bootstrap.servers=localhost:9092
 
 For each module there are additional configs that are explained in the individual sections.
 
-
-[[build-locally]]
-==== Build locally
-
-----
-mvn clean install
-----
-
-1. Copy `<project_dir>/target/neo4j-streams-<VERSION>.jar` into `$NEO4J_HOME/plugins`
-2. Restart Neo4j
-
-
 include::producer/index.adoc[]
 
 include::consumer/index.adoc[]
@@ -88,3 +147,5 @@ include::procedures/index.adoc[]
 include::docker/index.adoc[]
 
 include::kafka-connect/index.adoc[]
+
+include::developing/index.adoc[]

--- a/doc/asciidoc/introduction/index.adoc
+++ b/doc/asciidoc/introduction/index.adoc
@@ -1,0 +1,164 @@
+[[introduction]]
+== Introduction
+
+ifdef::env-docs[]
+[abstract]
+--
+This chapter provides an introduction to the Neo4j Streams Library, and instructions for installation.
+--
+endif::env-docs[]
+
+Many user and customers want to integrate Kafka and other streaming solutions with Neo4j.
+Either to ingest data into the graph from other sources.
+Or to send update events (change data capture - CDC) to the event log for later consumption.
+
+This extension was developed to satisfy all these use-cases and more to come.
+
+The project is composed of several parts:
+
+* Neo4j Streams Procedure: a procedure to send a payload to a topic
+* Neo4j Streams Producer: a transaction event handler events that sends data to a Kafka topic
+* Neo4j Streams Consumer: a Neo4j application that ingest data from Kafka topics into Neo4j via templated Cypher Statements
+* Kafka-Connect Plugin: a plugin for the Confluent Platform that allows to ingest data into Neo4j, from Kafka topics, via Cypher queries.
+
+[[before_begin]]
+=== Before you Begin
+
+Neo4j streams can run in two modes:
+
+* As a **Neo4j plugin**, neo4j-streams runs inside of the database, and can both consume and produce messages
+to Kafka.
+* As a **Kafka Connect worker**, neo4j-streams is deployed separately from the Neo4j database.  At this time,
+the connect worker can be used to push data to Neo4j (Neo4j as the consumer) but does not yet support
+change data capture (CDC) coming _from_ Neo4j.
+
+Experienced Neo4j users will likely prefer running the software as a Neo4j Plugin.  Kafka administrators
+may prefer using the Kafka Connect method.
+
+The remainder of the introduction section assumes you are running Neo4j Streams as a Neo4j plugin. 
+More information on the alternative Kafka Connect method can be link:/kafka-connect/[found in this section].
+
+[[installation]]
+=== Installation
+
+Download the latest release jar from https://github.com/neo4j-contrib/neo4j-streams/releases/latest
+
+Copy it into `$NEO4J_HOME/plugins` and configure the relevant connections.
+
+[[configuration]]
+=== Configuration Example
+
+Configuring neo4j-streams comes in three different parts, depending on your need:
+
+. *Required*: Configuring a connection to Kafka
+. _Optional_: Configuring Neo4j to ingest from Kafka (link:/consumer[Consumer])
+. _Optional_: Configuring Neo4j to produce records to Kafka (link:/producer[Producer])
+
+Below is a complete configured example of using the plugin in both modes, assuming kafka running
+on localhost.  See the relevant subsections to adjust the configuration as necessary.
+
+.neo4j.conf
+[source,ini]
+----
+kafka.zookeeper.connect=localhost:2181
+kafka.bootstrap.servers=localhost:9092
+
+streams.sink.enabled=true
+streams.sink.topic.cypher.topic-name=MERGE (n:Person { id: event.id }) SET n += event
+
+streams.source.enabled=true
+streams.source.topic.nodes.new-person-topic=Person{*}
+streams.source.topic.relationships.who-knows-who=KNOWS{*}
+streams.source.schema.polling.interval=10000
+----
+
+The rest of this section will deal with overall plugin configuration.
+
+[[kafka_settings]]
+=== Kafka Settings
+
+Any configuration option that starts with `kafka.` will be passed to the underlying Kafka driver. Neo4j 
+streams uses the official Confluent Kafka producer and consumer java clients.
+Configuration settings which are valid for those connectors will also work for Neo4j Streams.  
+
+For example, in the
+kafka documentation linked below, the configuration setting named `batch.size` should be stated as
+`kafka.batch.size` in Neo4j Streams.
+
+The following are common configuration settings you may wish to use.  _This is not a complete
+list_.  The full list of configuration options and reference material is available from Confluent's
+site for link:https://docs.confluent.io/current/installation/configuration/consumer-configs.html#cp-config-consumer[consumer configurations] and
+link:https://docs.confluent.io/current/installation/configuration/producer-configs.html#cp-config-producer[producer configurations]
+
+.Most Common Needed Configuration Settings
+|===
+|Setting Name |Description |Default Value
+
+|kafka.max.poll.records
+|The maximum number of records to pull per batch from Kafka. Increasing this number will mean
+larger transactions in Neo4j memory and may improve throughput.
+|500
+
+|kafka.buffer.memory
+|The total bytes of memory the producer can use to buffer records waiting.  Use this to adjust
+how much memory the plugin may require to hold messages not yet delivered to Neo4j
+|33554432
+
+|kafka.batch.size
+|(Producer only) The producer will attempt to batch records together into fewer requests whenever multiple records are being sent to the same partition. This helps performance on both the client and the server. This configuration controls the default batch size in bytes.
+|16384
+
+|kafka.batch.size
+|(Producer only) The producer will attempt to batch records together into fewer requests whenever multiple records are being sent to the same partition. This helps performance on both the client and the server. This configuration controls the default batch size in bytes.
+|16384
+
+|kafka.max.partition.fetch.bytes
+|(Consumer only) The maximum amount of data per-partition the server will return. Records are fetched in batches by the consumer. If the first record batch in the first non-empty partition of the fetch is larger than this limit, the batch will still be returned to ensure that the consumer can make progress. 
+|1048576
+
+|kafka.group.id
+|A unique string that identifies the consumer group this consumer belongs to.
+|N/A
+|===
+
+[[confluent_cloud]]
+=== Confluent Cloud
+
+Configuring a connection to a Confluent Cloud instance should follow 
+link:https://docs.confluent.io/current/cloud/using/config-client.html#java-client[Confluent's Java Client]
+configuration advice, and the advice just above.  At a minimum, to configure this, you will need:
+
+* `bootstrap_server_url`
+* `api-key`
+* `api-secret`
+
+[[configuration_plugin]]
+=== Plugin Configuration
+
+Any configuration option that starts with `streams.` controls how the plugin itself behaves.  For a full
+list of options available, see the documentation subsections on the producer and consumer.
+
+[[configuration_docker]]
+=== A Note on Running Neo4j in Docker
+
+When Neo4j is run in a docker, some special considerations apply; please see 
+link:https://neo4j.com/docs/operations-manual/current/docker/configuration/[Neo4j Docker Configuration]
+for more information.  In particular, the configuration format used in `neo4j.conf` looks different.
+
+Please note that the Neo4j Docker image use a naming convention; you can override every neo4j.conf property by prefix it with `NEO4J_` and using the following transformations:
+
+* single underscore is converted in double underscore: `_ -> __`
+* point is converted in single underscore: `.` -> `_`
+
+Example:
+
+* `dbms.memory.heap.max_size=8G` -> `NEO4J_dbms_memory_heap_max__size: 8G`
+* `dbms.logs.debug.level=DEBUG` -> `NEO4J_dbms_logs_debug_level: DEBUG`
+
+For more information and examples see the link:/docker[Docker section] of the documentation.
+
+[[restart]]
+=== Restart Neo4j
+
+Once the plugin is installed and configured, restarting the database will make it active.
+If you have configured Neo4j to consume from kafka, it will begin immediately processing messages.

--- a/doc/asciidoc/neo4j-cluster/index.adoc
+++ b/doc/asciidoc/neo4j-cluster/index.adoc
@@ -1,0 +1,69 @@
+[[cluster]]
+== Using with Neo4j Causal Cluster
+
+ifdef::env-docs[]
+[abstract]
+--
+This chapter describes considerations around using Neo4j Streams with Neo4j Enterprise Causal Cluster.
+--
+endif::env-docs[]
+
+[[build-locally]]
+=== Overview
+
+link:https://neo4j.com/docs/operations-manual/current/clustering/[Neo4j Clustering] is a feature available in
+Enterprise Edition which allows high availability of the database through having multiple database members.
+
+Neo4j Enterprise uses a link:https://neo4j.com/docs/operations-manual/current/clustering/introduction/#causal-clustering-introduction-operational[LEADER/FOLLOWER]
+operational view, where writes are always processed by the leader, while reads can be serviced by either followers,
+or optionally be read replicas, which maintain a copy of the database and serve to scale out read operations
+horizontally.
+
+=== Kafka Connect
+
+When using Neo4j Streams in this method with a Neo4j cluster, the most important consideration is to use
+a routing driver.  Generally, these are identified by a URI with `bolt+routing://` as the scheme instead of
+just `bolt://` as the scheme.
+
+If your Neo4j cluster is located at `graph.mycompany.com:7687`, simply configure the Kafka Connect worker with
+
+---
+neo4j.server.uri=bolt+routing://graph.mycompany.com:7687
+---
+
+The use of the `bolt+routing` driver will mean that the Neo4j Driver itself will handle connecting to
+the correct cluster member, and managing changes to the cluster membership over time.
+
+For further information on routing drivers, see the link:https://neo4j.com/docs/driver-manual/current/[Neo4j Driver Manual].
+
+=== Neo4j Plugin
+
+When using Neo4j Streams as a plugin together with a cluster, there are several things to keep in mind:
+
+* The plugin must be present in the plugins directory of _all cluster members_, and not just one.
+* The configuration settings must be present in _all of the neo4j.conf files_, not just one.
+
+Through the course of the cluster lifecycle, the leader may change; for this reason the plugin must be everywhere,
+and not just on the leader.  
+
+The plugin detects the leader, and will not attempt to perform a write (i.e. in the case of the consumer) 
+on a follower where it would fail.  The plugin checks cluster toplogy as needed.
+
+Additionally for CDC, a consideration to keep in mind is that as of Neo4j 3.5, committed transactions are only
+published on the leader as well.  In practical terms, this means that as new data is committed to Neo4j, it is
+the leader that will be publishing that data back out to Kafka, if you have the producer configured.
+
+The neo4j streams utility procedures, in particular `CALL streams.publish`, can work on any cluster member, or 
+read replica.  `CALL streams.consume` may also be used on any cluster member, however it is important to keep in
+mind that due to the way clustering in Neo4j works, using `streams.consume` together with write operations will
+not work on a cluster follower or read replica, as only the leader can process writes.
+
+=== Remote Clients
+
+Sometimes there will be remote applications that talk to Neo4j via official drivers, that want to use
+streams functionality.  Best practices in these cases are:
+
+* Always use a `bolt+routing://` driver URI when communicating with the cluster in the client application.
+* Use link:https://neo4j.com/docs/driver-manual/current/sessions-transactions/#driver-transactions[Explicit Write Transactions] in
+your client application when using procedure calls such as `CALL streams.consume` to ensure that the routing
+driver routes the query to the leader.

--- a/doc/asciidoc/procedures/index.adoc
+++ b/doc/asciidoc/procedures/index.adoc
@@ -1,17 +1,18 @@
 [[procedures]]
-== Procedures
+== Cypher Procedures
 
 ifdef::env-docs[]
 [abstract]
 --
-This chapter describes consumer and producer procedures in the Neo4j Streams Library.
+This chapter describes consumer and producer procedures in the Neo4j Streams Library.  Procedures
+allow the functionality of the plugin to be used ad-hoc in any Cypher query.
 --
 endif::env-docs[]
 
 
 The Streams project comes out with a list of procedures.
 
-=== General configuration
+=== Configuration
 
 You can enable/disable the procedures by changing this variable inside the `neo4j.conf`
 

--- a/doc/asciidoc/producer/index.adoc
+++ b/doc/asciidoc/producer/index.adoc
@@ -1,10 +1,11 @@
 [[producer]]
-== Neo4j Streams Producer
+== Producer: Neo4j -> Kafka
 
 ifdef::env-docs[]
 [abstract]
 --
-This chapter describes the Neo4j Streams Producer in the Neo4j Streams Library.
+This chapter describes the Neo4j Streams Producer in the Neo4j Streams Library.  Use this section
+to configure Neo4j to publish CDC style data to Kafka.
 --
 endif::env-docs[]
 


### PR DESCRIPTION
Fixes a number of documentation related issues (see commits)

- Adds a "Quickstart" section to address common criticisms on Neo4j internal slack.
- Adds a section describing extended kafka configuration options
- Adds a section dealing with causal cluster
- Adds a section dealing with Confluent Cloud.