### PR TITLE
 fixes #181: Validate configuration before attempting to start

### DIFF
--- a/common/src/main/kotlin/streams/utils/ValidationUtils.kt
+++ b/common/src/main/kotlin/streams/utils/ValidationUtils.kt
@@ -1,22 +1,42 @@
 package streams.utils
 
+import java.io.IOException
+import java.net.Socket
+import java.net.URI
+
 object ValidationUtils {
 
-    fun validateTopics(cdcMergeTopics: Set<String>, cdcSchemaTopics: Set<String>,
-                       cypherTopics: Set<String>, nodePatternTopics: Set<String>, relPatternTopics: Set<String>) {
-        val allTopicsLists = mutableListOf<String>()
-        allTopicsLists.addAll(cdcMergeTopics)
-        allTopicsLists.addAll(cdcSchemaTopics)
-        allTopicsLists.addAll(cypherTopics)
-        allTopicsLists.addAll(nodePatternTopics)
-        allTopicsLists.addAll(relPatternTopics)
-        val crossDefinedTopics = allTopicsLists.map { it to 1 }
-                .groupBy({ it.first }, { it.second })
-                .mapValues { it.value.reduce { acc, i -> acc + i } }
-                .filterValues { it > 1 }
-                .keys
-        if (crossDefinedTopics.isNotEmpty()) {
-            throw RuntimeException("The following topics are cross defined: $crossDefinedTopics")
+    fun isServerReachable(url: String, port: Int): Boolean = try {
+        Socket(url, port).use { true }
+    } catch (e: IOException) {
+        false
+    }
+
+    fun checkServersUnreachable(urls: String, separator: String = ","): List<String> = urls
+            .split(separator)
+            .map {
+                val uri = URI.create(it)
+                when (uri.host.isNullOrBlank()) {
+                    true -> {
+                        val splitted = it.split(":")
+                        URI("fake-scheme", "", splitted.first(), splitted.last().toInt(),
+                                "", "", "")
+                    }
+                    else -> uri
+                }
+            }
+            .filter { uri -> !isServerReachable(uri.host, uri.port) }
+            .map { if (it.scheme == "fake-scheme") "${it.host}:${it.port}" else it.toString() }
+
+    fun validateConnection(url: String, kafkaPropertyKey: String, checkReachable: Boolean = true) {
+        if (url.isBlank()) {
+            throw RuntimeException("The `kafka.$kafkaPropertyKey` property is empty")
+        } else if (checkReachable) {
+            val unreachableServers = ValidationUtils.checkServersUnreachable(url)
+            if (unreachableServers.isNotEmpty()) {
+                throw RuntimeException("The servers defined into the property `kafka.$kafkaPropertyKey` are not reachable: $unreachableServers")
+            }
         }
     }
+
 }

--- a/common/src/test/kotlin/streams/utils/ValidationUtilsTest.kt
+++ b/common/src/test/kotlin/streams/utils/ValidationUtilsTest.kt
@@ -1,0 +1,36 @@
+package streams.utils
+
+import org.junit.Test
+import org.testcontainers.containers.GenericContainer
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class FakeWebServer: GenericContainer<FakeWebServer>("alpine") {
+    override fun start() {
+        this.withCommand("/bin/sh", "-c", "while true; do { echo -e 'HTTP/1.1 200 OK'; echo ; } | nc -l -p 8000; done")
+                .withExposedPorts(8000)
+        super.start()
+    }
+
+    fun getUrl() = "http://localhost:${getMappedPort(8000)}"
+}
+
+class ValidationUtilsTest {
+
+    @Test
+    fun `should reach the server`() {
+        val httpServer = FakeWebServer()
+        httpServer.start()
+        assertTrue { ValidationUtils.checkServersUnreachable(httpServer.getUrl()).isEmpty() }
+        httpServer.stop()
+    }
+
+    @Test
+    fun `should not reach the server`() {
+        val urls = "http://my.fake.host:1234,PLAINTEXT://my.fake.host1:1234,my.fake.host2:1234"
+        val checkServersUnreachable = ValidationUtils
+                .checkServersUnreachable(urls)
+        assertTrue { checkServersUnreachable.isNotEmpty() }
+        assertEquals(urls.split(",").toList(), checkServersUnreachable)
+    }
+}

--- a/consumer/src/test/kotlin/integrations/kafka/KafkaEventSinkBase.kt
+++ b/consumer/src/test/kotlin/integrations/kafka/KafkaEventSinkBase.kt
@@ -60,6 +60,7 @@ open class KafkaEventSinkBase {
         graphDatabaseBuilder = org.neo4j.test.TestGraphDatabaseFactory()
                 .newImpermanentDatabaseBuilder()
                 .setConfig("kafka.bootstrap.servers", KafkaEventSinkSuiteIT.kafka.bootstrapServers)
+                .setConfig("kafka.zookeeper.connect", KafkaEventSinkSuiteIT.kafka.envMap["KAFKA_ZOOKEEPER_CONNECT"])
                 .setConfig("streams.sink.enabled", "true")
         kafkaProducer = createProducer()
         kafkaAvroProducer = createProducer(valueSerializer = KafkaAvroSerializer::class.java.name,

--- a/consumer/src/test/kotlin/integrations/kafka/KafkaEventSinkNoConfigurationIT.kt
+++ b/consumer/src/test/kotlin/integrations/kafka/KafkaEventSinkNoConfigurationIT.kt
@@ -1,0 +1,55 @@
+package integrations.kafka
+
+import io.confluent.kafka.serializers.KafkaAvroDeserializer
+import org.junit.Test
+import org.neo4j.kernel.internal.GraphDatabaseAPI
+import org.neo4j.test.TestGraphDatabaseFactory
+import org.testcontainers.containers.GenericContainer
+import kotlin.test.assertEquals
+
+
+class FakeWebServer: GenericContainer<FakeWebServer>("alpine") {
+    override fun start() {
+        this.withCommand("/bin/sh", "-c", "while true; do { echo -e 'HTTP/1.1 200 OK'; echo ; } | nc -l -p 8000; done")
+                .withExposedPorts(8000)
+        super.start()
+    }
+
+    fun getUrl() = "http://localhost:${getMappedPort(8000)}"
+}
+
+class KafkaEventSinkNoConfigurationIT {
+
+    private val topic = "no-config"
+
+    @Test
+    fun `the db should start even with no bootstrap servers provided()`() {
+        val db = TestGraphDatabaseFactory()
+                .newImpermanentDatabaseBuilder()
+                .setConfig("kafka.bootstrap.servers", "")
+                .setConfig("streams.sink.enabled", "true")
+                .setConfig("streams.sink.topic.cypher.$topic", "CREATE (p:Place{name: event.name, coordinates: event.coordinates, citizens: event.citizens})")
+                .newGraphDatabase() as GraphDatabaseAPI
+        val count = db.execute("MATCH (n) RETURN COUNT(n) AS count").columnAs<Long>("count").next()
+        assertEquals(0L, count)
+    }
+
+    @Test
+    fun `the db should start even with AVRO serializers and no schema registry url provided()`() {
+        val fakeWebServer = FakeWebServer()
+        fakeWebServer.start()
+        val url = fakeWebServer.getUrl().replace("http://", "")
+        val db = TestGraphDatabaseFactory()
+                .newImpermanentDatabaseBuilder()
+                .setConfig("kafka.bootstrap.servers", url)
+                .setConfig("kafka.zookeeper.connect", url)
+                .setConfig("streams.sink.enabled", "true")
+                .setConfig("streams.sink.topic.cypher.$topic", "CREATE (p:Place{name: event.name, coordinates: event.coordinates, citizens: event.citizens})")
+                .setConfig("kafka.key.deserializer", KafkaAvroDeserializer::class.java.name)
+                .setConfig("kafka.value.deserializer", KafkaAvroDeserializer::class.java.name)
+                .newGraphDatabase() as GraphDatabaseAPI
+        val count = db.execute("MATCH (n) RETURN COUNT(n) AS count").columnAs<Long>("count").next()
+        assertEquals(0L, count)
+        fakeWebServer.stop()
+    }
+}

--- a/producer/src/test/kotlin/streams/kafka/KafkaConfigurationTest.kt
+++ b/producer/src/test/kotlin/streams/kafka/KafkaConfigurationTest.kt
@@ -24,7 +24,7 @@ class KafkaConfigurationTest {
                 "kafka.linger.ms" to 10,
                 "kafka.fetch.min.bytes" to 1234)
 
-        val kafkaConfig = KafkaConfiguration.from(map.mapValues { it.value.toString() })
+        val kafkaConfig = KafkaConfiguration.create(map.mapValues { it.value.toString() })
 
         assertFalse { kafkaConfig.extraProperties.isEmpty() }
         assertTrue { kafkaConfig.extraProperties.containsKey("fetch.min.bytes") }


### PR DESCRIPTION
Fixes #181 (we need to close this after #211 )

We validate some configuration params ensuring that the missing of these params will not affect the correct DB start-up. Following an example log in case the endpoint in `kafka.bootstrap.servers` param is not reachable:

```
neo4j              | 2019-07-25 13:29:02.019+0000 INFO  Kafka Connector started
neo4j              | 2019-07-25 13:29:02.024+0000 INFO  Streams Source module initialised
neo4j              | 2019-07-25 13:29:02.290+0000 INFO  Initialising the Streams Sink module
neo4j              | 2019-07-25 13:29:04.817+0000 INFO  Starting the Kafka Sink
neo4j              | 2019-07-25 13:29:04.932+0000 WARN  The Kafka Sink cannot be started because of this exception: The servers defined into the property `kafka.bootstrap.servers` are not reachable: [localhost:9092]
neo4j              | java.lang.RuntimeException: The servers defined into the property `kafka.bootstrap.servers` are not reachable: [localhost:9092]
neo4j              |    at streams.kafka.KafkaSinkConfigurationKt.validateConnection(KafkaSinkConfiguration.kt:38)
neo4j              |    at streams.kafka.KafkaSinkConfigurationKt.validateConnection$default(KafkaSinkConfiguration.kt:32)
neo4j              |    at streams.kafka.KafkaSinkConfiguration$Companion.validate(KafkaSinkConfiguration.kt:92)
neo4j              |    at streams.kafka.KafkaSinkConfiguration$Companion.from(KafkaSinkConfiguration.kt:61)
neo4j              |    at streams.kafka.KafkaEventSink$getEventConsumerFactory$1.createStreamsEventConsumer(KafkaEventSink.kt:40)
neo4j              |    at streams.kafka.KafkaEventSink.start(KafkaEventSink.kt:73)
neo4j              |    at streams.StreamsEventSinkExtensionFactory$StreamsEventLifecycle.initSinkModule(StreamsEventSinkExtensionFactory.kt:86)
neo4j              |    at streams.StreamsEventSinkExtensionFactory$StreamsEventLifecycle.access$initSinkModule(StreamsEventSinkExtensionFactory.kt:31)
neo4j              |    at streams.StreamsEventSinkExtensionFactory$StreamsEventLifecycle$start$1$available$2.invoke(StreamsEventSinkExtensionFactory.kt:68)
neo4j              |    at streams.StreamsEventSinkExtensionFactory$StreamsEventLifecycle$start$1$available$2.invoke(StreamsEventSinkExtensionFactory.kt:41)
neo4j              |    at streams.utils.Neo4jUtils.executeInWriteableInstance(Neo4jUtils.kt:76)
neo4j              |    at streams.StreamsEventSinkExtensionFactory$StreamsEventLifecycle$start$1.available(StreamsEventSinkExtensionFactory.kt:68)
neo4j              |    at org.neo4j.helpers.Listeners.notifySingleListener(Listeners.java:145)
neo4j              |    at org.neo4j.helpers.Listeners.notify(Listeners.java:101)
neo4j              |    at org.neo4j.kernel.availability.DatabaseAvailabilityGuard.fulfill(DatabaseAvailabilityGuard.java:90)
neo4j              |    at org.neo4j.kernel.availability.DatabaseAvailability.start(DatabaseAvailability.java:59)
neo4j              |    at org.neo4j.kernel.lifecycle.LifeSupport$LifecycleInstance.start(LifeSupport.java:452)
neo4j              |    at org.neo4j.kernel.lifecycle.LifeSupport.start(LifeSupport.java:111)
neo4j              |    at org.neo4j.kernel.NeoStoreDataSource.start(NeoStoreDataSource.java:444)
neo4j              |    at org.neo4j.kernel.lifecycle.LifeSupport$LifecycleInstance.start(LifeSupport.java:452)
neo4j              |    at org.neo4j.kernel.lifecycle.LifeSupport.start(LifeSupport.java:111)
neo4j              |    at org.neo4j.kernel.impl.transaction.state.DataSourceManager.start(DataSourceManager.java:116)
neo4j              |    at org.neo4j.kernel.lifecycle.LifeSupport$LifecycleInstance.start(LifeSupport.java:452)
neo4j              |    at org.neo4j.kernel.lifecycle.LifeSupport.start(LifeSupport.java:111)
neo4j              |    at org.neo4j.graphdb.facade.GraphDatabaseFacadeFactory.initFacade(GraphDatabaseFacadeFactory.java:225)
neo4j              |    at org.neo4j.graphdb.facade.GraphDatabaseFacadeFactory.newFacade(GraphDatabaseFacadeFactory.java:146)
neo4j              |    at org.neo4j.server.database.CommunityGraphFactory.newGraphDatabase(CommunityGraphFactory.java:41)
neo4j              |    at org.neo4j.server.database.LifecycleManagingDatabase.start(LifecycleManagingDatabase.java:90)
neo4j              |    at org.neo4j.kernel.lifecycle.LifeSupport$LifecycleInstance.start(LifeSupport.java:452)
neo4j              |    at org.neo4j.kernel.lifecycle.LifeSupport.start(LifeSupport.java:111)
neo4j              |    at org.neo4j.server.AbstractNeoServer.start(AbstractNeoServer.java:180)
neo4j              |    at org.neo4j.server.ServerBootstrapper.start(ServerBootstrapper.java:124)
neo4j              |    at org.neo4j.server.ServerBootstrapper.start(ServerBootstrapper.java:91)
neo4j              |    at org.neo4j.server.CommunityEntryPoint.main(CommunityEntryPoint.java:32)
neo4j              | 2019-07-25 13:29:23.802+0000 INFO  Bolt enabled on 0.0.0.0:7687.
neo4j              | 2019-07-25 13:29:25.214+0000 INFO  Started.
```


## Proposed Changes (Mandatory)

A brief list of proposed changes in order to fix the issue:

  - Added the validation
