### PR TITLE
Docs Links Fixes

### DIFF
--- a/doc/asciidoc/index.adoc
+++ b/doc/asciidoc/index.adoc
@@ -89,7 +89,7 @@ that cypher statement executes, the `event` variable that is referenced will be 
 so this sample cypher will create a `(:Label)` node in the graph with the given ID, copying all of the
 properties in the source message.
 
-For full details on what you can do here, see the link:/consumer[Consumer Section] of the documentation.
+For full details on what you can do here, see the  link:../consumer[Consumer Section] of the documentation.
 
 ==== Producer
 
@@ -108,9 +108,9 @@ relationships of type `-[:KNOWS]->` to the topic named `my-rels-topic`.  Further
 be polled every 10,000 ms, which affects how quickly the database picks up new indexes/schema changes.
 
 The expressions `Person{\*}` and `KNOWS{*}` are _patterns_.  You can find documentation on how to change
-these in the link:/producer/#_patterns[Patterns section].
+these in the  link:../producer/#_patterns[Patterns section].
 
-For full details on what you can do here, see the link:/producer[Producer Section] of the documentation.
+For full details on what you can do here, see the  link:../producer[Producer Section] of the documentation.
 
 include::introduction/index.adoc[]
 

--- a/doc/asciidoc/introduction/index.adoc
+++ b/doc/asciidoc/introduction/index.adoc
@@ -36,7 +36,7 @@ Experienced Neo4j users will likely prefer running the software as a Neo4j Plugi
 may prefer using the Kafka Connect method.
 
 The remainder of the introduction section assumes you are running Neo4j Streams as a Neo4j plugin. 
-More information on the alternative Kafka Connect method can be link:/kafka-connect/[found in this section].
+More information on the alternative Kafka Connect method can be  link:../kafka-connect/[found in this section].
 
 [[installation]]
 === Installation
@@ -51,8 +51,8 @@ Copy it into `$NEO4J_HOME/plugins` and configure the relevant connections.
 Configuring neo4j-streams comes in three different parts, depending on your need:
 
 . *Required*: Configuring a connection to Kafka
-. _Optional_: Configuring Neo4j to ingest from Kafka (link:/consumer[Consumer])
-. _Optional_: Configuring Neo4j to produce records to Kafka (link:/producer[Producer])
+. _Optional_: Configuring Neo4j to ingest from Kafka ( link:../consumer[Consumer])
+. _Optional_: Configuring Neo4j to produce records to Kafka ( link:../producer[Producer])
 
 Below is a complete configured example of using the plugin in both modes, assuming kafka running
 on localhost.  See the relevant subsections to adjust the configuration as necessary.
@@ -155,7 +155,7 @@ Example:
 * `dbms.memory.heap.max_size=8G` -> `NEO4J_dbms_memory_heap_max__size: 8G`
 * `dbms.logs.debug.level=DEBUG` -> `NEO4J_dbms_logs_debug_level: DEBUG`
 
-For more information and examples see the link:/docker[Docker section] of the documentation.
+For more information and examples see the  link:../docker[Docker section] of the documentation.
 
 [[restart]]
 === Restart Neo4j


### PR DESCRIPTION
Fixed links that are now broken on neo4j.com/docs/labs

