### PR TITLE
issue #227 add parallelizeBatches config option (WIP)

### DIFF
--- a/kafka-connect-neo4j/docker/readme.adoc
+++ b/kafka-connect-neo4j/docker/readme.adoc
@@ -23,6 +23,7 @@ You can set the following configuration values via Confluent Connect UI, or via 
 |neo4j.connection.liveness.check.timeout.msecs|Long| The max Neo4j liveness check timeout (default 1 hour)
 |neo4j.connection.max.pool.size|Int| The max pool size (default 100)
 |neo4j.load.balance.strategy|enum[ROUND_ROBIN, LEAST_CONNECTED]| The Neo4j load balance strategy (default LEAST_CONNECTED)
+|neo4j.batch.parallelize|Boolean|(default true) whether batches should be written in parallel or not.  Parallel writing speeds overall throughput, but comes with the possibility of transactions succeeding out of order, and hence messages being applied not in strict order coming from Kafka.  Set to false if you need strict ordering.
 |===
 
 === Configuring the stack

--- a/kafka-connect-neo4j/src/main/kotlin/streams/kafka/connect/sink/Neo4jService.kt
+++ b/kafka-connect-neo4j/src/main/kotlin/streams/kafka/connect/sink/Neo4jService.kt
@@ -116,29 +116,34 @@ class Neo4jService(private val config: Neo4jSinkConnectorConfig):
     suspend fun writeData(data: Map<String, List<List<StreamsSinkEntity>>>) = coroutineScope {
         val timeout = config.batchTimeout
         val ticker = ticker(timeout)
-        val deferredList = data
-                .flatMap { (topic, records) ->
-                    records.map { async(Dispatchers.IO) { writeForTopic(topic, it) } }
+
+        if (config.parallelBatches) {
+            val deferredList = data
+                    .flatMap { (topic, records) ->
+                        records.map { async(Dispatchers.IO) { writeForTopic(topic, it) } }
+                    }
+            whileSelect {
+                ticker.onReceive {
+                    if (log.isDebugEnabled) {
+                        log.debug("Timeout $timeout occurred while executing queries")
+                    }
+                    deferredList.forEach { deferred -> deferred.cancel() }
+                    false // Stops the whileSelect
                 }
-        whileSelect {
-            ticker.onReceive {
-                if (log.isDebugEnabled) {
-                    log.debug("Timeout $timeout occurred while executing queries")
+                val isAllCompleted = deferredList.all { it.isCompleted } // when all are completed
+                deferredList.forEach {
+                    it.onAwait { !isAllCompleted } // Stops the whileSelect
                 }
-                deferredList.forEach { deferred -> deferred.cancel() }
-                false // Stops the whileSelect
             }
-            val isAllCompleted = deferredList.all { it.isCompleted } // when all are completed
-            deferredList.forEach {
-                it.onAwait { !isAllCompleted } // Stops the whileSelect
+            val exceptionMessages = deferredList
+                    .mapNotNull { it.getCompletionExceptionOrNull() }
+                    .map { it.message }
+                    .joinToString("\n")
+            if (exceptionMessages.isNotBlank()) {
+                throw ConnectException(exceptionMessages)
             }
-        }
-        val exceptionMessages = deferredList
-                .mapNotNull { it.getCompletionExceptionOrNull() }
-                .map { it.message }
-                .joinToString("\n")
-        if (exceptionMessages.isNotBlank()) {
-            throw ConnectException(exceptionMessages)
+        } else {
+            data.flatMap { (topic, records) -> records.map { writeForTopic(topic, it) } }
         }
     }
 }

--- a/kafka-connect-neo4j/src/main/kotlin/streams/kafka/connect/sink/Neo4jSinkConnectorConfig.kt
+++ b/kafka-connect-neo4j/src/main/kotlin/streams/kafka/connect/sink/Neo4jSinkConnectorConfig.kt
@@ -58,6 +58,7 @@ class Neo4jSinkConnectorConfig(originals: Map<*, *>): AbstractConfig(config(), o
 
     val batchTimeout: Long
     val batchSize: Int
+    val parallelBatches: Boolean
 
 //    val cdcTopics: Map<TopicType, Set<String>>
 //
@@ -103,6 +104,7 @@ class Neo4jSinkConnectorConfig(originals: Map<*, *>): AbstractConfig(config(), o
         topics = Topics.from(originals, "streams.sink.", "neo4j.")
         strategyMap = TopicUtils.toStrategyMap(topics, sourceIdStrategyConfig)
 
+        parallelBatches = getBoolean(BATCH_PARALLELIZE)
         validateAllTopics(originals)
     }
 
@@ -145,6 +147,7 @@ class Neo4jSinkConnectorConfig(originals: Map<*, *>): AbstractConfig(config(), o
 
         const val BATCH_SIZE = "neo4j.batch.size"
         const val BATCH_TIMEOUT_MSECS = "neo4j.batch.timeout.msecs"
+        const val BATCH_PARALLELIZE = "neo4j.batch.parallelize"
 
         const val RETRY_BACKOFF_MSECS = "neo4j.retry.backoff.msecs"
         const val RETRY_MAX_ATTEMPTS = "neo4j.retry.max.attemps"
@@ -326,6 +329,10 @@ class Neo4jSinkConnectorConfig(originals: Map<*, *>): AbstractConfig(config(), o
                     .define(ConfigKeyBuilder.of(TOPIC_CDC_SCHEMA, ConfigDef.Type.STRING)
                             .documentation(PropertiesUtil.getProperty(TOPIC_CDC_SCHEMA)).importance(ConfigDef.Importance.HIGH)
                             .defaultValue("").group(ConfigGroup.TOPIC_CYPHER_MAPPING)
+                            .build())
+                    .define(ConfigKeyBuilder.of(BATCH_PARALLELIZE, ConfigDef.Type.BOOLEAN)
+                            .documentation(PropertiesUtil.getProperty(BATCH_PARALLELIZE)).importance(ConfigDef.Importance.MEDIUM)
+                            .defaultValue(true).group(ConfigGroup.BATCH)
                             .build())
         }
     }


### PR DESCRIPTION
Fixes #227

neo4j-streams and the connect worker can write messages in batches out of order, because it parallelizes transactions.  When a volume comes in and we attempt to write more than one TX batch at a time, the fact that this is done concurrently (to improve throughput) means things can be written out of order.  Issue #227 is a case where the order matters and results in poor CDC outcomes.

## Proposed Changes (Mandatory)

Add a configuration flag `neo4j.batch.parallelize` with default value `true`.  By switching it to false users can make TXs synchronous, which guarantees ordering at the expense of throughput.