### PR TITLE
warning about docker configuration in documentation

### DIFF
--- a/doc/asciidoc/docker/index.adoc
+++ b/doc/asciidoc/docker/index.adoc
@@ -8,6 +8,13 @@ This chapter describes Docker Compose templates that can be used to test Neo4j S
 --
 endif::env-docs[]
 
+**Important Note**:  the Neo4j docker container is built on an approach that uses environment variables passed to
+the container as a way to configure Neo4j.  There are certain characters which environment variables cannot contain,
+notably the dash `-` character.  Configuring the plugin to use stream names that contain these characters will not
+work properly, because a configuration environment variable such as `NEO4J_streams_sink_topic_cypher_my-topic` cannot
+be correctly evaluated as an environment variable (`my-topic`).  This is a limitation of the Neo4j docker container
+rather than neo4j-streams.
+
 Following you'll find a lightweight Docker Compose file that allows you to test the application in your local environment
 
 Prerequisites:


### PR DESCRIPTION
This issue was found in debugging with @conker84 a while ago.   The issue was raised with Neo4j packaging, (@jennyowen) but it's not terribly simple for them to fix because the container is based on bash.

As a consequence of neo4j-streams using configuration that needs to end up in neo4j.conf, combined with Neo4j/Docker only allowing valid environment variables, this is just a limitation that needs to be documented to avoid user confusion.  Actual observed behavior with the plugin would be that if you used `topic-name` in the config, the Neo4j docker container would probably see it as just named "topic", and consumption would fail as that topic probably doesn't exist.