### PR TITLE
fixes #247: Schema Ingestion Strategy: double node creation

### DIFF
--- a/consumer/src/test/kotlin/integrations/kafka/KafkaEventSinkCDC.kt
+++ b/consumer/src/test/kotlin/integrations/kafka/KafkaEventSinkCDC.kt
@@ -91,8 +91,10 @@ class KafkaEventSinkCDC: KafkaEventSinkBase() {
         graphDatabaseBuilder.setConfig("streams.sink.topic.cdc.schema", topic)
         db = graphDatabaseBuilder.newGraphDatabase() as GraphDatabaseAPI
 
+        val constraints = listOf(Constraint(label = "User", type = StreamsConstraintType.UNIQUE, properties = setOf("name", "surname")))
+        val relSchema = Schema(properties = mapOf("since" to "Long"), constraints = constraints)
         val nodeSchema = Schema(properties = mapOf("name" to "String", "surname" to "String", "comp@ny" to "String"),
-                constraints = listOf(Constraint(label = "User", type =  StreamsConstraintType.UNIQUE, properties = setOf("name", "surname"))))
+                constraints = constraints)
         val cdcDataStart = StreamsTransactionEvent(
                 meta = Meta(timestamp = System.currentTimeMillis(),
                         username = "user",
@@ -137,7 +139,7 @@ class KafkaEventSinkCDC: KafkaEventSinkBase() {
                         before = null,
                         label = "KNOWS WHO"
                 ),
-                schema = Schema()
+                schema = relSchema
         )
         var producerRecord = ProducerRecord(topic, UUID.randomUUID().toString(), JSONUtils.writeValueAsBytes(cdcDataStart))
         kafkaProducer.send(producerRecord).get()

--- a/producer/src/test/kotlin/streams/integrations/KafkaEventRouterIT.kt
+++ b/producer/src/test/kotlin/streams/integrations/KafkaEventRouterIT.kt
@@ -17,6 +17,7 @@ import streams.kafka.KafkaConfiguration
 import streams.procedures.StreamsProcedures
 import streams.serialization.JSONUtils
 import streams.utils.StreamsUtils
+import java.lang.RuntimeException
 import kotlin.test.assertEquals
 
 @Suppress("UNCHECKED_CAST", "DEPRECATION")
@@ -90,6 +91,8 @@ class KafkaEventRouterIT {
         }
         if (testName.methodName.endsWith(WITH_CONSTRAINTS_SUFFIX)) {
             graphDatabaseBuilder.setConfig("streams.source.topic.nodes.personConstraints", "PersonConstr{*}")
+                    .setConfig("streams.source.topic.nodes.productConstraints", "ProductConstr{*}")
+                    .setConfig("streams.source.topic.relationships.boughtConstraints", "BOUGHT{*}")
                     .setConfig("streams.source.schema.polling.interval", "0")
         }
         db = graphDatabaseBuilder.newGraphDatabase() as GraphDatabaseAPI
@@ -97,6 +100,7 @@ class KafkaEventRouterIT {
                 .registerProcedure(StreamsProcedures::class.java, true)
         if (testName.methodName.endsWith(WITH_CONSTRAINTS_SUFFIX)) {
             db.execute("CREATE CONSTRAINT ON (p:PersonConstr) ASSERT p.name IS UNIQUE").close()
+            db.execute("CREATE CONSTRAINT ON (p:ProductConstr) ASSERT p.name IS UNIQUE").close()
         }
 
     }
@@ -246,6 +250,57 @@ class KafkaEventRouterIT {
                         && it.schema.properties == mapOf("name" to "String")
                         && it.schema.constraints == listOf(Constraint("PersonConstr", setOf("name"), StreamsConstraintType.UNIQUE))
             }
+        })
+        consumer.close()
+    }
+
+    @Test
+    fun testCreateRelationshipWithConstraints() {
+        db.execute("CREATE (:PersonConstr {name:'Andrea'})").close()
+        db.execute("CREATE (:ProductConstr {name:'My Awesome Product', price: '100€'})").close()
+        db.execute("""
+            |MATCH (p:PersonConstr {name:'Andrea'})
+            |MATCH (pp:ProductConstr {name:'My Awesome Product'})
+            |MERGE (p)-[:BOUGHT]->(pp)
+        """.trimMargin())
+        val config = KafkaConfiguration(bootstrapServers = kafka.bootstrapServers)
+        val consumer = createConsumer(config)
+        consumer.subscribe(listOf("personConstraints", "productConstraints", "boughtConstraints"))
+        val records = consumer.poll(10000)
+        assertEquals(3, records.count())
+
+        val map = records
+                .map {
+                    val evt = JSONUtils.asStreamsTransactionEvent(it.value())
+                    evt.payload.type to evt
+                }
+                .groupBy({ it.first }, { it.second })
+        assertEquals(true, map[EntityType.node].orEmpty().isNotEmpty() && map[EntityType.node].orEmpty().all {
+            val payload = it.payload as NodePayload
+            val (labels, properties) = payload.after!!.labels!! to payload.after!!.properties!!
+            when (labels) {
+                listOf("ProductConstr") -> properties == mapOf("name" to "My Awesome Product", "price" to "100€")
+                        && it.meta.operation == OperationType.created
+                        && it.schema.properties == mapOf("name" to "String", "price" to "String")
+                        && it.schema.constraints == listOf(Constraint("ProductConstr", setOf("name"), StreamsConstraintType.UNIQUE))
+                listOf("PersonConstr") -> properties == mapOf("name" to "Andrea")
+                        && it.meta.operation == OperationType.created
+                        && it.schema.properties == mapOf("name" to "String")
+                        && it.schema.constraints == listOf(Constraint("PersonConstr", setOf("name"), StreamsConstraintType.UNIQUE))
+                else -> false
+            }
+        })
+        assertEquals(true, map[EntityType.relationship].orEmpty().isNotEmpty() && map[EntityType.relationship].orEmpty().all {
+            val payload = it.payload as RelationshipPayload
+            val (start, end, properties) = Triple(payload.start, payload.end, payload.after!!.properties!!)
+            properties.isNullOrEmpty()
+                    && start.ids == mapOf("name" to "Andrea")
+                    && end.ids == mapOf("name" to "My Awesome Product")
+                    && it.meta.operation == OperationType.created
+                    && it.schema.properties == emptyMap<String, String>()
+                    && it.schema.constraints.toSet() == setOf(
+                            Constraint("PersonConstr", setOf("name"), StreamsConstraintType.UNIQUE),
+                            Constraint("ProductConstr", setOf("name"), StreamsConstraintType.UNIQUE))
         })
         consumer.close()
     }


### PR DESCRIPTION
Fixes #247
Fixed the bug

## Proposed Changes (Mandatory)

A brief list of proposed changes in order to fix the issue:

  - Added the schema information about start/end nodes into the relationship schema event
  - Updated the Schema ingestion strategy in order to leverage the new schema information
