### PR TITLE
fixes #252: Source with non-existant topic hangs indefinitely

### DIFF
--- a/common/src/main/kotlin/streams/utils/KafkaValidationUtils.kt
+++ b/common/src/main/kotlin/streams/utils/KafkaValidationUtils.kt
@@ -1,0 +1,37 @@
+package streams.utils
+
+import org.apache.kafka.clients.admin.AdminClient
+import org.apache.kafka.common.config.ConfigResource
+import java.util.*
+
+object KafkaValidationUtils {
+    fun getInvalidTopicsError(invalidTopics: List<String>) = "The BROKER config `auto.create.topics.enable` is false, the following topics need to be created into the Kafka cluster otherwise the messages will be discarded: $invalidTopics"
+
+    fun getInvalidTopics(kafkaProps: Properties, allTopics: List<String>) = getInvalidTopics(AdminClient.create(kafkaProps), allTopics)
+
+    fun getInvalidTopics(client: AdminClient, allTopics: List<String>): List<String> {
+        val kafkaTopics = client.listTopics().names().get()
+        val invalidTopics = allTopics.filter { !kafkaTopics.contains(it) }
+        return if (invalidTopics.isNotEmpty()) {
+            if (isAutoCreateTopicsEnabled(client)) {
+                emptyList()
+            } else {
+                invalidTopics
+            }
+        } else {
+            invalidTopics
+        }
+    }
+
+    fun isAutoCreateTopicsEnabled(kafkaProps: Properties) = isAutoCreateTopicsEnabled(AdminClient.create(kafkaProps))
+
+    fun isAutoCreateTopicsEnabled(client: AdminClient): Boolean {
+        val firstNodeId = client.describeCluster().nodes().get().first().id()
+        val configs = client.describeConfigs(listOf(ConfigResource(ConfigResource.Type.BROKER, firstNodeId.toString()))).all().get()
+        return configs.values
+                .flatMap { it.entries() }
+                .find { it.name() == "auto.create.topics.enable" }
+                ?.value()
+                ?.toBoolean() ?: false
+    }
+}

--- a/consumer/src/main/kotlin/streams/StreamsEventConsumer.kt
+++ b/consumer/src/main/kotlin/streams/StreamsEventConsumer.kt
@@ -17,6 +17,8 @@ abstract class StreamsEventConsumer(private val log: Log, private val dlqService
 
     abstract fun read(action: (String, List<StreamsSinkEntity>) -> Unit)
 
+    abstract fun invalidTopics(): List<String>
+
 }
 
 

--- a/consumer/src/main/kotlin/streams/StreamsEventSink.kt
+++ b/consumer/src/main/kotlin/streams/StreamsEventSink.kt
@@ -21,6 +21,8 @@ abstract class StreamsEventSink(private val config: Config,
 
     open fun getEventSinkConfigMapper(): StreamsEventSinkConfigMapper = StreamsEventSinkConfigMapper(streamsConfigMap, mappingKeys)
 
+    open fun printInvalidTopics() {}
+
 }
 
 object StreamsEventSinkFactory {

--- a/consumer/src/main/kotlin/streams/StreamsEventSinkExtensionFactory.kt
+++ b/consumer/src/main/kotlin/streams/StreamsEventSinkExtensionFactory.kt
@@ -83,6 +83,7 @@ class StreamsEventSinkExtensionFactory : KernelExtensionFactory<StreamsEventSink
             streamsTopicService.clearAll()
             streamsTopicService.setAll(streamsSinkConfiguration.topics)
             eventSink.start()
+            eventSink.printInvalidTopics()
         }
 
         override fun stop() {

--- a/consumer/src/main/kotlin/streams/StreamsSinkConfiguration.kt
+++ b/consumer/src/main/kotlin/streams/StreamsSinkConfiguration.kt
@@ -24,13 +24,15 @@ data class StreamsSinkConfiguration(val enabled: Boolean = false,
             return from(cfg.raw)
         }
 
-        fun from(cfg: Map<String, String>): StreamsSinkConfiguration {
+        fun from(cfg: Map<String, String>, invalidTopics: List<String> = emptyList()): StreamsSinkConfiguration {
             val default = StreamsSinkConfiguration()
             val config = cfg
                     .filterKeys { it.startsWith(StreamsSinkConfigurationConstants.STREAMS_CONFIG_PREFIX) }
                     .mapKeys { it.key.substring(StreamsSinkConfigurationConstants.STREAMS_CONFIG_PREFIX.length) }
 
-            val topics = Topics.from(config, StreamsSinkConfigurationConstants.STREAMS_CONFIG_PREFIX)
+            val topics = Topics.from(config = config,
+                    prefix = StreamsSinkConfigurationConstants.STREAMS_CONFIG_PREFIX,
+                    invalidTopics = invalidTopics)
 
             TopicUtils.validate<RuntimeException>(topics)
 

--- a/consumer/src/main/kotlin/streams/StreamsTopicService.kt
+++ b/consumer/src/main/kotlin/streams/StreamsTopicService.kt
@@ -1,18 +1,13 @@
 package streams
 
-import org.apache.commons.lang3.StringUtils
 import org.neo4j.kernel.impl.core.EmbeddedProxySPI
 import org.neo4j.kernel.impl.core.GraphProperties
 import org.neo4j.kernel.internal.GraphDatabaseAPI
 import streams.serialization.JSONUtils
 import streams.service.STREAMS_TOPIC_KEY
 import streams.service.TopicType
-import streams.service.TopicTypeGroup
-import streams.service.sink.strategy.NodePatternConfiguration
-import streams.service.sink.strategy.RelationshipPatternConfiguration
-import streams.utils.Neo4jUtils
-import streams.service.TopicUtils
 import streams.service.Topics
+import streams.utils.Neo4jUtils
 
 class StreamsTopicService(private val db: GraphDatabaseAPI) {
     private val properties: GraphProperties = db.dependencyResolver.resolveDependency(EmbeddedProxySPI::class.java).newGraphPropertiesProxy()

--- a/consumer/src/main/kotlin/streams/kafka/KafkaAutoCommitEventConsumer.kt
+++ b/consumer/src/main/kotlin/streams/kafka/KafkaAutoCommitEventConsumer.kt
@@ -42,6 +42,8 @@ open class KafkaAutoCommitEventConsumer(private val config: KafkaSinkConfigurati
                                         private val log: Log,
                                         private val errorService: ErrorService): StreamsEventConsumer(log, errorService) {
 
+    override fun invalidTopics(): List<String> = config.streamsSinkConfiguration.topics.invalid
+
     private var isSeekSet = false
 
     val consumer: KafkaConsumer<*, *> = when {

--- a/consumer/src/main/kotlin/streams/kafka/KafkaEventSink.kt
+++ b/consumer/src/main/kotlin/streams/kafka/KafkaEventSink.kt
@@ -1,14 +1,29 @@
 package streams.kafka
 
-import kotlinx.coroutines.*
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import org.apache.kafka.clients.consumer.ConsumerConfig
 import org.neo4j.kernel.configuration.Config
 import org.neo4j.kernel.internal.GraphDatabaseAPI
 import org.neo4j.logging.Log
-import streams.*
+import streams.StreamsEventConsumer
+import streams.StreamsEventConsumerFactory
+import streams.StreamsEventSink
+import streams.StreamsEventSinkQueryExecution
+import streams.StreamsSinkConfiguration
+import streams.StreamsSinkConfigurationConstants
+import streams.StreamsTopicService
 import streams.service.errors.ErrorService
 import streams.service.errors.KafkaErrorService
+import streams.utils.KafkaValidationUtils.getInvalidTopicsError
 import streams.utils.Neo4jUtils
+import streams.utils.StreamsUtils
 import java.util.concurrent.TimeUnit
 
 
@@ -115,6 +130,14 @@ class KafkaEventSink(private val config: Config,
                 eventConsumer.stop()
             }
         }
+    }
+
+    override fun printInvalidTopics() {
+        StreamsUtils.ignoreExceptions({
+            if (eventConsumer.invalidTopics().isNotEmpty()) {
+                log.warn(getInvalidTopicsError(eventConsumer.invalidTopics()))
+            }
+        }, UninitializedPropertyAccessException::class.java)
     }
 
 }

--- a/consumer/src/test/kotlin/integrations/kafka/KafkaEventSinkCommit.kt
+++ b/consumer/src/test/kotlin/integrations/kafka/KafkaEventSinkCommit.kt
@@ -1,5 +1,6 @@
 package integrations.kafka
 
+import integrations.kafka.KafkaTestUtils.createConsumer
 import kotlinx.coroutines.runBlocking
 import org.apache.kafka.clients.consumer.ConsumerConfig
 import org.apache.kafka.clients.producer.ProducerRecord
@@ -32,7 +33,9 @@ class KafkaEventSinkCommit : KafkaEventSinkBase() {
             val query = "MATCH (n:Label) RETURN count(*) AS count"
             val result = db.execute(query).columnAs<Long>("count")
 
-            val kafkaConsumer = createConsumer<String, ByteArray>()
+            val kafkaConsumer = createConsumer<String, ByteArray>(
+                    kafka = KafkaEventSinkSuiteIT.kafka,
+                    schemaRegistry = KafkaEventSinkSuiteIT.schemaRegistry)
             val offsetAndMetadata = kafkaConsumer.committed(TopicPartition(topic, partition))
             kafkaConsumer.close()
 

--- a/consumer/src/test/kotlin/integrations/kafka/KafkaEventSinkDLQ.kt
+++ b/consumer/src/test/kotlin/integrations/kafka/KafkaEventSinkDLQ.kt
@@ -1,5 +1,6 @@
 package integrations.kafka
 
+import integrations.kafka.KafkaTestUtils.createConsumer
 import org.apache.kafka.clients.producer.ProducerRecord
 import org.apache.kafka.common.serialization.ByteArrayDeserializer
 import org.hamcrest.Matchers
@@ -27,9 +28,12 @@ class KafkaEventSinkDLQ : KafkaEventSinkBase() {
 
         var producerRecord = ProducerRecord(topic, UUID.randomUUID().toString(), JSONUtils.writeValueAsBytes(data))
         kafkaProducer.send(producerRecord).get()
-        val dlqConsumer = createConsumer<ByteArray, ByteArray>(ByteArrayDeserializer::class.java.name,
-                ByteArrayDeserializer::class.java.name,
-                dlqTopic)
+        val dlqConsumer = createConsumer<ByteArray, ByteArray>(
+                kafka = KafkaEventSinkSuiteIT.kafka,
+                schemaRegistry = KafkaEventSinkSuiteIT.schemaRegistry,
+                keyDeserializer = ByteArrayDeserializer::class.java.name,
+                valueDeserializer = ByteArrayDeserializer::class.java.name,
+                topics = *arrayOf(dlqTopic))
 
         dlqConsumer.let {
             Assert.assertEventually(ThrowingSupplier<Boolean, Exception> {
@@ -66,9 +70,12 @@ class KafkaEventSinkDLQ : KafkaEventSinkBase() {
         var producerRecord = ProducerRecord(topic, UUID.randomUUID().toString(),
                 data.toByteArray())
         kafkaProducer.send(producerRecord).get()
-        val dlqConsumer = createConsumer<ByteArray, ByteArray>(ByteArrayDeserializer::class.java.name,
-                ByteArrayDeserializer::class.java.name,
-                dlqTopic)
+        val dlqConsumer = createConsumer<ByteArray, ByteArray>(
+                kafka = KafkaEventSinkSuiteIT.kafka,
+                schemaRegistry = KafkaEventSinkSuiteIT.schemaRegistry,
+                keyDeserializer = ByteArrayDeserializer::class.java.name,
+                valueDeserializer = ByteArrayDeserializer::class.java.name,
+                topics = *arrayOf(dlqTopic))
         dlqConsumer.let {
             Assert.assertEventually(ThrowingSupplier<Boolean, Exception> {
                 val query = """

--- a/consumer/src/test/kotlin/integrations/kafka/KafkaEventSinkNoConfigurationIT.kt
+++ b/consumer/src/test/kotlin/integrations/kafka/KafkaEventSinkNoConfigurationIT.kt
@@ -23,7 +23,7 @@ class KafkaEventSinkNoConfigurationIT {
     private val topic = "no-config"
 
     @Test
-    fun `the db should start even with no bootstrap servers provided()`() {
+    fun `the db should start even with no bootstrap servers provided`() {
         val db = TestGraphDatabaseFactory()
                 .newImpermanentDatabaseBuilder()
                 .setConfig("kafka.bootstrap.servers", "")
@@ -35,7 +35,7 @@ class KafkaEventSinkNoConfigurationIT {
     }
 
     @Test
-    fun `the db should start even with AVRO serializers and no schema registry url provided()`() {
+    fun `the db should start even with AVRO serializers and no schema registry url provided`() {
         val fakeWebServer = FakeWebServer()
         fakeWebServer.start()
         val url = fakeWebServer.getUrl().replace("http://", "")

--- a/consumer/src/test/kotlin/integrations/kafka/KafkaEventSinkNoTopicAutocreationIT.kt
+++ b/consumer/src/test/kotlin/integrations/kafka/KafkaEventSinkNoTopicAutocreationIT.kt
@@ -1,0 +1,101 @@
+package integrations.kafka
+
+import integrations.kafka.KafkaTestUtils.createProducer
+import org.apache.kafka.clients.admin.AdminClient
+import org.apache.kafka.clients.admin.NewTopic
+import org.apache.kafka.clients.producer.KafkaProducer
+import org.apache.kafka.clients.producer.ProducerRecord
+import org.hamcrest.Matchers
+import org.junit.AfterClass
+import org.junit.Assume
+import org.junit.BeforeClass
+import org.junit.Test
+import org.neo4j.function.ThrowingSupplier
+import org.neo4j.kernel.internal.GraphDatabaseAPI
+import org.neo4j.test.TestGraphDatabaseFactory
+import org.neo4j.test.assertion.Assert
+import org.testcontainers.containers.KafkaContainer
+import streams.serialization.JSONUtils
+import streams.utils.StreamsUtils
+import java.util.*
+import java.util.concurrent.TimeUnit
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class KafkaEventSinkNoTopicAutoCreationIT {
+    companion object {
+        /**
+         * Kafka TestContainers uses Confluent OSS images.
+         * We need to keep in mind which is the right Confluent Platform version for the Kafka version this project uses
+         *
+         * Confluent Platform | Apache Kafka
+         *                    |
+         * 4.0.x	          | 1.0.x
+         * 4.1.x	          | 1.1.x
+         * 5.0.x	          | 2.0.x
+         *
+         * Please see also https://docs.confluent.io/current/installation/versions-interoperability.html#cp-and-apache-kafka-compatibility
+         */
+        private const val confluentPlatformVersion = "4.0.2"
+        @JvmStatic
+        lateinit var kafka: KafkaContainer
+
+        @BeforeClass
+        @JvmStatic
+        fun setUpContainer() {
+            var exists = false
+            StreamsUtils.ignoreExceptions({
+                kafka = KafkaContainer(confluentPlatformVersion)
+                kafka.withEnv("KAFKA_AUTO_CREATE_TOPICS_ENABLE", "false")
+                kafka.start()
+                exists = true
+            }, IllegalStateException::class.java)
+            Assume.assumeTrue("Kafka container has to exist", exists)
+            Assume.assumeTrue("Kafka must be running", kafka.isRunning)
+        }
+
+        @AfterClass
+        @JvmStatic
+        fun tearDownContainer() {
+            StreamsUtils.ignoreExceptions({
+                kafka.stop()
+            }, UninitializedPropertyAccessException::class.java)
+        }
+    }
+
+    @Test
+    fun `should consume only the registered topic`() {
+        // given
+        val topic = "shouldWriteCypherQuery"
+        val client = AdminClient.create(mapOf("bootstrap.servers" to "localhost:" + kafka.firstMappedPort))
+        val expectedTopics = listOf(topic)
+        client.createTopics(expectedTopics.map { NewTopic(it, 1, 1) })
+                .all()
+                .get()
+        val topicList = client.listTopics().names().get()
+        val notRegisteredTopic = "notRegistered"
+        assertTrue { topicList.containsAll(expectedTopics.toSet()) && !topicList.contains(notRegisteredTopic) }
+        val db = TestGraphDatabaseFactory()
+                .newImpermanentDatabaseBuilder()
+                .setConfig("kafka.bootstrap.servers", kafka.bootstrapServers)
+                .setConfig("streams.sink.enabled", "true")
+                .setConfig("streams.sink.topic.cypher.$notRegisteredTopic", "MERGE (p:NotRegisteredTopic{name: event.name})")
+                .setConfig("streams.sink.topic.cypher.$topic", "MERGE (p:Person{name: event.name})")
+                .newGraphDatabase() as GraphDatabaseAPI
+        val kafkaProducer: KafkaProducer<String, ByteArray> = createProducer(kafka = kafka)
+
+        // when
+        val data = mapOf<String, Any>("name" to "Andrea")
+        val producerRecord = ProducerRecord(topic, UUID.randomUUID().toString(), JSONUtils.writeValueAsBytes(data))
+        kafkaProducer.send(producerRecord).get()
+
+        // then
+        Assert.assertEventually(ThrowingSupplier<Boolean, Exception> {
+            val count = db.execute("MATCH (n:Person) RETURN COUNT(n) AS count")
+                    .columnAs<Long>("count")
+                    .next()
+            val topics = client.listTopics().names().get()
+            count == 1L && !topics.contains(notRegisteredTopic)
+        }, Matchers.equalTo(true), 30, TimeUnit.SECONDS)
+    }
+}

--- a/consumer/src/test/kotlin/integrations/kafka/KafkaStreamsSinkProcedures.kt
+++ b/consumer/src/test/kotlin/integrations/kafka/KafkaStreamsSinkProcedures.kt
@@ -1,5 +1,6 @@
 package integrations.kafka
 
+import integrations.kafka.KafkaTestUtils.createConsumer
 import io.confluent.kafka.serializers.KafkaAvroDeserializer
 import kotlinx.coroutines.*
 import org.apache.avro.SchemaBuilder
@@ -200,7 +201,9 @@ class KafkaStreamsSinkProcedures : KafkaEventSinkBase() {
         assertTrue { searchResultMap.containsKey("count") }
         assertEquals(1L, searchResultMap["count"])
 
-        val kafkaConsumer = createConsumer<String, ByteArray>()
+        val kafkaConsumer = createConsumer<ByteArray, ByteArray>(
+                kafka = KafkaEventSinkSuiteIT.kafka,
+                schemaRegistry = KafkaEventSinkSuiteIT.schemaRegistry)
         val offsetAndMetadata = kafkaConsumer.committed(TopicPartition(topic, partition))
         assertNull(offsetAndMetadata)
     }

--- a/consumer/src/test/kotlin/integrations/kafka/KafkaTestUtils.kt
+++ b/consumer/src/test/kotlin/integrations/kafka/KafkaTestUtils.kt
@@ -1,0 +1,53 @@
+package integrations.kafka
+
+import org.apache.kafka.clients.consumer.ConsumerConfig
+import org.apache.kafka.clients.consumer.KafkaConsumer
+import org.apache.kafka.clients.producer.KafkaProducer
+import org.apache.kafka.clients.producer.ProducerConfig
+import org.apache.kafka.common.serialization.ByteArrayDeserializer
+import org.apache.kafka.common.serialization.ByteArraySerializer
+import org.apache.kafka.common.serialization.StringDeserializer
+import org.apache.kafka.common.serialization.StringSerializer
+import org.testcontainers.containers.KafkaContainer
+import java.util.*
+
+object KafkaTestUtils {
+    fun <K, V> createConsumer(kafka: KafkaContainer,
+                              schemaRegistry: SchemaRegistryContainer?,
+                              keyDeserializer: String = StringDeserializer::class.java.name,
+                              valueDeserializer: String = ByteArrayDeserializer::class.java.name,
+                              vararg topics: String): KafkaConsumer<K, V> {
+        val props = Properties()
+        props[ProducerConfig.BOOTSTRAP_SERVERS_CONFIG] = kafka.bootstrapServers
+        props["zookeeper.connect"] = kafka.envMap["KAFKA_ZOOKEEPER_CONNECT"]
+        props["group.id"] = "neo4j"
+        props["enable.auto.commit"] = "true"
+        props[ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG] = keyDeserializer
+        props[ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG] = valueDeserializer
+        props["auto.offset.reset"] = "earliest"
+        if (schemaRegistry != null) {
+            props["schema.registry.url"] = schemaRegistry.getSchemaRegistryUrl()
+        }
+        val consumer = KafkaConsumer<K, V>(props)
+        if (!topics.isNullOrEmpty()) {
+            consumer.subscribe(topics.toList())
+        }
+        return consumer
+    }
+
+    fun <K, V> createProducer(kafka: KafkaContainer,
+                              schemaRegistry: SchemaRegistryContainer? = null,
+                              keySerializer: String = StringSerializer::class.java.name,
+                              valueSerializer: String = ByteArraySerializer::class.java.name): KafkaProducer<K, V> {
+        val props = Properties()
+        props[ProducerConfig.BOOTSTRAP_SERVERS_CONFIG] = kafka.bootstrapServers
+        props["zookeeper.connect"] = kafka.envMap["KAFKA_ZOOKEEPER_CONNECT"]
+        props["group.id"] = "neo4j"
+        props[ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG] = keySerializer
+        props[ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG] = valueSerializer
+        if (schemaRegistry != null) {
+            props["schema.registry.url"] = schemaRegistry.getSchemaRegistryUrl()
+        }
+        return KafkaProducer(props)
+    }
+}

--- a/doc/asciidoc/producer/configuration.adoc
+++ b/doc/asciidoc/producer/configuration.adoc
@@ -15,6 +15,7 @@ kafka.connection.timeout.ms=10000
 kafka.replication=1
 kafka.linger.ms=1
 kafka.transactional.id=
+kafka.topic.discovery.polling.interval=300000
 
 streams.source.topic.nodes.<TOPIC_NAME>=<PATTERN>
 streams.source.topic.relationships.<TOPIC_NAME>=<PATTERN>
@@ -25,3 +26,10 @@ streams.source.schema.polling.interval=<MILLIS, the polling interval for getting
 Note: To use the Kafka transactions please set `kafka.transactional.id` and `kafka.acks` properly
 
 See the https://kafka.apache.org/documentation/#brokerconfigs[Apache Kafka documentation] for details on these settings.
+
+In case you Kafka broker is configured with `auto.create.topics.enable` to `false`,
+all the messages sent to topics that don't exist are discarded;
+this because the `KafkaProducer.send()` method blocks the execution, as explained in https://issues.apache.org/jira/browse/KAFKA-3539[KAFKA-3539].
+You can tune the custom property `kafka.topic.discovery.polling.interval` in order to
+periodically check for new topics into the Kafka cluster so the plugin will be able
+to send events to the defined topics.

--- a/doc/asciidoc/producer/index.adoc
+++ b/doc/asciidoc/producer/index.adoc
@@ -14,7 +14,7 @@ Is the transaction event handler events that sends data to a Kafka topic
 
 === Configuration
 
-include::configuration.adoc[]
+include::configurqation.adoc[]
 
 [[producer-patterns]]
 === Patterns

--- a/producer/src/main/kotlin/streams/StreamsEventRouter.kt
+++ b/producer/src/main/kotlin/streams/StreamsEventRouter.kt
@@ -13,6 +13,8 @@ abstract class StreamsEventRouter(val logService: LogService?, val config: Confi
 
     abstract fun stop()
 
+    open fun printInvalidTopics() {}
+
 }
 
 

--- a/producer/src/main/kotlin/streams/StreamsEventRouterConfiguration.kt
+++ b/producer/src/main/kotlin/streams/StreamsEventRouterConfiguration.kt
@@ -30,6 +30,13 @@ data class StreamsEventRouterConfiguration(val enabled: Boolean = true,
                                            val nodeRouting: List<NodeRoutingConfiguration> = listOf(NodeRoutingConfiguration()),
                                            val relRouting: List<RelationshipRoutingConfiguration> = listOf(RelationshipRoutingConfiguration()),
                                            val schemaPollingInterval: Long = 300000) {
+
+    fun allTopics(): List<String> {
+        val nodeTopics = nodeRouting.map { it.topic }
+        val relTopics = relRouting.map { it.topic }
+        return nodeTopics + relTopics
+    }
+
     companion object {
         fun from(config: Map<String, String>): StreamsEventRouterConfiguration {
             val nodeRouting = filterMap<NodeRoutingConfiguration>(config = config,

--- a/producer/src/main/kotlin/streams/StreamsExtensionFactory.kt
+++ b/producer/src/main/kotlin/streams/StreamsExtensionFactory.kt
@@ -46,6 +46,7 @@ class StreamsEventRouterLifecycle(val db: GraphDatabaseAPI, val configuration: C
             StreamsProcedures.registerEventRouter(eventRouter = streamHandler)
             StreamsProcedures.registerEventRouterConfiguration(eventRouterConfiguration = streamsEventRouterConfiguration)
             streamHandler.start()
+            streamHandler.printInvalidTopics()
             registerTransactionEventHandler()
             streamsLog.info("Streams Source module initialised")
         } catch (e: Exception) {

--- a/producer/src/main/kotlin/streams/kafka/KafkaAdminService.kt
+++ b/producer/src/main/kotlin/streams/kafka/KafkaAdminService.kt
@@ -1,0 +1,48 @@
+package streams.kafka
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import org.apache.kafka.clients.admin.AdminClient
+import streams.utils.KafkaValidationUtils
+import streams.utils.StreamsUtils
+import java.util.Collections
+import java.util.concurrent.ConcurrentHashMap
+
+class KafkaAdminService(private val props: KafkaConfiguration, private val allTopics: List<String>) {
+    private val client = AdminClient.create(props.asProperties())
+    private val kafkaTopics: MutableSet<String> = Collections.newSetFromMap(ConcurrentHashMap<String, Boolean>())
+    private val isAutoCreateTopicsEnabled = KafkaValidationUtils.isAutoCreateTopicsEnabled(client)
+    private lateinit var job: Job
+
+    fun start() {
+        if (!isAutoCreateTopicsEnabled) {
+            job = GlobalScope.launch(Dispatchers.IO) {
+                while (isActive) {
+                    kafkaTopics += client.listTopics().names().get()
+                    delay(props.topicDiscoveryPollingInterval)
+                }
+            }
+        }
+    }
+
+    fun stop() {
+        StreamsUtils.ignoreExceptions({
+            runBlocking {
+                job.cancelAndJoin()
+            }
+        }, UninitializedPropertyAccessException::class.java)
+    }
+
+    fun isValidTopic(topic: String) = when (isAutoCreateTopicsEnabled) {
+        true -> true
+        else -> kafkaTopics.contains(topic)
+    }
+
+    fun getInvalidTopics() = KafkaValidationUtils.getInvalidTopics(client, allTopics)
+}

--- a/producer/src/test/kotlin/streams/integrations/KafkaEventRouterIT.kt
+++ b/producer/src/test/kotlin/streams/integrations/KafkaEventRouterIT.kt
@@ -2,10 +2,6 @@ package streams.integrations
 
 import kotlinx.coroutines.async
 import kotlinx.coroutines.runBlocking
-import org.apache.kafka.clients.consumer.ConsumerConfig
-import org.apache.kafka.clients.consumer.KafkaConsumer
-import org.apache.kafka.common.serialization.ByteArrayDeserializer
-import org.apache.kafka.common.serialization.StringDeserializer
 import org.junit.*
 import org.junit.rules.TestName
 import org.neo4j.kernel.impl.proc.Procedures
@@ -14,10 +10,10 @@ import org.neo4j.test.TestGraphDatabaseFactory
 import org.testcontainers.containers.KafkaContainer
 import streams.events.*
 import streams.kafka.KafkaConfiguration
+import streams.kafka.KafkaTestUtils.createConsumer
 import streams.procedures.StreamsProcedures
 import streams.serialization.JSONUtils
 import streams.utils.StreamsUtils
-import java.lang.RuntimeException
 import kotlin.test.assertEquals
 
 @Suppress("UNCHECKED_CAST", "DEPRECATION")
@@ -174,16 +170,6 @@ class KafkaEventRouterIT {
             }
         })
         consumer.close()
-    }
-
-    private fun createConsumer(config: KafkaConfiguration): KafkaConsumer<String, ByteArray> {
-        val props = config.asProperties()
-        props["group.id"] = "neo4j"
-        props["enable.auto.commit"] = "true"
-        props[ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG] = StringDeserializer::class.java
-        props[ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG] = ByteArrayDeserializer::class.java
-        props["auto.offset.reset"] = "earliest"
-        return KafkaConsumer(props)
     }
 
     @Test

--- a/producer/src/test/kotlin/streams/integrations/KafkaEventRouterNoTopicAutocreationIT.kt
+++ b/producer/src/test/kotlin/streams/integrations/KafkaEventRouterNoTopicAutocreationIT.kt
@@ -1,0 +1,123 @@
+package streams.integrations
+
+import kotlinx.coroutines.async
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import org.apache.kafka.clients.admin.AdminClient
+import org.apache.kafka.clients.admin.NewTopic
+import org.junit.AfterClass
+import org.junit.Assume
+import org.junit.BeforeClass
+import org.junit.Test
+import org.neo4j.kernel.internal.GraphDatabaseAPI
+import org.neo4j.test.TestGraphDatabaseFactory
+import org.testcontainers.containers.KafkaContainer
+import streams.kafka.KafkaConfiguration
+import streams.kafka.KafkaTestUtils
+import streams.utils.StreamsUtils
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+@Suppress("UNCHECKED_CAST", "DEPRECATION")
+class KafkaEventRouterNoTopicAutocreationIT {
+
+    companion object {
+        /**
+         * Kafka TestContainers uses Confluent OSS images.
+         * We need to keep in mind which is the right Confluent Platform version for the Kafka version this project uses
+         *
+         * Confluent Platform | Apache Kafka
+         *                    |
+         * 4.0.x	          | 1.0.x
+         * 4.1.x	          | 1.1.x
+         * 5.0.x	          | 2.0.x
+         *
+         * Please see also https://docs.confluent.io/current/installation/versions-interoperability.html#cp-and-apache-kafka-compatibility
+         */
+        private const val confluentPlatformVersion = "4.0.2"
+        @JvmStatic
+        lateinit var kafka: KafkaContainer
+
+        @BeforeClass @JvmStatic
+        fun setUpContainer() {
+            var exists = false
+            StreamsUtils.ignoreExceptions({
+                kafka = KafkaContainer(confluentPlatformVersion)
+                kafka.withEnv("KAFKA_AUTO_CREATE_TOPICS_ENABLE", "false")
+                kafka.start()
+                exists = true
+            }, IllegalStateException::class.java)
+            Assume.assumeTrue("Kafka container has to exist", exists)
+            Assume.assumeTrue("Kafka must be running", kafka.isRunning)
+
+            val client = AdminClient.create(mapOf("bootstrap.servers" to "localhost:" + kafka.firstMappedPort))
+            val topicsToCreate = listOf("person")
+            client.createTopics(topicsToCreate.map { NewTopic(it, 1, 1) })
+                    .all()
+                    .get()
+        }
+
+        @AfterClass @JvmStatic
+        fun tearDownContainer() {
+            StreamsUtils.ignoreExceptions({
+                kafka.stop()
+            }, UninitializedPropertyAccessException::class.java)
+        }
+    }
+
+    @Test
+    fun `should start even with no topic created`() {
+        // when
+        val db = TestGraphDatabaseFactory()
+                .newImpermanentDatabaseBuilder()
+                .setConfig("kafka.bootstrap.servers", kafka.bootstrapServers)
+                .setConfig("streams.source.topic.nodes.personNotDefined", "Person{*}")
+                .newGraphDatabase() as GraphDatabaseAPI
+
+        // then
+        val count = db.execute("MATCH (n) RETURN COUNT(n) AS count")
+                .columnAs<Long>("count")
+                .next()
+        assertEquals(0L, count)
+    }
+
+    @Test
+    fun `should insert data without hanging`() = runBlocking {
+        // given
+        val personTopic = "person"
+        val customerTopic = "customer"
+        val neo4jTopic = "neo4j"
+        val expectedTopics = listOf(personTopic, customerTopic, neo4jTopic)
+        val db = TestGraphDatabaseFactory()
+                .newImpermanentDatabaseBuilder()
+                .setConfig("kafka.bootstrap.servers", kafka.bootstrapServers)
+                .setConfig("streams.source.topic.nodes.$personTopic", "Person{*}")
+                .setConfig("streams.source.topic.nodes.$customerTopic", "Customer{*}")
+                .newGraphDatabase() as GraphDatabaseAPI
+        // we create a new node an check that the source plugin is working
+        db.execute("CREATE (p:Person{id: 1})").close()
+        val config = KafkaConfiguration(bootstrapServers = kafka.bootstrapServers)
+        val consumer = KafkaTestUtils.createConsumer(config)
+        consumer.subscribe(expectedTopics)
+        // the consumer consumes the message from the topic
+        consumer.use {
+            val records = it.poll(5000)
+            assertEquals(1, records.count())
+        }
+
+        // when
+        val waitFor = 10000L
+        withTimeout(waitFor) { // n.b. the default value for `max.block.ms` is 60 seconds so if exceeds `waitFor` throws a CancellationException
+            async { db.execute("CREATE (p:Customer{id: 2})").close() }.await()
+        }
+
+        // then
+        val count = db.execute("MATCH (n) RETURN COUNT(n) AS count")
+                .columnAs<Long>("count")
+                .next()
+        assertEquals(2L, count)
+    }
+
+}

--- a/producer/src/test/kotlin/streams/kafka/KafkaConfigurationTest.kt
+++ b/producer/src/test/kotlin/streams/kafka/KafkaConfigurationTest.kt
@@ -22,7 +22,8 @@ class KafkaConfigurationTest {
                 "kafka.replication" to 2,
                 "kafka.transactional.id" to "foo",
                 "kafka.linger.ms" to 10,
-                "kafka.fetch.min.bytes" to 1234)
+                "kafka.fetch.min.bytes" to 1234,
+                "kafka.topic.discovery.polling.interval" to 0L)
 
         val kafkaConfig = KafkaConfiguration.create(map.mapValues { it.value.toString() })
 
@@ -46,5 +47,6 @@ class KafkaConfigurationTest {
         assertEquals(map["kafka.transactional.id"], properties["transactional.id"])
         assertEquals(map["kafka.linger.ms"], properties["linger.ms"])
         assertEquals(map["kafka.fetch.min.bytes"].toString(), properties["fetch.min.bytes"])
+        assertEquals(map["kafka.topic.discovery.polling.interval"], properties["topic.discovery.polling.interval"])
     }
 }

--- a/producer/src/test/kotlin/streams/kafka/KafkaTestUtils.kt
+++ b/producer/src/test/kotlin/streams/kafka/KafkaTestUtils.kt
@@ -1,0 +1,19 @@
+package streams.kafka
+
+import org.apache.kafka.clients.consumer.ConsumerConfig
+import org.apache.kafka.clients.consumer.KafkaConsumer
+import org.apache.kafka.common.serialization.ByteArrayDeserializer
+import org.apache.kafka.common.serialization.StringDeserializer
+
+object KafkaTestUtils {
+    fun createConsumer(config: KafkaConfiguration): KafkaConsumer<String, ByteArray> {
+        val props = config.asProperties()
+        props["group.id"] = "neo4j"
+        props["enable.auto.commit"] = "true"
+        props[ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG] = StringDeserializer::class.java
+        props[ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG] = ByteArrayDeserializer::class.java
+        props["auto.offset.reset"] = "earliest"
+        return KafkaConsumer(props)
+    }
+
+}


### PR DESCRIPTION
Fixes #252

This PR simply provides a discard mechanism for topics that are not defined in case the Kafka Broker property `auto.create.topics.enable` is set to `false`.

## Proposed Changes (Mandatory)

A brief list of proposed changes in order to fix the issue:

- For the Streams SINK, we just print the `invalid topics` because is not affect by the `block` problem
- For the Streams SOURCE:
  - we created the `KafkaAdminService` class that every `kafka.topic.discovery.polling.interval` checks for new topics into the Kafka Broker
  - the `KafkaEventRouter#sendEvent` method uses the `KafkaAdminService` in order to block the call to `Producer#send` method if the topic is not defined. N.b. in case `auto.create.topics.enable` is set to `true` the check return always `true`.

