### PR TITLE
Fixes an issue with wrong ids value in cdc when updating relationships

### DIFF
--- a/producer/src/main/kotlin/streams/events/PreviousTransactionData.kt
+++ b/producer/src/main/kotlin/streams/events/PreviousTransactionData.kt
@@ -139,7 +139,7 @@ class PreviousTransactionDataBuilder {
                             .withId(it.id.toString())
                             .withName(it.type.name())
                             .withStartNode(it.startNode.id.toString(), startLabels, it.startNode.getProperties(*startNodeKeys))
-                            .withEndNode(it.endNode.id.toString(), endLabels, it.startNode.getProperties(*endNodeKeys))
+                            .withEndNode(it.endNode.id.toString(), endLabels, it.endNode.getProperties(*endNodeKeys))
                             .withBefore(beforeNode)
                             .withAfter(afterNode)
                             .build()


### PR DESCRIPTION
Fixes a bug with wrong ids value in cdc when updating relationships

When updating the relationship, if the properties of startNode and endNode are different,  the `ids` value in `end` of `payload` in the produced cdc data may be empty, this will affect consumer processing

## Proposed Changes (Mandatory)

A brief list of proposed changes in order to fix the issue:

  - The last parameter of the `withEndNode` of the `build` method in the `PreviousTransactionDataBuilder` class should replace `it.startNode.getProperties` with `it.endNode.getProperties`
