### PR TITLE
fixes #249: Correct typo in DLQ property

### DIFF
--- a/common/src/main/kotlin/streams/service/errors/ErrorService.kt
+++ b/common/src/main/kotlin/streams/service/errors/ErrorService.kt
@@ -71,7 +71,7 @@ abstract class ErrorService(private val config: Map<String, Any> = emptyMap()) {
 
 
             "errors.log.enable": true,
-            "errors.deadletterqueue.context.header.enable"=true/false
+            "errors.deadletterqueue.context.headers.enable"=true/false
             "errors.deadletterqueue.topic.name": "test-error-topic",
             "errors.deadletterqueue.topic.replication.factor": 1,
             "errors.log.include.messages": true,
@@ -82,8 +82,8 @@ abstract class ErrorService(private val config: Map<String, Any> = emptyMap()) {
             const val LOG = "errors.log.enable"
             const val LOG_MESSAGES = "errors.log.include.messages"
             const val DLQ_TOPIC = "errors.deadletterqueue.topic.name"
-            const val DLQ_HEADERS = "errors.deadletterqueue.context.header.enable"
-            const val DLQ_HEADER_PREFIX = "errors.deadletterqueue.context.header.prefix"
+            const val DLQ_HEADERS = "errors.deadletterqueue.context.headers.enable"
+            const val DLQ_HEADER_PREFIX = "errors.deadletterqueue.context.headers.prefix"
             const val DLQ_REPLICATION = "errors.deadletterqueue.topic.replication.factor"
 
             fun from(props: Properties) = from(props.toMap() as Map<String, Any>)

--- a/doc/asciidoc/consumer/index.adoc
+++ b/doc/asciidoc/consumer/index.adoc
@@ -478,8 +478,8 @@ Config Options
 | errors.log.enable | false/true | log errors (default: false)
 | errors.log.include.messages | false/true | log bad messages too (default: false)
 | errors.deadletterqueue.topic.name | topic-name | dead letter queue topic name, if left off no DLQ, default: not set
-| errors.deadletterqueue.context.header.enable | false/true | enrich messages with metadata headers like exception, timestamp, org. topic, org.part, default:false
-| errors.deadletterqueue.context.header.prefix | prefix-text | common prefix for header entries, e.g. `"__streams.errors."` , default: not set
+| errors.deadletterqueue.context.headers.enable | false/true | enrich messages with metadata headers like exception, timestamp, org. topic, org.part, default:false
+| errors.deadletterqueue.context.headers.prefix | prefix-text | common prefix for header entries, e.g. `"__streams.errors."` , default: not set
 | errors.deadletterqueue.topic.replication.factor | 3/1 | replication factor, need to set to 1 for single partition, default:3
 |===
 
@@ -527,7 +527,7 @@ errors.log.include.messages=true
 ----
 errors.tolerance=all
 errors.deadletterqueue.topic.name=my-dlq-topic
-errors.deadletterqueue.context.header.enable=true
+errors.deadletterqueue.context.headers.enable=true
 ----
 
 .Same Settings for Neo4j Server Plugin
@@ -535,7 +535,7 @@ errors.deadletterqueue.context.header.enable=true
 ----
 streams.sink.errors.tolerance=all
 streams.sink.errors.deadletterqueue.topic.name=my-dlq-topic
-streams.sink.errors.deadletterqueue.context.header.enable=true
+streams.sink.errors.deadletterqueue.context.headers.enable=true
 ----
 
 Every published record in the `Dead Letter Queue` contains the original record `Key` and `Value` pairs and optionally the following headers:


### PR DESCRIPTION
Fixes #249

Fixed the typo

## Proposed Changes (Mandatory)

A brief list of proposed changes in order to fix the issue:

  - Fixed the typo