### PR TITLE
Fixes #295: Lower-case and normalize all database names in 4.0 configs

### DIFF
--- a/common/src/main/kotlin/streams/service/Topics.kt
+++ b/common/src/main/kotlin/streams/service/Topics.kt
@@ -45,8 +45,8 @@ data class Topics(val cypherTopics: Map<String, String> = emptyMap(),
     companion object {
         fun from(map: Map<String, Any?>, replacePrefix: Pair<String, String> = ("" to ""), dbName: String = "", invalidTopics: List<String> = emptyList()): Topics {
             val config = map
-                    .filterKeys { if (dbName.isNotBlank()) it.endsWith(".to.$dbName") else !it.contains(".to.") }
-                    .mapKeys { if (dbName.isNotBlank()) it.key.replace(".to.$dbName", "") else it.key }
+                    .filterKeys { if (dbName.isNotBlank()) it.toLowerCase().endsWith(".to.$dbName") else !it.contains(".to.") }
+                    .mapKeys { if (dbName.isNotBlank()) it.key.replace(".to.$dbName", "", true) else it.key }
             val cypherTopicPrefix = TopicType.CYPHER.replaceKeyBy(replacePrefix)
             val sourceIdKey = TopicType.CDC_SOURCE_ID.replaceKeyBy(replacePrefix)
             val schemaKey = TopicType.CDC_SCHEMA.replaceKeyBy(replacePrefix)

--- a/consumer/src/test/kotlin/streams/StreamsSinkConfigurationTest.kt
+++ b/consumer/src/test/kotlin/streams/StreamsSinkConfigurationTest.kt
@@ -105,6 +105,21 @@ class StreamsSinkConfigurationTest {
         assertEquals(customId, streamsSinkConf.sourceIdStrategyConfig.idName)
     }
 
+    @Test
+    fun shouldReturnConfigurationFromMapWithNonLowerCaseDbName() {
+        val topic = "mytopic"
+        val topicKey = "streams.sink.topic.cypher.$topic.to.nonLowerCaseDb"
+        val topicValue = "MERGE (n:Label{ id: event.id })"
+        val config = mapOf(
+                topicKey to topicValue,
+                "streams.sink.enabled" to "false",
+                "streams.sink.enabled.to.nonLowerCaseDb" to "true")
+        streamsConfig.config.putAll(config)
+        val streamsSinkConf = StreamsSinkConfiguration.from(streamsConfig, "nonlowercasedb")
+        assertFalse { streamsSinkConf.enabled }
+        assertEquals(topicValue, streamsSinkConf.topics.cypherTopics[topic])
+    }
+
     @Test(expected = TopicValidationException::class)
     fun shouldFailWithCrossDefinedTopics() {
         val pollingInterval = "10"

--- a/doc/asciidoc/consumer/configuration.adoc
+++ b/doc/asciidoc/consumer/configuration.adoc
@@ -37,13 +37,11 @@ streams.sink.topic.cdc.schema.to.<DB_NAME>=<LIST_OF_TOPICS_SEPARATE_BY_SEMICOLON
 streams.sink.topic.pattern.node.<TOPIC_NAME>.to.<DB_NAME>=<NODE_EXTRACTION_PATTERN>
 streams.sink.topic.pattern.relationship.<TOPIC_NAME>.to.<DB_NAME>=<RELATIONSHIP_EXTRACTION_PATTERN>
 streams.sink.enabled.to.<DB_NAME>=<true/false, default=true>
-streams.procedures.enabled.<DB_NAME>=<true/false, default=true>
 ----
 
 This means that for each db instance you can specify if:
 * use the source connector
 * the routing patterns
-* use the procedures
 
 So if you have a instance name `foo` you can specify a configuration in this way:
 
@@ -54,7 +52,6 @@ streams.sink.topic.cdc.schema.to.foo=<LIST_OF_TOPICS_SEPARATE_BY_SEMICOLON>
 streams.sink.topic.pattern.node.<TOPIC_NAME>.to.foo=<NODE_EXTRACTION_PATTERN>
 streams.sink.topic.pattern.relationship.<TOPIC_NAME>.to.foo=<RELATIONSHIP_EXTRACTION_PATTERN>
 streams.sink.enabled.to.foo=<true/false, default=true>
-streams.procedures.enabled.foo=<true/false, default=true>
 ----
 
 The old properties:
@@ -68,21 +65,22 @@ streams.sink.topic.pattern.relationship.<TOPIC_NAME>=<RELATIONSHIP_EXTRACTION_PA
 streams.sink.enabled=<true/false, default=true>
 ----
 
-are still valid and they refer to Neo4j's default db instance, which is usually called `neo4j`, but can be controlled by separate Neo4j system configuration.
+are still valid and they refer to Neo4j's default db instance, which is usually called `neo4j`, but can be controlled by
+separate Neo4j system configuration.
 
-[abstract]
-.How manage the Neo4j's default db
---
- The default database is controlled by Neo4j's dbms.default_database configuration property so we're being clear about which default database applies for this user.
- Database names are case-sensitive, and must follow Neo4j database naming rules (Reference: https://neo4j.com/docs/operations-manual/current/manage-databases/configuration/#manage-databases-administration)
---
+[NOTE]
+====
+The default database is controlled by Neo4j's *dbms.default_database* configuration property so we're being clear about
+which default database applies for this user.
+Database names are case-insensitive and normalized to lowercase, and must follow Neo4j database naming rules.
+(Reference: https://neo4j.com/docs/operations-manual/current/manage-databases/configuration/#manage-databases-administration)
+====
 
-In particular the following two properties will be used ad default values
-for non-default db instances, in case of the specific configuration params are not provided:
+In particular the following property will be used as default values
+for non-default db instances, in case of the specific configuration params is not provided:
 
 ----
 streams.sink.enabled=<true/false, default=true>
-streams.procedures.enabled=<true/false, default=true>
 ----
 
 This means that if you have Neo4j with 3 db instances:

--- a/doc/asciidoc/procedures/index.adoc
+++ b/doc/asciidoc/procedures/index.adoc
@@ -42,6 +42,43 @@ image::../../images/procedure_not_found.png[title="Neo4j Streams procedure not f
 
 ====
 
+==== Multi Database Support
+
+Neo4j 4.0 Enterprise has https://neo4j.com/docs/operations-manual/4.0/manage-databases/[multi-tenancy support],
+in order to support this feature you can set for each database instance a configuration suffix with the following pattern
+`<DB_NAME>` to the properties in your neo4j.conf file.
+
+So, to enable the Streams procedures the following property should be added:
+
+.neo4j.conf
+[subs="verbatim"]
+----
+streams.procedures.enabled.<DB_NAME>=<true/false, default=true>
+----
+
+So if you have a instance name `foo` you can specify a configuration in this way:
+
+.neo4j.conf
+----
+streams.procedures.enabled.foo=<true/false, default=true>
+----
+
+The old property:
+
+.neo4j.conf
+----
+streams.procedures.enabled=<true/false, default=true>
+----
+
+are still valid and it refers to Neo4j's default db instance.
+
+In particular the following property will be used as default value
+for non-default db instances, in case of the specific configuration params is not provided:
+
+----
+streams.procedures.enabled=<true/false, default=true>
+----
+
 === streams.publish
 
 This procedure allows custom message streaming from Neo4j to the configured environment by using the underlying configured Producer.

--- a/doc/asciidoc/producer/configuration.adoc
+++ b/doc/asciidoc/producer/configuration.adoc
@@ -53,13 +53,11 @@ Following the list of new properties that allows to support multi-tenancy:
 streams.source.topic.nodes.<TOPIC_NAME>.from.<DB_NAME>=<PATTERN>
 streams.source.topic.relationships.<TOPIC_NAME>.from.<DB_NAME>=<PATTERN>
 streams.source.enabled.from.<DB_NAME>=<true/false, default=true>
-streams.procedures.enabled.<DB_NAME>=<true/false, default=true>
 ----
 
 This means that for each db instance you can specify if:
 * use the source connector
 * the routing patterns
-* use the procedures
 
 So if you have a instance name `foo` you can specify a configuration in this way:
 
@@ -67,7 +65,6 @@ So if you have a instance name `foo` you can specify a configuration in this way
 streams.source.topic.nodes.myTopic.from.foo=<PATTERN>
 streams.source.topic.relationships.myTopic.from.foo=<PATTERN>
 streams.source.enabled.from.foo=<true/false, default=true>
-streams.procedures.enabled.foo=<true/false, default=true>
 ----
 
 The old properties:
@@ -81,19 +78,19 @@ streams.procedures.enabled=<true/false, default=true>
 
 are still valid and they refer to Neo4j's default db instance.
 
-[abstract]
-.How manage the Neo4j's default db
---
- The default database is controlled by Neo4j's dbms.default_database configuration property so we're being clear about which default database applies for this user.
- Database names are case-sensitive, and must follow Neo4j database naming rules (Reference: https://neo4j.com/docs/operations-manual/current/manage-databases/configuration/#manage-databases-administration)
---
+[NOTE]
+====
+The default database is controlled by Neo4j's *dbms.default_database* configuration property so we're being clear about
+which default database applies for this user.
+Database names are case-insensitive and normalized to lowercase, and must follow Neo4j database naming rules.
+(Reference: https://neo4j.com/docs/operations-manual/current/manage-databases/configuration/#manage-databases-administration)
+====
 
-In particular the following two properties will be used ad default values
-for non-default db instances, in case of the specific configuration params are not provided:
+In particular the following property will be used as default value
+for non-default db instances, in case of the specific configuration params is not provided:
 
 ----
 streams.source.enabled=<true/false, default=true>
-streams.procedures.enabled=<true/false, default=true>
 ----
 
 This means that if you have Neo4j with 3 db instances:


### PR DESCRIPTION
Fixes #295 

Updated all database names to lower-case and add a note about naming rules for Neo4j database names