### PR TITLE
fixes #306: Unify kotlin-reflect version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -152,6 +152,12 @@
             <version>${kafka.version}</version>
         </dependency>
 
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-reflect</artifactId>
+            <version>${kotlin.version}</version>
+        </dependency>
+
 
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
@@ -163,6 +169,12 @@
             <groupId>com.fasterxml.jackson.module</groupId>
             <artifactId>jackson-module-kotlin</artifactId>
             <version>${jackson.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.jetbrains.kotlin</groupId>
+                    <artifactId>kotlin-reflect</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Fixes #306

As @pecollet has highlighted there are particular situations where the use get the following exception while he tries to install the Kafka Connect Sink:

```
[2020-04-29 09:02:41,586] ERROR WorkerConnector{id=Neo4jSinkConn} Error while starting connector (org.apache.kafka.connect.runtime.WorkerConnector)
java.util.ServiceConfigurationError: kotlin.reflect.jvm.internal.impl.builtins.BuiltInsLoader: Provider kotlin.reflect.jvm.internal.impl.serialization.deserialization.builtins.BuiltInsLoaderImpl not a subtype
at java.util.ServiceLoader.fail(ServiceLoader.java:239)
at java.util.ServiceLoader.access$300(ServiceLoader.java:185)
at java.util.ServiceLoader$LazyIterator.nextService(ServiceLoader.java:376)
at java.util.ServiceLoader$LazyIterator.next(ServiceLoader.java:404)
at java.util.ServiceLoader$1.next(ServiceLoader.java:480)
at kotlin.collections.CollectionsKt___CollectionsKt.first(_Collections.kt:185)
at kotlin.reflect.jvm.internal.impl.builtins.BuiltInsLoader$Companion.<clinit>(BuiltInsLoader.kt:38)
at kotlin.reflect.jvm.internal.impl.builtins.BuiltInsLoader.<clinit>(BuiltInsLoader.kt)
at kotlin.reflect.jvm.internal.impl.builtins.KotlinBuiltIns.createBuiltInsModule(KotlinBuiltIns.java:148)
at kotlin.reflect.jvm.internal.impl.platform.JvmBuiltIns.<init>(JvmBuiltIns.kt:56)
at kotlin.reflect.jvm.internal.impl.platform.JvmBuiltIns.<init>(JvmBuiltIns.kt:31)
at kotlin.reflect.jvm.internal.components.RuntimeModuleData$Companion.create(RuntimeModuleData.kt:57)
at kotlin.reflect.jvm.internal.ModuleByClassLoaderKt.getOrCreateModule(moduleByClassLoader.kt:58)
at kotlin.reflect.jvm.internal.KDeclarationContainerImpl$Data$moduleData$2.invoke(KDeclarationContainerImpl.kt:35)
at kotlin.reflect.jvm.internal.KDeclarationContainerImpl$Data$moduleData$2.invoke(KDeclarationContainerImpl.kt:32)
at kotlin.reflect.jvm.internal.ReflectProperties$LazySoftVal.invoke(ReflectProperties.java:93)
at kotlin.reflect.jvm.internal.ReflectProperties$Val.getValue(ReflectProperties.java:32)
at kotlin.reflect.jvm.internal.KDeclarationContainerImpl$Data.getModuleData(KDeclarationContainerImpl.kt)
at kotlin.reflect.jvm.internal.KClassImpl$Data$descriptor$2.invoke(KClassImpl.kt:46)
at kotlin.reflect.jvm.internal.KClassImpl$Data$descriptor$2.invoke(KClassImpl.kt:43)
at kotlin.reflect.jvm.internal.KClassImpl$Data.getDescriptor(KClassImpl.kt)
at kotlin.reflect.jvm.internal.KClassImpl.getDescriptor(KClassImpl.kt:172)
at kotlin.reflect.jvm.internal.KClassImpl.getConstructorDescriptors(KClassImpl.kt:186)
at kotlin.reflect.jvm.internal.KClassImpl$Data$constructors$2.invoke(KClassImpl.kt:90)
at kotlin.reflect.jvm.internal.KClassImpl$Data$constructors$2.invoke(KClassImpl.kt:43)
at kotlin.reflect.jvm.internal.KClassImpl$Data.getConstructors(KClassImpl.kt)
at kotlin.reflect.jvm.internal.KClassImpl.getConstructors(KClassImpl.kt:222)
at streams.kafka.connect.sink.Neo4jSinkConnectorConfig.validateAllTopics(Neo4jSinkConnectorConfig.kt:347)
at streams.kafka.connect.sink.Neo4jSinkConnectorConfig.<init>(Neo4jSinkConnectorConfig.kt:111)
at streams.kafka.connect.sink.Neo4jSinkConnector.start(Neo4jSinkConnector.kt:25)
at org.apache.kafka.connect.runtime.WorkerConnector.doStart(WorkerConnector.java:110)
at org.apache.kafka.connect.runtime.WorkerConnector.start(WorkerConnector.java:135)
at org.apache.kafka.connect.runtime.WorkerConnector.transitionTo(WorkerConnector.java:195)
at org.apache.kafka.connect.runtime.Worker.startConnector(Worker.java:257)
at org.apache.kafka.connect.runtime.distributed.DistributedHerder.startConnector(DistributedHerder.java:1190)
at org.apache.kafka.connect.runtime.distributed.DistributedHerder.access$1300(DistributedHerder.java:126)
at org.apache.kafka.connect.runtime.distributed.DistributedHerder$14.call(DistributedHerder.java:1206)
at org.apache.kafka.connect.runtime.distributed.DistributedHerder$14.call(DistributedHerder.java:1202)
at java.util.concurrent.FutureTask.run(FutureTask.java:266)
at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
at java.lang.Thread.run(Thread.java:748)
```