### PR TITLE
add the sink lifecycle procedures

### DIFF
--- a/common/src/main/kotlin/streams/events/StreamsPluginStatus.kt
+++ b/common/src/main/kotlin/streams/events/StreamsPluginStatus.kt
@@ -1,0 +1,3 @@
+package streams.events
+
+enum class StreamsPluginStatus { RUNNING, STOPPED, UNKNOWN }

--- a/common/src/main/kotlin/streams/utils/Neo4jUtils.kt
+++ b/common/src/main/kotlin/streams/utils/Neo4jUtils.kt
@@ -14,7 +14,7 @@ import kotlin.streams.toList
 
 object Neo4jUtils {
     @JvmStatic val LEADER = "LEADER"
-    fun isWriteableInstance(db: GraphDatabaseAPI): Boolean {
+    fun isWriteableInstance(db: GraphDatabaseAPI, isCluster: Boolean = false): Boolean {
         try {
             val isSlave = StreamsUtils.ignoreExceptions(
                     {
@@ -26,10 +26,7 @@ object Neo4jUtils {
                 return false
             }
 
-            val hasProc = db.execute("""CALL dbms.procedures() YIELD name
-                    |WHERE name = 'dbms.cluster.role'
-                    |RETURN name""".trimMargin()).hasNext()
-            return if (hasProc) {
+            return if (isCluster) {
                 val role = db.execute("CALL dbms.cluster.role() YIELD role RETURN role").columnAs<String>("role").next()
                 return role.equals(LEADER, ignoreCase = true)
             } else {

--- a/common/src/main/kotlin/streams/utils/Neo4jUtils.kt
+++ b/common/src/main/kotlin/streams/utils/Neo4jUtils.kt
@@ -57,6 +57,19 @@ object Neo4jUtils {
         }
     }
 
+    fun hasApoc(db: GraphDatabaseAPI): Boolean {
+        try {
+            db.execute("RETURN apoc.version() AS version").columnAs<String>("version").next()
+            return true
+        } catch (e: QueryExecutionException) {
+            if (e.statusCode.equals("Neo.ClientError.Statement.SyntaxError", ignoreCase = true)
+                    && e.message!!.contains("Unknown function", ignoreCase = true)) {
+                return false
+            }
+            throw e
+        }
+    }
+
     fun clusterHasLeader(db: GraphDatabaseAPI): Boolean {
         try {
             return db.execute("""

--- a/common/src/main/kotlin/streams/utils/StreamsUtils.kt
+++ b/common/src/main/kotlin/streams/utils/StreamsUtils.kt
@@ -1,5 +1,8 @@
 package streams.utils
 
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.delay
+
 object StreamsUtils {
 
     const val UNWIND: String = "UNWIND {events} AS event"
@@ -20,6 +23,16 @@ object StreamsUtils {
                 else -> throw e
             }
         }
+    }
+
+    fun blockUntilTrueOrTimeout(timeout: Long, delay: Long = 1000, action: () -> Boolean): Boolean = runBlocking {
+        val start = System.currentTimeMillis()
+        var success = action()
+        while (System.currentTimeMillis() - start < timeout && !success) {
+            delay(delay)
+            success = action()
+        }
+        success
     }
 
 }

--- a/common/src/test/kotlin/streams/utils/Neo4jUtilsTest.kt
+++ b/common/src/test/kotlin/streams/utils/Neo4jUtilsTest.kt
@@ -37,4 +37,9 @@ class Neo4jUtilsTest {
         assertFalse { isEnterprise }
     }
 
+    @Test
+    fun `should not have APOC`() {
+        assertFalse { Neo4jUtils.hasApoc(db) }
+    }
+
 }

--- a/consumer/src/main/kotlin/streams/StreamsEventSink.kt
+++ b/consumer/src/main/kotlin/streams/StreamsEventSink.kt
@@ -3,6 +3,7 @@ package streams
 import org.neo4j.kernel.configuration.Config
 import org.neo4j.kernel.internal.GraphDatabaseAPI
 import org.neo4j.logging.Log
+import streams.events.StreamsPluginStatus
 
 abstract class StreamsEventSink(private val config: Config,
                                 private val queryExecution: StreamsEventSinkQueryExecution,
@@ -22,6 +23,8 @@ abstract class StreamsEventSink(private val config: Config,
     open fun getEventSinkConfigMapper(): StreamsEventSinkConfigMapper = StreamsEventSinkConfigMapper(streamsConfigMap, mappingKeys)
 
     open fun printInvalidTopics() {}
+
+    abstract fun status(): StreamsPluginStatus
 
 }
 

--- a/consumer/src/main/kotlin/streams/StreamsEventSinkExtensionFactory.kt
+++ b/consumer/src/main/kotlin/streams/StreamsEventSinkExtensionFactory.kt
@@ -72,6 +72,7 @@ class StreamsEventSinkExtensionFactory : KernelExtensionFactory<StreamsEventSink
                             StreamsSinkProcedures.registerStreamsSinkConfiguration(streamsSinkConfiguration)
                             StreamsSinkProcedures.registerStreamsEventConsumerFactory(eventSink.getEventConsumerFactory())
                             StreamsSinkProcedures.registerStreamsEventSinkConfigMapper(eventSink.getEventSinkConfigMapper())
+                            StreamsSinkProcedures.registerStreamsEventSink(eventSink)
                         } catch (e: Exception) {
                             streamsLog.error("Error initializing the streaming sink:", e)
                         }

--- a/consumer/src/main/kotlin/streams/StreamsEventSinkExtensionFactory.kt
+++ b/consumer/src/main/kotlin/streams/StreamsEventSinkExtensionFactory.kt
@@ -88,7 +88,7 @@ class StreamsEventSinkExtensionFactory : KernelExtensionFactory<StreamsEventSink
                 GlobalScope.launch(Dispatchers.IO) {
                     val success = StreamsUtils.blockUntilTrueOrTimeout(streamsSinkConfiguration.checkApocTimeout, streamsSinkConfiguration.checkApocInterval) {
                         val hasApoc = Neo4jUtils.hasApoc(db)
-                        if (streamsLog.isDebugEnabled) {
+                        if (!hasApoc && streamsLog.isDebugEnabled) {
                             streamsLog.debug("APOC not loaded yet, next check in ${streamsSinkConfiguration.checkApocInterval} ms")
                         }
                         hasApoc

--- a/consumer/src/main/kotlin/streams/StreamsSinkConfiguration.kt
+++ b/consumer/src/main/kotlin/streams/StreamsSinkConfiguration.kt
@@ -1,9 +1,12 @@
 package streams
 
 import org.neo4j.kernel.configuration.Config
+import streams.extensions.toPointCase
+import streams.serialization.JSONUtils
 import streams.service.TopicUtils
 import streams.service.sink.strategy.SourceIdIngestionStrategyConfig
 import streams.service.Topics
+import java.util.Properties
 
 
 object StreamsSinkConfigurationConstants {
@@ -14,7 +17,6 @@ object StreamsSinkConfigurationConstants {
 
 data class StreamsSinkConfiguration(val enabled: Boolean = false,
                                     val proceduresEnabled: Boolean = true,
-                                    val sinkPollingInterval: Long = 10000,
                                     val topics: Topics = Topics(),
                                     val errorConfig: Map<String,Any?> = emptyMap(),
                                     val sourceIdStrategyConfig: SourceIdIngestionStrategyConfig = SourceIdIngestionStrategyConfig()) {
@@ -47,7 +49,6 @@ data class StreamsSinkConfiguration(val enabled: Boolean = false,
             return default.copy(enabled = config.getOrDefault(StreamsSinkConfigurationConstants.ENABLED, default.enabled).toString().toBoolean(),
                     proceduresEnabled = config.getOrDefault(StreamsSinkConfigurationConstants.PROCEDURES_ENABLED, default.proceduresEnabled)
                             .toString().toBoolean(),
-                    sinkPollingInterval = config.getOrDefault("sink.polling.interval", default.sinkPollingInterval).toString().toLong(),
                     topics = topics,
                     errorConfig = errorHandler,
                     sourceIdStrategyConfig = sourceIdStrategyConfig)

--- a/consumer/src/main/kotlin/streams/StreamsSinkConfiguration.kt
+++ b/consumer/src/main/kotlin/streams/StreamsSinkConfiguration.kt
@@ -10,7 +10,9 @@ import java.util.Properties
 
 
 object StreamsSinkConfigurationConstants {
-    const val STREAMS_CONFIG_PREFIX: String = "streams."
+    const val CHECK_APOC_TIMEOUT = "check.apoc.timeout"
+    const val CHECK_APOC_INTERVAL = "check.apoc.interval"
+    const val STREAMS_CONFIG_PREFIX = "streams."
     const val ENABLED = "sink.enabled"
     const val PROCEDURES_ENABLED = "procedures.enabled"
 }
@@ -19,6 +21,8 @@ data class StreamsSinkConfiguration(val enabled: Boolean = false,
                                     val proceduresEnabled: Boolean = true,
                                     val topics: Topics = Topics(),
                                     val errorConfig: Map<String,Any?> = emptyMap(),
+                                    val checkApocTimeout: Long = -1,
+                                    val checkApocInterval: Long = 1000,
                                     val sourceIdStrategyConfig: SourceIdIngestionStrategyConfig = SourceIdIngestionStrategyConfig()) {
 
     companion object {
@@ -51,6 +55,10 @@ data class StreamsSinkConfiguration(val enabled: Boolean = false,
                             .toString().toBoolean(),
                     topics = topics,
                     errorConfig = errorHandler,
+                    checkApocTimeout = config.getOrDefault(StreamsSinkConfigurationConstants.CHECK_APOC_TIMEOUT, default.checkApocTimeout)
+                            .toString().toLong(),
+                    checkApocInterval = config.getOrDefault(StreamsSinkConfigurationConstants.CHECK_APOC_INTERVAL, default.checkApocInterval)
+                            .toString().toLong(),
                     sourceIdStrategyConfig = sourceIdStrategyConfig)
         }
 

--- a/consumer/src/main/kotlin/streams/StreamsTopicService.kt
+++ b/consumer/src/main/kotlin/streams/StreamsTopicService.kt
@@ -1,106 +1,69 @@
 package streams
 
-import org.neo4j.kernel.impl.core.EmbeddedProxySPI
-import org.neo4j.kernel.impl.core.GraphProperties
 import org.neo4j.kernel.internal.GraphDatabaseAPI
-import streams.serialization.JSONUtils
-import streams.service.STREAMS_TOPIC_KEY
 import streams.service.TopicType
 import streams.service.Topics
 import streams.utils.Neo4jUtils
+import java.util.Collections
+import java.util.concurrent.ConcurrentHashMap
 
-class StreamsTopicService(private val db: GraphDatabaseAPI) {
-    private val properties: GraphProperties = db.dependencyResolver.resolveDependency(EmbeddedProxySPI::class.java).newGraphPropertiesProxy()
+class StreamsTopicService(db: GraphDatabaseAPI) {
+    private val log = Neo4jUtils.getLogService(db).getUserLog(StreamsTopicService::class.java)
 
-    fun clearAll() { // TODO move to Neo4jUtils#executeInWriteableInstance
-        if (!Neo4jUtils.isWriteableInstance(db)) {
-            return
-        }
-        return db.beginTx().use {
-            val keys = properties.allProperties
-                    .filterKeys { it.startsWith(STREAMS_TOPIC_KEY) }
-                    .keys
-            keys.forEach {
-                properties.removeProperty(it)
-            }
-            it.success()
-        }
+    private val storage = ConcurrentHashMap<TopicType, Any>()
+
+    fun clearAll() {
+        storage.clear()
     }
 
-    fun set(topicType: TopicType, data: Any) = Neo4jUtils.executeInWriteableInstance(db) {
-        db.beginTx().use {
-            if (properties.hasProperty(topicType.key)) {
-                val topicData = JSONUtils.readValue<Any>(properties.getProperty(topicType.key))
-                val newData = when (topicData) {
-                    is Map<*, *> -> topicData + (data as Map<String, Any?>)
-                    is Collection<*> -> topicData + (data as Collection<String>)
-                    else -> throw RuntimeException("Unsupported data $data for topic type $topicType")
-                }
-                properties.setProperty(topicType.key, JSONUtils.writeValueAsString(newData))
-            } else {
-                properties.setProperty(topicType.key, JSONUtils.writeValueAsString(data))
-            }
-            it.success()
+    fun set(topicType: TopicType, data: Any) {
+        val runtimeException = RuntimeException("Unsupported data $data for topic type $topicType")
+        var oldData = storage[topicType]
+        oldData = oldData ?: when (data) {
+            is Map<*, *> -> emptyMap<String, Any?>()
+            is Collection<*> -> emptyList<String>()
+            else -> throw runtimeException
         }
+        val newData = when (oldData) {
+            is Map<*, *> -> oldData + (data as Map<String, Any?>)
+            is Collection<*> -> oldData + (data as Collection<String>)
+            else -> throw runtimeException
+        }
+        storage[topicType] = newData
     }
 
-    fun remove(topicType: TopicType, topic: String) = Neo4jUtils.executeInWriteableInstance(db) {
-        db.beginTx().use {
-            if (properties.hasProperty(topicType.key)) {
-                val topicData = JSONUtils.readValue<Any>(properties.getProperty(topicType.key))
-                val newData = when (topicData) {
-                    is Map<*, *> -> topicData.filterKeys { it.toString() != topic }
-                    is Collection<*> -> topicData.filter { it.toString() != topic }
-                    else -> throw RuntimeException("Unsupported data $topicData for topic type $topicType")
-                }
-                val isEmpty = when (newData) {
-                    is Map<*, *> -> newData.isEmpty()
-                    is Collection<*> -> newData.isEmpty()
-                    else -> throw RuntimeException("Unsupported data $topicData for topic type $topicType")
-                }
-                if (isEmpty) {
-                    properties.removeProperty(topicType.key)
-                } else {
-                    properties.setProperty(topicType.key, JSONUtils.writeValueAsString(newData))
+    fun remove(topicType: TopicType, topic: String) {
+        val topicData = storage[topicType] ?: return
+
+        val runtimeException = RuntimeException("Unsupported data $topicData for topic type $topicType")
+        val filteredData = when (topicData) {
+            is Map<*, *> -> topicData.filterKeys { it.toString() != topic }
+            is Collection<*> -> topicData.filter { it.toString() != topic }
+            else -> throw runtimeException
+        }
+
+        storage[topicType] = filteredData
+    }
+
+    fun getTopicType(topic: String) = TopicType.values()
+            .find {
+                val topicData = storage[it]
+                when (topicData) {
+                    is Map<*, *> -> topicData.containsKey(topic)
+                    is Collection<*> -> topicData.contains(topic)
+                    else -> false
                 }
             }
-            it.success()
-        }
-    }
 
-    fun getTopicType(topic: String) = Neo4jUtils.executeInWriteableInstance(db) {
-        db.beginTx().use {
-            val ret = TopicType.values().find {
-                if (!properties.hasProperty(it.key)) {
-                    false
-                } else {
-                    val data = JSONUtils.readValue<Any>(properties.getProperty(it.key))
-                    when (data) {
-                        is Map<*, *> -> data.containsKey(topic)
-                        is Collection<*> -> data.contains(topic)
-                        else -> false
-                    }
+    fun getTopics() = TopicType.values()
+            .flatMap {
+                val data = storage[it]
+                when (data) {
+                    is Map<*, *> -> data.keys
+                    is Collection<*> -> data.toSet()
+                    else -> emptySet<String>()
                 }
-            }
-            it.success()
-            ret
-        }
-    }
-
-    fun getTopics() = db.beginTx().use {
-        val ret = TopicType.values()
-                .filter { properties.hasProperty(it.key) }
-                .flatMap {
-                    val data = JSONUtils.readValue<Any>(properties.getProperty(it.key))
-                    when (data) {
-                        is Map<*, *> -> data.keys
-                        is Collection<*> -> data.toSet()
-                        else -> emptySet()
-                    }
-                }.toSet() as Set<String>
-        it.success()
-        ret
-    }
+            }.toSet() as Set<String>
 
     fun setAll(topics: Topics) {
         topics.asMap().forEach { topicType, data ->
@@ -108,22 +71,9 @@ class StreamsTopicService(private val db: GraphDatabaseAPI) {
         }
     }
 
-    fun getCypherTemplate(topic: String) = db.beginTx().use {
-        if (properties.hasProperty(TopicType.CYPHER.key)) {
-            val data = JSONUtils.readValue<Map<String, String>>(properties.getProperty(TopicType.CYPHER.key))
-            data[topic]
-        } else {
-            null
-        }
-    }
+    fun getCypherTemplate(topic: String) = (storage.getOrDefault(TopicType.CYPHER, emptyMap<String, String>()) as Map<String, String>)
+            .let { it[topic] }
 
-    fun getAll() = db.beginTx().use {
-        val ret = TopicType.values()
-                .filter { properties.hasProperty(it.key) }
-                .map { it to JSONUtils.readValue<Any>(properties.getProperty(it.key)) }
-                .toMap()
-        it.success()
-        ret
-    }
+    fun getAll(): Map<TopicType, Any> = Collections.unmodifiableMap(storage)
 
 }

--- a/consumer/src/main/kotlin/streams/StreamsTopicService.kt
+++ b/consumer/src/main/kotlin/streams/StreamsTopicService.kt
@@ -70,7 +70,7 @@ class StreamsTopicService(private val db: GraphDatabaseAPI) {
 
     fun getTopicType(topic: String) = Neo4jUtils.executeInWriteableInstance(db) {
         db.beginTx().use {
-            TopicType.values().find {
+            val ret = TopicType.values().find {
                 if (!properties.hasProperty(it.key)) {
                     false
                 } else {
@@ -82,11 +82,13 @@ class StreamsTopicService(private val db: GraphDatabaseAPI) {
                     }
                 }
             }
+            it.success()
+            ret
         }
     }
 
     fun getTopics() = db.beginTx().use {
-        TopicType.values()
+        val ret = TopicType.values()
                 .filter { properties.hasProperty(it.key) }
                 .flatMap {
                     val data = JSONUtils.readValue<Any>(properties.getProperty(it.key))
@@ -96,6 +98,8 @@ class StreamsTopicService(private val db: GraphDatabaseAPI) {
                         else -> emptySet()
                     }
                 }.toSet() as Set<String>
+        it.success()
+        ret
     }
 
     fun setAll(topics: Topics) {
@@ -114,10 +118,12 @@ class StreamsTopicService(private val db: GraphDatabaseAPI) {
     }
 
     fun getAll() = db.beginTx().use {
-        TopicType.values()
+        val ret = TopicType.values()
                 .filter { properties.hasProperty(it.key) }
                 .map { it to JSONUtils.readValue<Any>(properties.getProperty(it.key)) }
                 .toMap()
+        it.success()
+        ret
     }
 
 }

--- a/consumer/src/main/kotlin/streams/procedures/StreamsSinkProcedures.kt
+++ b/consumer/src/main/kotlin/streams/procedures/StreamsSinkProcedures.kt
@@ -1,7 +1,8 @@
 package streams.procedures
 
+import org.apache.commons.lang3.exception.ExceptionUtils
 import org.neo4j.graphdb.GraphDatabaseService
-import org.neo4j.kernel.configuration.Config
+import org.neo4j.kernel.internal.GraphDatabaseAPI
 import org.neo4j.logging.Log
 import org.neo4j.procedure.Context
 import org.neo4j.procedure.Description
@@ -13,11 +14,15 @@ import streams.StreamsEventConsumerFactory
 import streams.StreamsEventSink
 import streams.StreamsEventSinkConfigMapper
 import streams.StreamsSinkConfiguration
-import java.net.URI
-import java.nio.file.Path
+import streams.events.StreamsPluginStatus
+import streams.extensions.toPointCase
+import streams.serialization.JSONUtils
+import streams.utils.Neo4jUtils
+import java.util.stream.Collectors
 import java.util.stream.Stream
 
 class StreamResult(@JvmField val event: Map<String, *>)
+class StreamsSinkDTO(@JvmField val name: String, @JvmField val value: Any?)
 
 class StreamsSinkProcedures {
 
@@ -47,21 +52,77 @@ class StreamsSinkProcedures {
     }
 
     @Procedure("streams.sink.start")
-    fun sinkStart(): Unit {
+    fun sinkStart(): Stream<StreamsSinkDTO> {
         checkEnabled()
-        streamsEventSink?.start()
+        checkLeader()
+        try {
+            streamsEventSink?.start()
+            return sinkStatus()
+        } catch (e: Exception) {
+            log?.error("Cannot start the Sink because of the following exception", e)
+            return Stream.concat(sinkStatus(),
+                    Stream.of(StreamsSinkDTO("exception", ExceptionUtils.getStackTrace(e))))
+        }
     }
 
     @Procedure("streams.sink.stop")
-    fun sinkStop(): Unit {
+    fun sinkStop(): Stream<StreamsSinkDTO> {
         checkEnabled()
-        streamsEventSink?.stop()
+        checkLeader()
+        try {
+            streamsEventSink?.stop()
+            return sinkStatus()
+        } catch (e: Exception) {
+            log?.error("Cannot stopped the Sink because of the following exception", e)
+            return Stream.concat(sinkStatus(),
+                    Stream.of(StreamsSinkDTO("exception", ExceptionUtils.getStackTrace(e))))
+        }
     }
 
     @Procedure("streams.sink.restart")
-    fun sinkRestart(): Unit {
-        sinkStop()
-        sinkStart()
+    fun sinkRestart(): Stream<StreamsSinkDTO> {
+        val stopped = sinkStop().collect(Collectors.toList())
+        val hasError = stopped.stream().anyMatch { it.name == "exception" }
+        if (hasError) {
+            return stopped.stream()
+        }
+        return sinkStart()
+    }
+
+    @Procedure("streams.sink.config")
+    fun sinkConfig(): Stream<StreamsSinkDTO> {
+        checkEnabled()
+        checkLeader()
+        val configMap = JSONUtils.asMap(streamsSinkConfiguration)
+                .filterKeys { it != "topics" && it != "enabled" && it != "proceduresEnabled" }
+                .mapKeys { it.key.toPointCase() }
+                .mapKeys {
+                    when (it.key) {
+                        "error.config" -> "streams.sink.errors"
+                        "procedures.enabled" -> "streams.${it.key}"
+                        else -> if (it.key.startsWith("streams.sink")) it.key else "streams.sink.${it.key}"
+                    }
+                }
+        val topicMap = streamsSinkConfiguration.topics.asMap()
+                .mapKeys { it.key.key }
+        val invalidTopics = mapOf("invalid_topics" to streamsSinkConfiguration.topics.invalid)
+        return (configMap + topicMap + invalidTopics)
+                .entries.stream()
+                .map { StreamsSinkDTO(it.key, it.value) }
+    }
+
+    @Procedure("streams.sink.status")
+    fun sinkStatus(): Stream<StreamsSinkDTO> {
+        checkEnabled()
+        checkLeader()
+        val value = (streamsEventSink?.status() ?: StreamsPluginStatus.UNKNOWN).toString()
+        return Stream.of(StreamsSinkDTO("status", value))
+    }
+
+    private fun checkLeader() {
+        if (!Neo4jUtils.isWriteableInstance(db as GraphDatabaseAPI)) {
+            throw RuntimeException("You can use it only in the LEADER or in a single instance configuration.")
+        }
     }
 
     private fun readData(topic: String, procedureConfig: Map<String, Any>, consumerConfig: Map<String, String>): List<Any> {

--- a/consumer/src/main/kotlin/streams/procedures/StreamsSinkProcedures.kt
+++ b/consumer/src/main/kotlin/streams/procedures/StreamsSinkProcedures.kt
@@ -94,7 +94,7 @@ class StreamsSinkProcedures {
         checkEnabled()
         checkLeader()
         val configMap = JSONUtils.asMap(streamsSinkConfiguration)
-                .filterKeys { it != "topics" && it != "enabled" && it != "proceduresEnabled" }
+                .filterKeys { it != "topics" && it != "enabled" && it != "proceduresEnabled" && !it.startsWith("check") }
                 .mapKeys { it.key.toPointCase() }
                 .mapKeys {
                     when (it.key) {

--- a/consumer/src/test/kotlin/integrations/kafka/KafkaEventSinkSimple.kt
+++ b/consumer/src/test/kotlin/integrations/kafka/KafkaEventSinkSimple.kt
@@ -7,8 +7,10 @@ import org.hamcrest.Matchers
 import org.junit.Test
 import org.neo4j.function.ThrowingSupplier
 import org.neo4j.graphdb.Node
+import org.neo4j.kernel.impl.proc.Procedures
 import org.neo4j.kernel.internal.GraphDatabaseAPI
 import org.neo4j.test.assertion.Assert
+import streams.procedures.StreamsSinkProcedures
 import streams.serialization.JSONUtils
 import java.util.*
 import java.util.concurrent.TimeUnit
@@ -86,6 +88,46 @@ class KafkaEventSinkSimple: KafkaEventSinkBase() {
                 WHERE properties(p) = {props}
                 RETURN count(p) AS count
             """.trimIndent()
+            val result = db.execute(query, mapOf("props" to props)).columnAs<Long>("count")
+            result.hasNext() && result.next() == 1L && !result.hasNext()
+        }, Matchers.equalTo(true), 30, TimeUnit.SECONDS)
+    }
+
+    @Test
+    fun `should stop and start the sink via procedures`() = runBlocking {
+        // given
+        graphDatabaseBuilder.setConfig("streams.sink.topic.cypher.shouldWriteCypherQuery", cypherQueryTemplate)
+        db = graphDatabaseBuilder.newGraphDatabase() as GraphDatabaseAPI
+        db.dependencyResolver.resolveDependency(Procedures::class.java)
+                .registerProcedure(StreamsSinkProcedures::class.java, true)
+
+        db.execute("CALL streams.sink.stop()").close()
+
+        val producerRecord = ProducerRecord(topics[0], UUID.randomUUID().toString(), JSONUtils.writeValueAsBytes(data))
+        kafkaProducer.send(producerRecord).get()
+        val props = data
+                .flatMap {
+                    if (it.key == "properties") {
+                        val map = it.value as Map<String, Any>
+                        map.entries.map { it.key to it.value }
+                    } else {
+                        listOf(it.key to it.value)
+                    }
+                }
+                .toMap()
+
+        delay(30000)
+
+        val query = """MATCH (n:Label) WHERE properties(n) = {props}
+                |RETURN count(*) AS count""".trimMargin()
+        val result = db.execute(query, mapOf("props" to props)).columnAs<Long>("count")
+        org.junit.Assert.assertEquals(0L, result.next())
+
+        // when
+        db.execute("CALL streams.sink.start()").close()
+
+        // then
+        Assert.assertEventually(ThrowingSupplier<Boolean, Exception> {
             val result = db.execute(query, mapOf("props" to props)).columnAs<Long>("count")
             result.hasNext() && result.next() == 1L && !result.hasNext()
         }, Matchers.equalTo(true), 30, TimeUnit.SECONDS)

--- a/consumer/src/test/kotlin/streams/StreamsSinkConfigurationTest.kt
+++ b/consumer/src/test/kotlin/streams/StreamsSinkConfigurationTest.kt
@@ -23,12 +23,16 @@ class StreamsSinkConfigurationTest {
         val topicValue = "MERGE (n:Label{ id: event.id }) "
         val customLabel = "CustomLabel"
         val customId = "customId"
+        val apocTimeout = "10000"
+        val apocInterval = "2000"
         val config = Config.builder()
                 .withSetting(topicKey, topicValue)
                 .withSetting("streams.sink.enabled", "false")
                 .withSetting("streams.sink.topic.cdc.sourceId", cdctopic)
                 .withSetting("streams.sink.topic.cdc.sourceId.labelName", customLabel)
                 .withSetting("streams.sink.topic.cdc.sourceId.idName", customId)
+                .withSetting("streams.check.apoc.timeout", apocTimeout)
+                .withSetting("streams.check.apoc.interval", apocInterval)
                 .build()
         val streamsConfig = StreamsSinkConfiguration.from(config)
         testFromConf(streamsConfig, topic, topicValue)
@@ -36,6 +40,8 @@ class StreamsSinkConfigurationTest {
         assertEquals(setOf(cdctopic), streamsConfig.topics.asMap()[TopicType.CDC_SOURCE_ID])
         assertEquals(customLabel, streamsConfig.sourceIdStrategyConfig.labelName)
         assertEquals(customId, streamsConfig.sourceIdStrategyConfig.idName)
+        assertEquals(apocTimeout.toLong(), streamsConfig.checkApocTimeout)
+        assertEquals(apocInterval.toLong(), streamsConfig.checkApocInterval)
     }
 
     @Test(expected = RuntimeException::class)

--- a/consumer/src/test/kotlin/streams/StreamsSinkConfigurationTest.kt
+++ b/consumer/src/test/kotlin/streams/StreamsSinkConfigurationTest.kt
@@ -17,7 +17,6 @@ class StreamsSinkConfigurationTest {
 
     @Test
     fun shouldReturnConfigurationFromMap() {
-        val pollingInterval = "10"
         val topic = "topic-neo"
         val cdctopic = "cdctopic"
         val topicKey = "streams.sink.topic.cypher.$topic"
@@ -25,7 +24,6 @@ class StreamsSinkConfigurationTest {
         val customLabel = "CustomLabel"
         val customId = "customId"
         val config = Config.builder()
-                .withSetting("streams.sink.polling.interval", pollingInterval)
                 .withSetting(topicKey, topicValue)
                 .withSetting("streams.sink.enabled", "false")
                 .withSetting("streams.sink.topic.cdc.sourceId", cdctopic)
@@ -33,7 +31,7 @@ class StreamsSinkConfigurationTest {
                 .withSetting("streams.sink.topic.cdc.sourceId.idName", customId)
                 .build()
         val streamsConfig = StreamsSinkConfiguration.from(config)
-        testFromConf(streamsConfig, pollingInterval, topic, topicValue)
+        testFromConf(streamsConfig, topic, topicValue)
         assertFalse { streamsConfig.enabled }
         assertEquals(setOf(cdctopic), streamsConfig.topics.asMap()[TopicType.CDC_SOURCE_ID])
         assertEquals(customLabel, streamsConfig.sourceIdStrategyConfig.labelName)
@@ -47,7 +45,6 @@ class StreamsSinkConfigurationTest {
         val topicKey = "streams.sink.topic.cypher.$topic"
         val topicValue = "MERGE (n:Label{ id: event.id }) "
         val config = Config.builder()
-                .withSetting("streams.sink.polling.interval", pollingInterval)
                 .withSetting(topicKey, topicValue)
                 .withSetting("streams.sink.topic.pattern.node.nodePatternTopic", "User{!userId,name,surname,address.city}")
                 .withSetting("streams.sink.enabled", "false")
@@ -58,10 +55,8 @@ class StreamsSinkConfigurationTest {
 
     @Test(expected = RuntimeException::class)
     fun shouldFailWithCrossDefinedCDCTopics() {
-        val pollingInterval = "10"
         val topic = "topic-neo"
         val config = Config.builder()
-                .withSetting("streams.sink.polling.interval", pollingInterval)
                 .withSetting("streams.sink.enabled", "false")
                 .withSetting("streams.sink.topic.cdc.sourceId", topic)
                 .withSetting("streams.sink.topic.cdc.schema", topic)
@@ -72,10 +67,8 @@ class StreamsSinkConfigurationTest {
     companion object {
         fun testDefaultConf(default: StreamsSinkConfiguration) {
             assertEquals(emptyMap(), default.topics.cypherTopics)
-            assertEquals(10000, default.sinkPollingInterval)
         }
-        fun testFromConf(streamsConfig: StreamsSinkConfiguration, pollingInterval: String, topic: String, topicValue: String) {
-            assertEquals(pollingInterval.toLong(), streamsConfig.sinkPollingInterval)
+        fun testFromConf(streamsConfig: StreamsSinkConfiguration, topic: String, topicValue: String) {
             assertEquals(1, streamsConfig.topics.cypherTopics.size)
             assertEquals(topicValue, streamsConfig.topics.cypherTopics[topic])
         }

--- a/consumer/src/test/kotlin/streams/kafka/KafkaSinkConfigurationTest.kt
+++ b/consumer/src/test/kotlin/streams/kafka/KafkaSinkConfigurationTest.kt
@@ -30,7 +30,6 @@ class KafkaSinkConfigurationTest {
 
     @Test
     fun `should return configuration from map`() {
-        val pollingInterval = "10"
         val topic = "topic-neo"
         val topicKey = "streams.sink.topic.cypher.$topic"
         val topicValue = "MERGE (n:Label{ id: event.id }) "
@@ -40,7 +39,6 @@ class KafkaSinkConfigurationTest {
         val autoOffsetReset = "latest"
         val autoCommit = "false"
         val config = Config.builder()
-                .withSetting("streams.sink.polling.interval", pollingInterval)
                 .withSetting(topicKey, topicValue)
                 .withSetting("kafka.zookeeper.connect", zookeeper)
                 .withSetting("kafka.bootstrap.servers", bootstrap)
@@ -58,7 +56,7 @@ class KafkaSinkConfigurationTest {
                 "value.deserializer" to KafkaAvroDeserializer::class.java.name)
 
         val kafkaSinkConfiguration = KafkaSinkConfiguration.create(config.raw)
-        StreamsSinkConfigurationTest.testFromConf(kafkaSinkConfiguration.streamsSinkConfiguration, pollingInterval, topic, topicValue)
+        StreamsSinkConfigurationTest.testFromConf(kafkaSinkConfiguration.streamsSinkConfiguration, topic, topicValue)
         assertEquals(emptyMap(), kafkaSinkConfiguration.extraProperties)
         assertEquals(zookeeper, kafkaSinkConfiguration.zookeeperConnect)
         assertEquals(bootstrap, kafkaSinkConfiguration.bootstrapServers)
@@ -71,7 +69,6 @@ class KafkaSinkConfigurationTest {
         assertEquals(expectedMap, resultMap)
 
         val streamsConfig = StreamsSinkConfiguration.from(config)
-        assertEquals(pollingInterval.toLong(), streamsConfig.sinkPollingInterval)
         assertTrue { streamsConfig.topics.cypherTopics.containsKey(topic) }
         assertEquals(topicValue, streamsConfig.topics.cypherTopics[topic])
     }
@@ -82,7 +79,6 @@ class KafkaSinkConfigurationTest {
         val zookeeper = "zookeeper:2181"
         val bootstrap = "bootstrap:9092"
         try {
-            val pollingInterval = "10"
             val topic = "topic-neo"
             val topicKey = "streams.sink.topic.cypher.$topic"
             val topicValue = "MERGE (n:Label{ id: event.id }) "
@@ -90,7 +86,6 @@ class KafkaSinkConfigurationTest {
             val autoOffsetReset = "latest"
             val autoCommit = "false"
             val config = Config.builder()
-                    .withSetting("streams.sink.polling.interval", pollingInterval)
                     .withSetting(topicKey, topicValue)
                     .withSetting("kafka.zookeeper.connect", zookeeper)
                     .withSetting("kafka.bootstrap.servers", bootstrap)
@@ -114,7 +109,6 @@ class KafkaSinkConfigurationTest {
         val zookeeper = "zookeeper:2181"
         val bootstrap = ""
         try {
-            val pollingInterval = "10"
             val topic = "topic-neo"
             val topicKey = "streams.sink.topic.cypher.$topic"
             val topicValue = "MERGE (n:Label{ id: event.id }) "
@@ -122,7 +116,6 @@ class KafkaSinkConfigurationTest {
             val autoOffsetReset = "latest"
             val autoCommit = "false"
             val config = Config.builder()
-                    .withSetting("streams.sink.polling.interval", pollingInterval)
                     .withSetting(topicKey, topicValue)
                     .withSetting("kafka.zookeeper.connect", zookeeper)
                     .withSetting("kafka.bootstrap.servers", bootstrap)

--- a/doc/asciidoc/consumer/configuration.adoc
+++ b/doc/asciidoc/consumer/configuration.adoc
@@ -18,6 +18,9 @@ kafka.value.deserializer=org.apache.kafka.common.serialization.ByteArrayDeserial
 {environment}.topic.pattern.node.<TOPIC_NAME>=<NODE_EXTRACTION_PATTERN>
 {environment}.topic.pattern.relationship.<TOPIC_NAME>=<RELATIONSHIP_EXTRACTION_PATTERN>
 {environment}.enabled=<true/false, default=false>
+
+streams.check.apoc.timeout=<ms to await for APOC being loaded, default -1 skip the wait>
+streams.check.apoc.interval=<ms interval awaiting for APOC being loaded, default 1000>
 ----
 
 See the https://kafka.apache.org/documentation/#brokerconfigs[Apache Kafka documentation] for details on these settings.

--- a/doc/asciidoc/kafka-ssl/index.adoc
+++ b/doc/asciidoc/kafka-ssl/index.adoc
@@ -83,7 +83,6 @@ Note that the passwords are stored in plaintext so limit access to this `neo4j.c
 kafka.zookeeper.connect=xxx.xxx.xxx.xxx:2181
 kafka.bootstrap.servers=xxx.xxx.xxx.xxx:9094
 streams.sink.enabled=false
-streams.sink.polling.interval=1000
 
 streams.source.topic.nodes.neoTest=Person{*}
 

--- a/doc/asciidoc/procedures/index.adoc
+++ b/doc/asciidoc/procedures/index.adoc
@@ -204,3 +204,63 @@ Supported deserializers are: `org.apache.kafka.common.serialization.ByteArrayDes
 
 |===
 
+=== Streams Sink Lifecycle procedure
+
+We provide a set of procedures in order to manage the Sink lifecycle.
+
+[cols="2*",options="header"]
+|===
+|Proc. Name
+|Description
+
+|`CALL streams.sink.stop() YIELD name, value`
+| stops the Sink, and return the status, with the error if one occurred during the process
+
+|`CALL streams.sink.start() YIELD name, value`
+| starts the Sink, and return the status, with the error if one occurred during the process
+
+|`CALL streams.sink.restart() YIELD name, value`
+| restart the Sink, and return the status, with the error if one occurred during the process
+
+|`CALL streams.sink.config() YIELD name, value`
+| returns the Sink config, please check the table "Streams Config"
+
+|`CALL streams.sink.status() YIELD name, value`
+| returns the status
+|===
+
+*N.b.* Please consider that in order to use this procedures you must enable the streams procedures and they are runnable only on the leader.
+
+.Streams Config
+[cols="2*",options="header"]
+|===
+|Config Name
+|Description
+
+|invalid_topics
+|return a list of invalid topics
+
+|streams.sink.topic.pattern.relationship
+|return a Map<K,V> where the K is the topic name and V is the provided pattern
+
+|streams.sink.topic.cud
+|return a list of topics defined for the CUD format
+
+|streams.sink.topic.cdc.sourceId
+|return a list of topics defined for the CDC SourceId strategy
+
+|streams.sink.topic.cypher
+|return a Map<K,V> where the K is the topic name and V is the provided Cypher Query
+
+|streams.sink.topic.cdc.schema
+|return a list of topics defined for the CDC Schema strategy
+
+|streams.sink.topic.pattern.node
+|return a Map<K,V> where the K is the topic name and V is the provided pattern
+
+|streams.sink.errors
+|return a Map<K,V> where the K sub property name, and V is the value
+
+|streams.sink.source.id.strategy.config
+|returns the config for the SourceId CDC strategy
+|==

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
         <java.version>1.8</java.version>
         <kotlin.version>1.3.0</kotlin.version>
         <kotlin.coroutines.version>1.0.0</kotlin.coroutines.version>
-        <neo4j.version>3.5.2</neo4j.version>
+        <neo4j.version>3.5.18</neo4j.version>
         <kafka.version>2.3.0</kafka.version>
         <jackson.version>2.9.7</jackson.version>
         <kotlin.compiler.incremental>true</kotlin.compiler.incremental>


### PR DESCRIPTION
This PR adds the sink lifecycle procedures allowing the user to start/stop/restart the sink without the need to physically restart the Neo4j instance.

**N.b.** Any changes made on the `neo4j.conf` file will not affect Streams conf.

## Proposed Changes (Mandatory)

A brief list of proposed changes in order to fix the issue:

- added `streams.sink.stop`
- added `streams.sink.start`
- added `streams.sink.restart`
- added tests
