### PR TITLE
add sink lifecyle procedures

### DIFF
--- a/common/src/main/kotlin/streams/config/StreamsConfig.kt
+++ b/common/src/main/kotlin/streams/config/StreamsConfig.kt
@@ -28,6 +28,8 @@ data class StreamsConfig(private val log: Log, private val dbms: DatabaseManagem
         const val SINK_ENABLED = "streams.sink.enabled"
         const val SINK_ENABLED_VALUE = false
         const val DEFAULT_PATH = "."
+        const val CHECK_APOC_TIMEOUT = "check.apoc.timeout"
+        const val CHECK_APOC_INTERVAL = "check.apoc.interval"
         private var afterInitListeners = mutableListOf<((MutableMap<String, String>) -> Unit)>()
 
         fun registerListener(after: (MutableMap<String, String>) -> Unit) {

--- a/common/src/main/kotlin/streams/config/StreamsConfig.kt
+++ b/common/src/main/kotlin/streams/config/StreamsConfig.kt
@@ -56,8 +56,8 @@ data class StreamsConfig(private val log: Log, private val dbms: DatabaseManagem
     private fun loadConfiguration() {
         val properties = neo4jConfAsProperties()
 
-        val filteredValues = filterProperties(properties,
-                { key -> !SUPPORTED_PREFIXES.find { key.toString().startsWith(it) }.isNullOrBlank() })
+        val filteredValues = filterProperties(properties)
+                { key -> !SUPPORTED_PREFIXES.find { key.toString().startsWith(it) }.isNullOrBlank() }
 
         if (log.isDebugEnabled) {
             log.debug("Neo4j Streams Global configuration from neo4j.conf file: $filteredValues")

--- a/common/src/main/kotlin/streams/events/StreamsPluginStatus.kt
+++ b/common/src/main/kotlin/streams/events/StreamsPluginStatus.kt
@@ -1,0 +1,3 @@
+package streams.events
+
+enum class StreamsPluginStatus { RUNNING, STOPPED, UNKNOWN }

--- a/common/src/main/kotlin/streams/utils/Neo4jUtils.kt
+++ b/common/src/main/kotlin/streams/utils/Neo4jUtils.kt
@@ -37,6 +37,21 @@ object Neo4jUtils {
         }
     }
 
+    fun hasApoc(db: GraphDatabaseAPI): Boolean {
+        try {
+            return db.execute("RETURN apoc.version() AS version") {
+                it.columnAs<String>("version").next()
+                true
+            }
+        } catch (e: QueryExecutionException) {
+            if (e.statusCode.equals("Neo.ClientError.Statement.SyntaxError", ignoreCase = true)
+                    && e.message!!.contains("Unknown function", ignoreCase = true)) {
+                return false
+            }
+            throw e
+        }
+    }
+
     fun getLogService(db: GraphDatabaseAPI): LogService {
         return db.dependencyResolver
                 .resolveDependency(LogService::class.java)

--- a/common/src/main/kotlin/streams/utils/Neo4jUtils.kt
+++ b/common/src/main/kotlin/streams/utils/Neo4jUtils.kt
@@ -37,19 +37,13 @@ object Neo4jUtils {
         }
     }
 
-    fun hasApoc(db: GraphDatabaseAPI): Boolean {
-        try {
-            return db.execute("RETURN apoc.version() AS version") {
-                it.columnAs<String>("version").next()
-                true
-            }
-        } catch (e: QueryExecutionException) {
-            if (e.statusCode.equals("Neo.ClientError.Statement.SyntaxError", ignoreCase = true)
-                    && e.message!!.contains("Unknown function", ignoreCase = true)) {
-                return false
-            }
-            throw e
+    fun hasApoc(db: GraphDatabaseAPI): Boolean = try {
+         db.execute("RETURN apoc.version() AS version") {
+            it.columnAs<String>("version").next()
+            true
         }
+    } catch (e: QueryExecutionException) {
+        false
     }
 
     fun getLogService(db: GraphDatabaseAPI): LogService {

--- a/common/src/main/kotlin/streams/utils/StreamsUtils.kt
+++ b/common/src/main/kotlin/streams/utils/StreamsUtils.kt
@@ -1,5 +1,8 @@
 package streams.utils
 
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.delay
+
 object StreamsUtils {
 
     const val UNWIND: String = "UNWIND \$events AS event"
@@ -20,6 +23,16 @@ object StreamsUtils {
                 else -> throw e
             }
         }
+    }
+
+    fun blockUntilTrueOrTimeout(timeout: Long, delay: Long = 1000, action: () -> Boolean): Boolean = runBlocking {
+        val start = System.currentTimeMillis()
+        var success = action()
+        while (System.currentTimeMillis() - start < timeout && !success) {
+            delay(delay)
+            success = action()
+        }
+        success
     }
 
 }

--- a/common/src/test/kotlin/streams/utils/Neo4jUtilsTest.kt
+++ b/common/src/test/kotlin/streams/utils/Neo4jUtilsTest.kt
@@ -25,4 +25,9 @@ class Neo4jUtilsTest {
         assertFalse { isEnterprise }
     }
 
+    @Test
+    fun `should not have APOC`() {
+        assertFalse { Neo4jUtils.hasApoc(db) }
+    }
+
 }

--- a/consumer/src/main/kotlin/streams/StreamsEventSink.kt
+++ b/consumer/src/main/kotlin/streams/StreamsEventSink.kt
@@ -1,9 +1,9 @@
 package streams
 
-import org.neo4j.configuration.Config
 import org.neo4j.kernel.internal.GraphDatabaseAPI
 import org.neo4j.logging.Log
 import streams.config.StreamsConfig
+import streams.events.StreamsPluginStatus
 
 abstract class StreamsEventSink(private val config: StreamsConfig,
                                 private val queryExecution: StreamsEventSinkQueryExecution,
@@ -23,6 +23,8 @@ abstract class StreamsEventSink(private val config: StreamsConfig,
     open fun getEventSinkConfigMapper(): StreamsEventSinkConfigMapper = StreamsEventSinkConfigMapper(streamsConfigMap, mappingKeys)
 
     open fun printInvalidTopics() {}
+
+    abstract fun status(): StreamsPluginStatus
 
 }
 

--- a/consumer/src/main/kotlin/streams/StreamsEventSinkExtensionFactory.kt
+++ b/consumer/src/main/kotlin/streams/StreamsEventSinkExtensionFactory.kt
@@ -1,5 +1,8 @@
 package streams
 
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
 import org.neo4j.dbms.api.DatabaseManagementService
 import org.neo4j.kernel.availability.AvailabilityGuard
 import org.neo4j.kernel.availability.AvailabilityListener
@@ -80,6 +83,7 @@ class StreamsEventSinkExtensionFactory : ExtensionFactory<StreamsEventSinkExtens
                         StreamsSinkProcedures.registerStreamsSinkConfiguration(streamsSinkConfiguration)
                         StreamsSinkProcedures.registerStreamsEventConsumerFactory(eventSink.getEventConsumerFactory())
                         StreamsSinkProcedures.registerStreamsEventSinkConfigMapper(eventSink.getEventSinkConfigMapper())
+                        StreamsSinkProcedures.registerStreamsEventSink(eventSink)
                     } catch (e: Exception) {
                         streamsLog.error("Error initializing the streaming sink:", e)
                     }
@@ -88,6 +92,28 @@ class StreamsEventSinkExtensionFactory : ExtensionFactory<StreamsEventSinkExtens
         }
 
         private fun initSinkModule(streamsTopicService: StreamsTopicService, streamsSinkConfiguration: StreamsSinkConfiguration) {
+            if (streamsSinkConfiguration.checkApocTimeout > -1) {
+                GlobalScope.launch(Dispatchers.IO) {
+                    val success = StreamsUtils.blockUntilTrueOrTimeout(streamsSinkConfiguration.checkApocTimeout, streamsSinkConfiguration.checkApocInterval) {
+                        val hasApoc = Neo4jUtils.hasApoc(db)
+                        if (!hasApoc && streamsLog.isDebugEnabled) {
+                            streamsLog.debug("APOC not loaded yet, next check in ${streamsSinkConfiguration.checkApocInterval} ms")
+                        }
+                        hasApoc
+                    }
+                    if (success) {
+                        initSink(streamsTopicService, streamsSinkConfiguration)
+                    } else {
+                        streamsLog.info("Streams Sink plugin not loaded as APOC are not installed")
+                    }
+                }
+            } else {
+                initSink(streamsTopicService, streamsSinkConfiguration)
+            }
+
+        }
+
+        private fun initSink(streamsTopicService: StreamsTopicService, streamsSinkConfiguration: StreamsSinkConfiguration) {
             streamsTopicService.clearAll()
             streamsTopicService.setAll(streamsSinkConfiguration.topics)
             eventSink.start()

--- a/consumer/src/main/kotlin/streams/StreamsSinkConfiguration.kt
+++ b/consumer/src/main/kotlin/streams/StreamsSinkConfiguration.kt
@@ -10,6 +10,8 @@ data class StreamsSinkConfiguration(val enabled: Boolean = StreamsConfig.SINK_EN
                                     val proceduresEnabled: Boolean = StreamsConfig.PROCEDURES_ENABLED_VALUE,
                                     val topics: Topics = Topics(),
                                     val errorConfig: Map<String,Any?> = emptyMap(),
+                                    val checkApocTimeout: Long = -1,
+                                    val checkApocInterval: Long = 1000,
                                     val sourceIdStrategyConfig: SourceIdIngestionStrategyConfig = SourceIdIngestionStrategyConfig()) {
 
     companion object {
@@ -39,10 +41,19 @@ data class StreamsSinkConfiguration(val enabled: Boolean = StreamsConfig.SINK_EN
                     .filterKeys { it.startsWith("streams.sink.error") }
                     .mapKeys { it.key.substring("streams.sink.".length) }
 
+
             return default.copy(enabled = cfg.isSinkEnabled(dbName),
                     proceduresEnabled = cfg.hasProceduresEnabled(dbName),
                     topics = topics,
                     errorConfig = errorHandler,
+                    checkApocTimeout = cfg.config.getOrDefault("streams.${StreamsConfig.CHECK_APOC_TIMEOUT}",
+                            default.checkApocTimeout)
+                            .toString()
+                            .toLong(),
+                    checkApocInterval = cfg.config.getOrDefault("streams.${StreamsConfig.CHECK_APOC_INTERVAL}",
+                            default.checkApocInterval)
+                            .toString()
+                            .toLong(),
                     sourceIdStrategyConfig = sourceIdStrategyConfig)
         }
 

--- a/consumer/src/main/kotlin/streams/procedures/StreamsSinkProcedures.kt
+++ b/consumer/src/main/kotlin/streams/procedures/StreamsSinkProcedures.kt
@@ -1,20 +1,33 @@
 package streams.procedures
 
+import org.apache.commons.lang3.exception.ExceptionUtils
+import org.neo4j.graphdb.GraphDatabaseService
+import org.neo4j.kernel.internal.GraphDatabaseAPI
 import org.neo4j.logging.Log
 import org.neo4j.procedure.*
 import streams.StreamsEventConsumer
 import streams.StreamsEventConsumerFactory
+import streams.StreamsEventSink
 import streams.StreamsEventSinkConfigMapper
 import streams.StreamsSinkConfiguration
 import streams.config.StreamsConfig
+import streams.events.StreamsPluginStatus
+import streams.extensions.toPointCase
+import streams.serialization.JSONUtils
+import streams.utils.Neo4jUtils
+import java.util.stream.Collectors
 import java.util.stream.Stream
 
 class StreamResult(@JvmField val event: Map<String, *>)
+class StreamsSinkDTO(@JvmField val name: String, @JvmField val value: Any?)
 
 class StreamsSinkProcedures {
 
     @JvmField @Context
     var log: Log? = null
+
+    @JvmField @Context
+    var db: GraphDatabaseService? = null
 
     @Procedure(mode = Mode.READ, name = "streams.consume")
     @Description("streams.consume(topic, {timeout: <long value>, from: <string>, groupId: <string>, commit: <boolean>, partitions:[{partition: <number>, offset: <number>}]}) " +
@@ -33,6 +46,80 @@ class StreamsSinkProcedures {
         val data = readData(topic, config ?: emptyMap(), configuration)
 
         return data.map { StreamResult(mapOf("data" to it)) }.stream()
+    }
+
+    @Procedure("streams.sink.start")
+    fun sinkStart(): Stream<StreamsSinkDTO> {
+        checkEnabled()
+        checkLeader()
+        try {
+            streamsEventSink?.start()
+            return sinkStatus()
+        } catch (e: Exception) {
+            log?.error("Cannot start the Sink because of the following exception", e)
+            return Stream.concat(sinkStatus(),
+                    Stream.of(StreamsSinkDTO("exception", ExceptionUtils.getStackTrace(e))))
+        }
+    }
+
+    @Procedure("streams.sink.stop")
+    fun sinkStop(): Stream<StreamsSinkDTO> {
+        checkEnabled()
+        checkLeader()
+        try {
+            streamsEventSink?.stop()
+            return sinkStatus()
+        } catch (e: Exception) {
+            log?.error("Cannot stopped the Sink because of the following exception", e)
+            return Stream.concat(sinkStatus(),
+                    Stream.of(StreamsSinkDTO("exception", ExceptionUtils.getStackTrace(e))))
+        }
+    }
+
+    @Procedure("streams.sink.restart")
+    fun sinkRestart(): Stream<StreamsSinkDTO> {
+        val stopped = sinkStop().collect(Collectors.toList())
+        val hasError = stopped.stream().anyMatch { it.name == "exception" }
+        if (hasError) {
+            return stopped.stream()
+        }
+        return sinkStart()
+    }
+
+    @Procedure("streams.sink.config")
+    fun sinkConfig(): Stream<StreamsSinkDTO> {
+        checkEnabled()
+        checkLeader()
+        val configMap = JSONUtils.asMap(streamsSinkConfiguration)
+                .filterKeys { it != "topics" && it != "enabled" && it != "proceduresEnabled" && !it.startsWith("check") }
+                .mapKeys { it.key.toPointCase() }
+                .mapKeys {
+                    when (it.key) {
+                        "error.config" -> "streams.sink.errors"
+                        "procedures.enabled" -> "streams.${it.key}"
+                        else -> if (it.key.startsWith("streams.sink")) it.key else "streams.sink.${it.key}"
+                    }
+                }
+        val topicMap = streamsSinkConfiguration.topics.asMap()
+                .mapKeys { it.key.key }
+        val invalidTopics = mapOf("invalid_topics" to streamsSinkConfiguration.topics.invalid)
+        return (configMap + topicMap + invalidTopics)
+                .entries.stream()
+                .map { StreamsSinkDTO(it.key, it.value) }
+    }
+
+    @Procedure("streams.sink.status")
+    fun sinkStatus(): Stream<StreamsSinkDTO> {
+        checkEnabled()
+        checkLeader()
+        val value = (streamsEventSink?.status() ?: StreamsPluginStatus.UNKNOWN).toString()
+        return Stream.of(StreamsSinkDTO("status", value))
+    }
+
+    private fun checkLeader() {
+        if (!Neo4jUtils.isWriteableInstance(db as GraphDatabaseAPI)) {
+            throw RuntimeException("You can use it only in the LEADER or in a single instance configuration.")
+        }
     }
 
     private fun readData(topic: String, procedureConfig: Map<String, Any>, consumerConfig: Map<String, String>): List<Any> {
@@ -80,6 +167,7 @@ class StreamsSinkProcedures {
         private lateinit var streamsSinkConfiguration: StreamsSinkConfiguration
         private lateinit var streamsEventConsumerFactory: StreamsEventConsumerFactory
         private lateinit var streamsEventSinkConfigMapper: StreamsEventSinkConfigMapper
+        private var streamsEventSink: StreamsEventSink? = null
 
         fun registerStreamsEventSinkConfigMapper(streamsEventSinkConfigMapper: StreamsEventSinkConfigMapper) {
             this.streamsEventSinkConfigMapper = streamsEventSinkConfigMapper
@@ -91,6 +179,10 @@ class StreamsSinkProcedures {
 
         fun registerStreamsEventConsumerFactory(streamsEventConsumerFactory: StreamsEventConsumerFactory) {
             this.streamsEventConsumerFactory = streamsEventConsumerFactory
+        }
+
+        fun registerStreamsEventSink(streamsEventSink: StreamsEventSink) {
+            this.streamsEventSink = streamsEventSink
         }
     }
 }

--- a/consumer/src/test/kotlin/streams/StreamsSinkConfigurationTest.kt
+++ b/consumer/src/test/kotlin/streams/StreamsSinkConfigurationTest.kt
@@ -84,10 +84,14 @@ class StreamsSinkConfigurationTest {
         val topicValue = "MERGE (n:Label{ id: event.id }) "
         val customLabel = "CustomLabel"
         val customId = "customId"
+        val apocTimeout = "10000"
+        val apocInterval = "2000"
         val config = mapOf(topicKey to topicValue,
                 "streams.sink.enabled" to "false",
                 "streams.sink.topic.cdc.sourceId" to cdctopic,
                 "streams.sink.topic.cdc.sourceId.labelName" to customLabel,
+                "streams.check.apoc.timeout" to apocTimeout,
+                "streams.check.apoc.interval" to apocInterval,
                 "streams.sink.topic.cdc.sourceId.idName" to customId)
         streamsConfig.config.putAll(config)
         val streamsSinkConf = StreamsSinkConfiguration.from(streamsConfig, defalutDbName)
@@ -96,6 +100,8 @@ class StreamsSinkConfigurationTest {
         assertEquals(setOf(cdctopic), streamsSinkConf.topics.asMap()[TopicType.CDC_SOURCE_ID])
         assertEquals(customLabel, streamsSinkConf.sourceIdStrategyConfig.labelName)
         assertEquals(customId, streamsSinkConf.sourceIdStrategyConfig.idName)
+        assertEquals(apocTimeout.toLong(), streamsSinkConf.checkApocTimeout)
+        assertEquals(apocInterval.toLong(), streamsSinkConf.checkApocInterval)
     }
 
     @Test

--- a/doc/asciidoc/consumer/configuration.adoc
+++ b/doc/asciidoc/consumer/configuration.adoc
@@ -18,6 +18,9 @@ kafka.value.deserializer=org.apache.kafka.common.serialization.ByteArrayDeserial
 {environment}.topic.pattern.node.<TOPIC_NAME>=<NODE_EXTRACTION_PATTERN>
 {environment}.topic.pattern.relationship.<TOPIC_NAME>=<RELATIONSHIP_EXTRACTION_PATTERN>
 {environment}.enabled=<true/false, default=true>
+
+streams.check.apoc.timeout=<ms to await for APOC being loaded, default -1 skip the wait>
+streams.check.apoc.interval=<ms interval awaiting for APOC being loaded, default 1000>
 ----
 
 See the https://kafka.apache.org/documentation/#brokerconfigs[Apache Kafka documentation] for details on these settings.

--- a/doc/asciidoc/procedures/index.adoc
+++ b/doc/asciidoc/procedures/index.adoc
@@ -302,3 +302,84 @@ Please consider that in order to use this procedures you must enable the streams
 |streams.sink.source.id.strategy.config
 |returns the config for the SourceId CDC strategy
 |===
+
+==== Example
+
+```
+Executing: CALL streams.sink.config()
++----------------------------------------------------------------------------------------------------------------------------------------------+
+| name                                      | value                                                                                            |
++----------------------------------------------------------------------------------------------------------------------------------------------+
+| "streams.sink.errors"                     | {}                                                                                               |
+| "streams.sink.source.id.strategy.config"  | {idName -> "sourceId", labelName -> "SourceEvent"}                                               |
+| "streams.sink.topic.cypher"               | {shouldWriteCypherQuery -> "MERGE (n:Label {id: event.id}) ON CREATE SET n += event.properties"} |
+| "streams.sink.topic.cud"                  | []                                                                                               |
+| "streams.sink.topic.cdc.schema"           | []                                                                                               |
+| "streams.sink.topic.cdc.sourceId"         | []                                                                                               |
+| "streams.sink.topic.pattern.node"         | {}                                                                                               |
+| "streams.sink.topic.pattern.relationship" | {}                                                                                               |
+| "invalid_topics"                          | []                                                                                               |
++----------------------------------------------------------------------------------------------------------------------------------------------+
+9 rows
+```
+
+```
+Executing: CALL streams.sink.stop()
++----------------------+
+| name     | value     |
++----------------------+
+| "status" | "STOPPED" |
++----------------------+
+1 row
+```
+
+```
+Executing: CALL streams.sink.status()
++----------------------+
+| name     | value     |
++----------------------+
+| "status" | "STOPPED" |
++----------------------+
+1 row
+```
+
+```
+Executing: CALL streams.sink.start()
++----------------------+
+| name     | value     |
++----------------------+
+| "status" | "RUNNING" |
++----------------------+
+1 row
+```
+
+```
+Executing: CALL streams.sink.status()
++----------------------+
+| name     | value     |
++----------------------+
+| "status" | "RUNNING" |
++----------------------+
+1 row
+```
+
+```
+Executing: CALL streams.sink.restart()
++----------------------+
+| name     | value     |
++----------------------+
+| "status" | "RUNNING" |
++----------------------+
+1 row
+```
+
+```
+Given a cluster env, executing in a NON LEADER: CALL streams.sink.status()
++--------------------------------------------------------------------------------------------------+
+| name    | value                                                                                  |
++--------------------------------------------------------------------------------------------------+
+| "error" | "You can use this procedure only in the LEADER or in a single instance configuration." |
++--------------------------------------------------------------------------------------------------+
+1 row
+
+```

--- a/doc/asciidoc/procedures/index.adoc
+++ b/doc/asciidoc/procedures/index.adoc
@@ -241,3 +241,64 @@ Supported deserializers are: `org.apache.kafka.common.serialization.ByteArrayDes
 
 |===
 
+=== Streams Sink Lifecycle procedure
+
+We provide a set of procedures in order to manage the Sink lifecycle.
+
+[cols="2*",options="header"]
+|===
+|Proc. Name
+|Description
+
+|`CALL streams.sink.stop() YIELD name, value`
+| stops the Sink, and return the status, with the error if one occurred during the process
+
+|`CALL streams.sink.start() YIELD name, value`
+| starts the Sink, and return the status, with the error if one occurred during the process
+
+|`CALL streams.sink.restart() YIELD name, value`
+| restart the Sink, and return the status, with the error if one occurred during the process
+
+|`CALL streams.sink.config() YIELD name, value`
+| returns the Sink config, please check the table "Streams Config"
+
+|`CALL streams.sink.status() YIELD name, value`
+| returns the status
+|===
+
+[NOTE]
+Please consider that in order to use this procedures you must enable the streams procedures and they are runnable only on the leader.
+
+.Streams Config
+[cols="2*",options="header"]
+|===
+|Config Name
+|Description
+
+|invalid_topics
+|return a list of invalid topics
+
+|streams.sink.topic.pattern.relationship
+|return a Map<K,V> where the K is the topic name and V is the provided pattern
+
+|streams.sink.topic.cud
+|return a list of topics defined for the CUD format
+
+|streams.sink.topic.cdc.sourceId
+|return a list of topics defined for the CDC SourceId strategy
+
+|streams.sink.topic.cypher
+|return a Map<K,V> where the K is the topic name and V is the provided Cypher Query
+
+|streams.sink.topic.cdc.schema
+|return a list of topics defined for the CDC Schema strategy
+
+|streams.sink.topic.pattern.node
+|return a Map<K,V> where the K is the topic name and V is the provided pattern
+
+|streams.sink.errors
+|return a Map<K,V> where the K sub property name, and V is the value
+
+|streams.sink.source.id.strategy.config
+|returns the config for the SourceId CDC strategy
+|===


### PR DESCRIPTION
Fixes #320 in branch 4.0

Provide the same set of feature as we did in branch `3.5`

## Proposed Changes (Mandatory)

A brief list of proposed changes in order to fix the issue:
- added `streams.sink.stop`
- added `streams.sink.start`
- added `streams.sink.restart`
- added tests

