### PR TITLE
fixes bug delete with pattern filtering

### DIFF
--- a/producer/src/main/kotlin/streams/StreamsTransactionEventHandler.kt
+++ b/producer/src/main/kotlin/streams/StreamsTransactionEventHandler.kt
@@ -126,13 +126,11 @@ class StreamsTransactionEventHandler(private val router: StreamsEventRouter,
                 .toMap()
 
         // returns a Map<Boolean, List<Node>> where the K is true if the node has been deleted
-        val removedNodeProps = allOrFiltered(txd.removedNodeProperties(), nodeAll)
-                { it.entity().labelNames().any { nodeRoutingLabels.contains(it) } }
+        val removedNodeProps = txd.removedNodeProperties()
                 .map { txd.deletedNodes().contains(it.entity()) to it }
                 .groupBy({ it.first }, { it.second })
                 .toMap()
-        val removedLbls = allOrFiltered(txd.removedLabels(), nodeAll)
-                { nodeRoutingLabels.contains(it.label().name()) }
+        val removedLbls = txd.removedLabels()
                 .map { txd.deletedNodes().contains(it.node()) to it }
                 .groupBy({ it.first }, { it.second })
                 .toMap()
@@ -147,12 +145,10 @@ class StreamsTransactionEventHandler(private val router: StreamsEventRouter,
                 .map { labelEntry -> labelEntry.node().id to labelEntry.label().name() } // [ (nodeId, [label]) ]
                 .groupBy({it.first},{it.second}) // { nodeId -> [label]  }
 
-
         val removedNodeProperties = removedNodeProps.getOrDefault(false, emptyList())
         val removedLabels = removedLbls.getOrDefault(false, emptyList())
 
-        val deletedPayload = allOrFiltered(txd.deletedNodes(), nodeAll)
-                { it.labels.any { nodeRoutingLabels.contains(it.name()) } }
+        val deletedPayload = txd.deletedNodes()
                 .map {
                     val beforeNode = NodeChangeBuilder()
                             .withLabels(deletedLabels.getOrDefault(it.id, emptyList()))


### PR DESCRIPTION
In case of delete event with the cdc module enabled with the property filtering we have the following error:

<img width="1561" alt="Schermata 2020-10-20 alle 11 46 19" src="https://user-images.githubusercontent.com/1833335/96570262-6e68fc80-12ca-11eb-901b-85d413224c7b.png">
