### PR TITLE
Fixes #349: Provide option for streams.publish to operate synchronously

### DIFF
--- a/doc/asciidoc/procedures/index.adoc
+++ b/doc/asciidoc/procedures/index.adoc
@@ -91,6 +91,27 @@ Uses:
 
 This procedure return a `RecordMetadata` value like this `{"timestamp": 1, "offset": 2, "partition", 3, "keySize", 4, "valueSize", 5}`
 
+[cols="2*",options="header"]
+|===
+|Variable Name
+|Description
+
+|`timestamp`
+|The timestamp of the record in the topic/partition.
+
+|`offset`
+|The offset of the record in the topic/partition.
+
+|`partition`
+|The partition the record was sent to
+
+|`keySize`
+|The size of the serialized, uncompressed key in bytes
+
+|`valueSize`
+|The size of the serialized, uncompressed value in bytes
+|===
+
 === streams.consume
 
 This procedure allows to consume messages from a given topic.

--- a/doc/asciidoc/procedures/index.adoc
+++ b/doc/asciidoc/procedures/index.adoc
@@ -80,6 +80,15 @@ You can send any kind of data in the payload, nodes, relationships, paths, lists
 
 In case of nodes or relationships if the topic is defined in the patterns provided by the configuration their properties will be filtered in according with the configuration.
 
+
+=== streams.publish.sync
+
+Similar to `streams.publish` procedure, but in a synchronous way.
+
+Uses:
+
+`CALL streams.publish.sync('my-topic', 'my-payload', {<config>}) YIELD topic, payload, config, timestamp, offset, partition, keySize, valueSize RETURN *`
+
 === streams.consume
 
 This procedure allows to consume messages from a given topic.

--- a/doc/asciidoc/procedures/index.adoc
+++ b/doc/asciidoc/procedures/index.adoc
@@ -87,7 +87,9 @@ Similar to `streams.publish` procedure, but in a synchronous way.
 
 Uses:
 
-`CALL streams.publish.sync('my-topic', 'my-payload', {<config>}) YIELD topic, payload, config, timestamp, offset, partition, keySize, valueSize RETURN *`
+`CALL streams.publish.sync('my-topic', 'my-payload', {<config>}) YIELD value RETURN value`
+
+This procedure return a `RecordMetadata` value like this `{"timestamp": 1, "offset": 2, "partition", 3, "keySize", 4, "valueSize", 5}`
 
 === streams.consume
 

--- a/producer/src/main/kotlin/streams/Extensions.kt
+++ b/producer/src/main/kotlin/streams/Extensions.kt
@@ -1,5 +1,6 @@
 package streams
 
+import org.apache.kafka.clients.producer.RecordMetadata
 import org.neo4j.graphdb.Node
 import org.neo4j.graphdb.Relationship
 import org.neo4j.graphdb.schema.ConstraintDefinition
@@ -18,6 +19,15 @@ fun Relationship.toMap(): Map<String, Any?> {
             "end" to endNode.toMap(),
             "type" to EntityType.relationship)
 }
+
+fun RecordMetadata.toMap(): Map<String, Any> = mapOf(
+        "offset" to offset(),
+        "timestamp" to timestamp(),
+        "keySize" to serializedKeySize(),
+        "valueSize" to serializedValueSize(),
+        "partition" to partition()
+)
+
 
 fun ConstraintDefinition.streamsConstraintType(): StreamsConstraintType {
     return when (this.constraintType) {

--- a/producer/src/main/kotlin/streams/StreamsEventRouter.kt
+++ b/producer/src/main/kotlin/streams/StreamsEventRouter.kt
@@ -3,11 +3,13 @@ package streams
 import org.neo4j.kernel.configuration.Config
 import org.neo4j.logging.internal.LogService
 import streams.events.StreamsEvent
-
+import org.apache.kafka.clients.producer.RecordMetadata
 
 abstract class StreamsEventRouter(val logService: LogService?, val config: Config?) {
 
-    abstract fun sendEvents(topic: String, transactionEvents: List<out StreamsEvent>)
+    abstract fun sendEvents(topic: String, transactionEvents: List<out StreamsEvent>, sync: Boolean = false) : List<RecordMetadata?>
+
+    abstract suspend fun sendEventsSync(topic: String, transactionEvents: List<out StreamsEvent>): List<RecordMetadata?>
 
     abstract fun start()
 

--- a/producer/src/main/kotlin/streams/StreamsEventRouter.kt
+++ b/producer/src/main/kotlin/streams/StreamsEventRouter.kt
@@ -7,9 +7,9 @@ import org.apache.kafka.clients.producer.RecordMetadata
 
 abstract class StreamsEventRouter(val logService: LogService?, val config: Config?) {
 
-    abstract fun sendEvents(topic: String, transactionEvents: List<out StreamsEvent>, sync: Boolean = false) : List<RecordMetadata?>
+    abstract fun sendEvents(topic: String, transactionEvents: List<out StreamsEvent>)
 
-    abstract suspend fun sendEventsSync(topic: String, transactionEvents: List<out StreamsEvent>): List<RecordMetadata?>
+    abstract fun sendEventsSync(topic: String, transactionEvents: List<out StreamsEvent>): List<RecordMetadata?>
 
     abstract fun start()
 

--- a/producer/src/main/kotlin/streams/StreamsEventRouter.kt
+++ b/producer/src/main/kotlin/streams/StreamsEventRouter.kt
@@ -8,7 +8,7 @@ abstract class StreamsEventRouter(val logService: LogService?, val config: Confi
 
     abstract fun sendEvents(topic: String, transactionEvents: List<out StreamsEvent>)
 
-    abstract fun sendEventsSync(topic: String, transactionEvents: List<out StreamsEvent>): List<Map<String, Any>?>
+    abstract fun sendEventsSync(topic: String, transactionEvents: List<out StreamsEvent>): List<Map<String, Any>>
 
     abstract fun start()
 

--- a/producer/src/main/kotlin/streams/StreamsEventRouter.kt
+++ b/producer/src/main/kotlin/streams/StreamsEventRouter.kt
@@ -3,13 +3,12 @@ package streams
 import org.neo4j.kernel.configuration.Config
 import org.neo4j.logging.internal.LogService
 import streams.events.StreamsEvent
-import org.apache.kafka.clients.producer.RecordMetadata
 
 abstract class StreamsEventRouter(val logService: LogService?, val config: Config?) {
 
     abstract fun sendEvents(topic: String, transactionEvents: List<out StreamsEvent>)
 
-    abstract fun sendEventsSync(topic: String, transactionEvents: List<out StreamsEvent>): List<RecordMetadata?>
+    abstract fun sendEventsSync(topic: String, transactionEvents: List<out StreamsEvent>): List<Map<String, Any>>
 
     abstract fun start()
 

--- a/producer/src/main/kotlin/streams/StreamsEventRouter.kt
+++ b/producer/src/main/kotlin/streams/StreamsEventRouter.kt
@@ -8,7 +8,7 @@ abstract class StreamsEventRouter(val logService: LogService?, val config: Confi
 
     abstract fun sendEvents(topic: String, transactionEvents: List<out StreamsEvent>)
 
-    abstract fun sendEventsSync(topic: String, transactionEvents: List<out StreamsEvent>): List<Map<String, Any>>
+    abstract fun sendEventsSync(topic: String, transactionEvents: List<out StreamsEvent>): List<Map<String, Any>?>
 
     abstract fun start()
 

--- a/producer/src/main/kotlin/streams/kafka/KafkaEventRouter.kt
+++ b/producer/src/main/kotlin/streams/kafka/KafkaEventRouter.kt
@@ -90,7 +90,7 @@ class KafkaEventRouter: StreamsEventRouter {
         return send(producerRecord, sync)
     }
 
-    private fun sendEvent(partition: Int, topic: String, event: StreamsTransactionEvent, sync: Boolean = false) {
+    private fun sendEvent(partition: Int, topic: String, event: StreamsTransactionEvent) {
         if (log.isDebugEnabled) {
             log.debug("Trying to send a transaction event with txId ${event.meta.txId} and txEventId ${event.meta.txEventId} to kafka")
         }

--- a/producer/src/main/kotlin/streams/kafka/KafkaEventRouter.kt
+++ b/producer/src/main/kotlin/streams/kafka/KafkaEventRouter.kt
@@ -100,10 +100,10 @@ class KafkaEventRouter: StreamsEventRouter {
     }
 
 
-    override fun sendEventsSync(topic: String, transactionEvents: List<out StreamsEvent>): List<Map<String, Any>?> {
+    override fun sendEventsSync(topic: String, transactionEvents: List<out StreamsEvent>): List<Map<String, Any>> {
         producer.beginTransaction()
 
-        val results = transactionEvents.map {
+        val results = transactionEvents.mapNotNull {
             sendEvent(ThreadLocalRandom.current().nextInt(kafkaConfig.numPartitions), topic, it, true)
         }
         producer.commitTransaction()

--- a/producer/src/main/kotlin/streams/kafka/KafkaEventRouter.kt
+++ b/producer/src/main/kotlin/streams/kafka/KafkaEventRouter.kt
@@ -57,10 +57,10 @@ class KafkaEventRouter: StreamsEventRouter {
         StreamsUtils.ignoreExceptions({ kafkaAdminService.stop() }, UninitializedPropertyAccessException::class.java)
     }
 
-    private fun send(producerRecord: ProducerRecord<String, ByteArray>, sync: Boolean = false): Map<String, Any> {
+    private fun send(producerRecord: ProducerRecord<String, ByteArray>, sync: Boolean = false): Map<String, Any>? {
         if (!kafkaAdminService.isValidTopic(producerRecord.topic())) {
             // TODO add logging system here
-            return emptyMap()
+            return null
         }
         return if (sync) {
             producer.send(producerRecord).get().toMap()
@@ -76,11 +76,11 @@ class KafkaEventRouter: StreamsEventRouter {
                     // TODO add logging system here
                 }
             }
-            emptyMap()
+            null
         }
     }
 
-    private fun sendEvent(partition: Int, topic: String, event: StreamsEvent, sync: Boolean = false): Map<String, Any> {
+    private fun sendEvent(partition: Int, topic: String, event: StreamsEvent, sync: Boolean = false): Map<String, Any>? {
         if (log.isDebugEnabled) {
             log.debug("Trying to send a simple event with payload ${event.payload} to kafka")
         }
@@ -100,7 +100,7 @@ class KafkaEventRouter: StreamsEventRouter {
     }
 
 
-    override fun sendEventsSync(topic: String, transactionEvents: List<out StreamsEvent>): List<Map<String, Any>> {
+    override fun sendEventsSync(topic: String, transactionEvents: List<out StreamsEvent>): List<Map<String, Any>?> {
         producer.beginTransaction()
 
         val results = transactionEvents.map {

--- a/producer/src/main/kotlin/streams/procedures/StreamsProcedures.kt
+++ b/producer/src/main/kotlin/streams/procedures/StreamsProcedures.kt
@@ -25,16 +25,9 @@ class StreamsProcedures {
 
         val streamsEvent = buildStreamEvent(topic, payload!!)
 
-        return eventRouter.sendEventsSync(topic, listOf(streamsEvent)).map { StreamPublishResult(
-                topic,
-                payload,
-                config,
-                it["timestamp"] as Long,
-                it["offset"] as Long,
-                (it["partition"] as Int).toLong(),
-                (it["keySize"] as Int).toLong(),
-                (it["valueSize"] as Int).toLong()
-        ) }.stream()
+        return eventRouter.sendEventsSync(topic, listOf(streamsEvent))
+                .mapNotNull { StreamPublishResult(it) }
+                .stream()
     }
 
     @Procedure(mode = Mode.READ, name = "streams.publish")

--- a/producer/src/main/kotlin/streams/procedures/StreamsProcedures.kt
+++ b/producer/src/main/kotlin/streams/procedures/StreamsProcedures.kt
@@ -16,7 +16,6 @@ class StreamsProcedures {
     @Description("streams.publish.sync(topic, payload, config) - Allows custom synchronous streaming from Neo4j to the configured stream environment")
     fun sync(@Name("topic") topic: String?, @Name("payload") payload: Any?,
              @Name(value = "config", defaultValue = "{}") config: Map<String, Any>?): Stream<StreamPublishResult> {
-
         checkEnabled()
         if (topic.isNullOrEmpty()) {
             log?.info("Topic empty, no message sent")
@@ -42,7 +41,6 @@ class StreamsProcedures {
     @Description("streams.publish(topic, payload, config) - Allows custom streaming from Neo4j to the configured stream environment")
     fun publish(@Name("topic") topic: String?, @Name("payload") payload: Any?,
                 @Name(value = "config", defaultValue = "{}") config: Map<String, Any>?) {
-
         checkEnabled()
         if (topic.isNullOrEmpty()) {
             log?.info("Topic empty, no message sent")

--- a/producer/src/main/kotlin/streams/procedures/StreamsProcedures.kt
+++ b/producer/src/main/kotlin/streams/procedures/StreamsProcedures.kt
@@ -29,11 +29,11 @@ class StreamsProcedures {
                 topic,
                 payload,
                 config,
-                it?.timestamp(),
-                it?.offset(),
-                it?.partition()?.toLong(),
-                it?.serializedKeySize()?.toLong(),
-                it?.serializedValueSize()?.toLong()
+                it["timestamp"] as Long,
+                it["offset"] as Long,
+                (it["partition"] as Int).toLong(),
+                (it["keySize"] as Int).toLong(),
+                (it["valueSize"] as Int).toLong()
         ) }.stream()
     }
 

--- a/producer/src/main/kotlin/streams/procedures/StreamsProcedures.kt
+++ b/producer/src/main/kotlin/streams/procedures/StreamsProcedures.kt
@@ -16,7 +16,7 @@ class StreamsProcedures {
     @Procedure(mode = Mode.READ, name = "streams.publish")
     @Description("streams.publish(topic, config) - Allows custom streaming from Neo4j to the configured stream environment")
     fun publish(@Name("topic") topic: String?, @Name("payload") payload: Any?,
-                @Name(value = "config", defaultValue = "{}") config: Map<String, Any>?): Stream<PublishResult> {
+                @Name(value = "config", defaultValue = "{}") config: Map<String, Any>?): Stream<StreamPublishResult> {
 
         checkEnabled()
         if (topic.isNullOrEmpty()) {
@@ -43,7 +43,7 @@ class StreamsProcedures {
             val result = runBlocking {
                 eventRouter.sendEventsSync(topic, listOf(streamsEvent))
             }
-            return result.map { PublishResult(
+            return result.map { StreamPublishResult(
                     topic, payload, config,
                     it?.timestamp(),
                     it?.offset(),

--- a/producer/src/main/kotlin/streams/procedures/StreamsProcedures.kt
+++ b/producer/src/main/kotlin/streams/procedures/StreamsProcedures.kt
@@ -1,6 +1,5 @@
 package streams.procedures
 
-import kotlinx.coroutines.runBlocking
 import org.neo4j.logging.Log
 import org.neo4j.procedure.*
 import streams.StreamsEventRouter
@@ -13,56 +12,74 @@ class StreamsProcedures {
 
     @JvmField @Context var log: Log? = null
 
-    @Procedure(mode = Mode.READ, name = "streams.publish")
-    @Description("streams.publish(topic, config) - Allows custom streaming from Neo4j to the configured stream environment")
-    fun publish(@Name("topic") topic: String?, @Name("payload") payload: Any?,
-                @Name(value = "config", defaultValue = "{}") config: Map<String, Any>?): Stream<StreamPublishResult> {
+    @Procedure(mode = Mode.READ, name = "streams.publish.sync")
+    @Description("streams.publish.sync(topic, payload, config) - Allows custom synchronous streaming from Neo4j to the configured stream environment")
+    fun sync(@Name("topic") topic: String?, @Name("payload") payload: Any?,
+             @Name(value = "config", defaultValue = "{}") config: Map<String, Any>?): Stream<StreamPublishResult> {
 
         checkEnabled()
         if (topic.isNullOrEmpty()) {
             log?.info("Topic empty, no message sent")
             return Stream.empty();
         }
+        checkPayloadNull(payload)
+
+        val streamsEvent = buildStreamEvent(topic, payload!!)
+
+        return eventRouter.sendEventsSync(topic, listOf(streamsEvent)).map { StreamPublishResult(
+                topic,
+                payload,
+                config,
+                it?.timestamp(),
+                it?.offset(),
+                it?.partition()?.toLong(),
+                it?.serializedKeySize()?.toLong(),
+                it?.serializedValueSize()?.toLong()
+        ) }.stream()
+    }
+
+    @Procedure(mode = Mode.READ, name = "streams.publish")
+    @Description("streams.publish(topic, payload, config) - Allows custom streaming from Neo4j to the configured stream environment")
+    fun publish(@Name("topic") topic: String?, @Name("payload") payload: Any?,
+                @Name(value = "config", defaultValue = "{}") config: Map<String, Any>?) {
+
+        checkEnabled()
+        if (topic.isNullOrEmpty()) {
+            log?.info("Topic empty, no message sent")
+            return
+        }
+        checkPayloadNull(payload)
+
+        val streamsEvent = buildStreamEvent(topic, payload!!)
+
+        eventRouter.sendEvents(topic, listOf(streamsEvent))
+    }
+
+    private fun checkEnabled() {
+        if (!eventRouterConfiguration.proceduresEnabled) {
+            throw RuntimeException("In order to use the procedure you must set streams.procedures.enabled=true")
+        }
+    }
+
+    private fun checkPayloadNull(payload: Any?) {
         if (payload == null) {
             log?.error("Payload empty, no message sent")
             throw RuntimeException("Payload may not be null")
         }
-        val streamsEvent = StreamsEventBuilder()
-                .withPayload(payload)
-                .withNodeRoutingConfiguration(StreamsProcedures.eventRouterConfiguration
-                        .nodeRouting
-                        .filter { it.topic == topic }
-                        .firstOrNull())
-                .withRelationshipRoutingConfiguration(StreamsProcedures.eventRouterConfiguration
-                        .relRouting
-                        .filter { it.topic == topic }
-                        .firstOrNull())
-                .withTopic(topic)
-                .build()
-        if (config?.getOrDefault("synchronous", false) as Boolean) {
-            val result = runBlocking {
-                eventRouter.sendEventsSync(topic, listOf(streamsEvent))
-            }
-            return result.map { StreamPublishResult(
-                    topic, payload, config,
-                    it?.timestamp(),
-                    it?.offset(),
-                    it?.partition()?.toLong(),
-                    it?.serializedKeySize()?.toLong(),
-                    it?.serializedValueSize()?.toLong()
-            ) }.stream()
-
-        } else {
-            eventRouter.sendEvents(topic, listOf(streamsEvent))
-            return Stream.empty()
-        }
     }
 
-    private fun checkEnabled() {
-        if (!StreamsProcedures.eventRouterConfiguration.proceduresEnabled) {
-            throw RuntimeException("In order to use the procedure you must set streams.procedures.enabled=true")
-        }
-    }
+    private fun buildStreamEvent(topic: String, payload: Any) = StreamsEventBuilder()
+            .withPayload(payload)
+            .withNodeRoutingConfiguration(eventRouterConfiguration
+                    .nodeRouting
+                    .filter { it.topic == topic }
+                    .firstOrNull())
+            .withRelationshipRoutingConfiguration(eventRouterConfiguration
+                    .relRouting
+                    .filter { it.topic == topic }
+                    .firstOrNull())
+            .withTopic(topic)
+            .build()
 
     companion object {
         private lateinit var eventRouter: StreamsEventRouter

--- a/producer/src/main/kotlin/streams/procedures/StreamsPublishResult.kt
+++ b/producer/src/main/kotlin/streams/procedures/StreamsPublishResult.kt
@@ -1,12 +1,12 @@
 package streams.procedures
 
 data class StreamPublishResult(
-        @JvmField var topic: String,
-        @JvmField var payload: Any,
-        @JvmField var config: Map<String, Any>?,
-        @JvmField var timestamp: Long?,
-        @JvmField var offset: Long?,
-        @JvmField var partition: Long?,
-        @JvmField var keySize: Long?,
-        @JvmField var valueSize: Long?
+        @JvmField val topic: String,
+        @JvmField val payload: Any,
+        @JvmField val config: Map<String, Any>?,
+        @JvmField var timestamp: Long,
+        @JvmField val offset: Long,
+        @JvmField val partition: Long,
+        @JvmField val keySize: Long,
+        @JvmField val valueSize: Long
 )

--- a/producer/src/main/kotlin/streams/procedures/StreamsPublishResult.kt
+++ b/producer/src/main/kotlin/streams/procedures/StreamsPublishResult.kt
@@ -1,0 +1,12 @@
+package streams.procedures
+
+data class PublishResult(
+        @JvmField public var topic: String,
+        @JvmField public var payload: Any,
+        @JvmField public var config: Map<String,Any>?,
+        @JvmField public var timestamp: Long?,
+        @JvmField public var offset: Long?,
+        @JvmField public var partition: Long?,
+        @JvmField public var keySize: Long?,
+        @JvmField public var valueSize: Long?
+)

--- a/producer/src/main/kotlin/streams/procedures/StreamsPublishResult.kt
+++ b/producer/src/main/kotlin/streams/procedures/StreamsPublishResult.kt
@@ -1,6 +1,6 @@
 package streams.procedures
 
-data class PublishResult(
+data class StreamPublishResult(
         @JvmField public var topic: String,
         @JvmField public var payload: Any,
         @JvmField public var config: Map<String,Any>?,

--- a/producer/src/main/kotlin/streams/procedures/StreamsPublishResult.kt
+++ b/producer/src/main/kotlin/streams/procedures/StreamsPublishResult.kt
@@ -1,12 +1,3 @@
 package streams.procedures
 
-data class StreamPublishResult(
-        @JvmField val topic: String,
-        @JvmField val payload: Any,
-        @JvmField val config: Map<String, Any>?,
-        @JvmField var timestamp: Long,
-        @JvmField val offset: Long,
-        @JvmField val partition: Long,
-        @JvmField val keySize: Long,
-        @JvmField val valueSize: Long
-)
+data class StreamPublishResult(@JvmField val value: Map<String, Any>?)

--- a/producer/src/main/kotlin/streams/procedures/StreamsPublishResult.kt
+++ b/producer/src/main/kotlin/streams/procedures/StreamsPublishResult.kt
@@ -1,12 +1,12 @@
 package streams.procedures
 
 data class StreamPublishResult(
-        @JvmField public var topic: String,
-        @JvmField public var payload: Any,
-        @JvmField public var config: Map<String,Any>?,
-        @JvmField public var timestamp: Long?,
-        @JvmField public var offset: Long?,
-        @JvmField public var partition: Long?,
-        @JvmField public var keySize: Long?,
-        @JvmField public var valueSize: Long?
+        @JvmField var topic: String,
+        @JvmField var payload: Any,
+        @JvmField var config: Map<String, Any>?,
+        @JvmField var timestamp: Long?,
+        @JvmField var offset: Long?,
+        @JvmField var partition: Long?,
+        @JvmField var keySize: Long?,
+        @JvmField var valueSize: Long?
 )

--- a/producer/src/test/kotlin/streams/integrations/KafkaEventRouterIT.kt
+++ b/producer/src/test/kotlin/streams/integrations/KafkaEventRouterIT.kt
@@ -6,7 +6,6 @@ import org.hamcrest.Matchers
 import org.junit.*
 import org.junit.rules.TestName
 import org.neo4j.function.ThrowingSupplier
-import org.neo4j.graphdb.Node
 import org.neo4j.kernel.impl.proc.Procedures
 import org.neo4j.kernel.internal.GraphDatabaseAPI
 import org.neo4j.test.TestGraphDatabaseFactory
@@ -226,13 +225,11 @@ class KafkaEventRouterIT {
 
         val result = db.execute("MATCH (n:Baz) \n" +
                 "CALL streams.publish.sync('neo4j', n) \n" +
-                "YIELD topic, payload, offset, partition, keySize, valueSize, timestamp \n" +
-                "RETURN topic, payload, offset, partition, keySize, valueSize, timestamp")
+                "YIELD value \n" +
+                "RETURN value")
         assertTrue { result.hasNext() }
-        val resultMap = result.next()
+        val resultMap = (result.next())["value"] as Map<String, Any>
 
-        assertTrue { resultMap["payload"] is Node }
-        assertEquals("neo4j", resultMap["topic"])
         assertNotNull(resultMap["offset"])
         assertNotNull(resultMap["partition"])
         assertNotNull(resultMap["keySize"])
@@ -259,9 +256,7 @@ class KafkaEventRouterIT {
         val message = "Hello World"
         val result =  db.execute("CALL streams.publish.sync('syncTopic', '$message')")
         assertTrue { result.hasNext() }
-        val resultMap = result.next()
-        assertEquals(message, resultMap["payload"])
-        assertEquals("syncTopic", resultMap["topic"])
+        val resultMap = (result.next())["value"] as Map<String, Any>
         assertNotNull(resultMap["offset"])
         assertNotNull(resultMap["partition"])
         assertNotNull(resultMap["keySize"])

--- a/producer/src/test/kotlin/streams/integrations/KafkaEventRouterIT.kt
+++ b/producer/src/test/kotlin/streams/integrations/KafkaEventRouterIT.kt
@@ -122,158 +122,160 @@ class KafkaEventRouterIT {
     fun testCreateNode() {
         val config = KafkaConfiguration(bootstrapServers = kafka.bootstrapServers,
                 zookeeperConnect = kafka.envMap["KAFKA_ZOOKEEPER_CONNECT"]!!)
-        val consumer = createConsumer(config)
-        consumer.subscribe(listOf("neo4j"))
-        db.execute("CREATE (:Person {name:'John Doe', age:42})").close()
-        val records = consumer.poll(5000)
-        assertEquals(1, records.count())
-        assertEquals(true, records.all {
-            JSONUtils.asStreamsTransactionEvent(it.value()).let {
-                val after = it.payload.after as NodeChange
-                val labels = after.labels
-                val propertiesAfter = after.properties
-                labels == listOf("Person") && propertiesAfter == mapOf("name" to "John Doe", "age" to 42)
-                        && it.meta.operation == OperationType.created
-                        && it.schema.properties == mapOf("name" to "String", "age" to "Long")
-                        && it.schema.constraints.isEmpty()
-            }
-        })
-        consumer.close()
+        createConsumer(config).use { consumer ->
+            consumer.subscribe(listOf("neo4j"))
+            db.execute("CREATE (:Person {name:'John Doe', age:42})").close()
+            val records = consumer.poll(5000)
+            assertEquals(1, records.count())
+            assertEquals(true, records.all {
+                JSONUtils.asStreamsTransactionEvent(it.value()).let {
+                    val after = it.payload.after as NodeChange
+                    val labels = after.labels
+                    val propertiesAfter = after.properties
+                    labels == listOf("Person") && propertiesAfter == mapOf("name" to "John Doe", "age" to 42)
+                            && it.meta.operation == OperationType.created
+                            && it.schema.properties == mapOf("name" to "String", "age" to "Long")
+                            && it.schema.constraints.isEmpty()
+                }
+            })
+        }
     }
 
     @Test
     fun testCreateRelationshipWithRelRouting() {
         val config = KafkaConfiguration(bootstrapServers = kafka.bootstrapServers)
-        val consumer = createConsumer(config)
-        consumer.subscribe(listOf("knows"))
-        db.execute("CREATE (:Person {name:'Andrea'})-[:KNOWS{since: 2014}]->(:Person {name:'Michael'})").close()
-        val records = consumer.poll(5000)
-        assertEquals(1, records.count())
-        assertEquals(true, records.all {
-            JSONUtils.asStreamsTransactionEvent(it.value()).let {
-                var payload = it.payload as RelationshipPayload
-                val properties = payload.after!!.properties!!
-                payload.type == EntityType.relationship && payload.label == "KNOWS"
-                        && properties["since"] == 2014
-                        && it.schema.properties == mapOf("since" to "Long")
-                        && it.schema.constraints.isEmpty()
-            }
-        })
-        consumer.close()
+        createConsumer(config).use { consumer ->
+            consumer.subscribe(listOf("knows"))
+            db.execute("CREATE (:Person {name:'Andrea'})-[:KNOWS{since: 2014}]->(:Person {name:'Michael'})").close()
+            val records = consumer.poll(5000)
+            assertEquals(1, records.count())
+            assertEquals(true, records.all {
+                JSONUtils.asStreamsTransactionEvent(it.value()).let {
+                    var payload = it.payload as RelationshipPayload
+                    val properties = payload.after!!.properties!!
+                    payload.type == EntityType.relationship && payload.label == "KNOWS"
+                            && properties["since"] == 2014
+                            && it.schema.properties == mapOf("since" to "Long")
+                            && it.schema.constraints.isEmpty()
+                }
+            })
+        }
     }
 
     @Test
     fun testCreateNodeWithNodeRouting() {
         val config = KafkaConfiguration(bootstrapServers = kafka.bootstrapServers)
-        val consumer = createConsumer(config)
-        consumer.subscribe(listOf("person"))
-        db.execute("CREATE (:Person {name:'Andrea'})").close()
-        val records = consumer.poll(5000)
-        assertEquals(1, records.count())
-        assertEquals(true, records.all {
-            JSONUtils.asStreamsTransactionEvent(it.value()).let {
-                val payload = it.payload as NodePayload
-                val labels = payload.after!!.labels!!
-                val properties = payload.after!!.properties
-                labels == listOf("Person") && properties == mapOf("name" to "Andrea")
-                        && it.meta.operation == OperationType.created
-                        && it.schema.properties == mapOf("name" to "String")
-                        && it.schema.constraints.isEmpty()
-            }
-        })
-        consumer.close()
+        createConsumer(config).use { consumer ->
+            consumer.subscribe(listOf("person"))
+            db.execute("CREATE (:Person {name:'Andrea'})").close()
+            val records = consumer.poll(5000)
+            assertEquals(1, records.count())
+            assertEquals(true, records.all {
+                JSONUtils.asStreamsTransactionEvent(it.value()).let {
+                    val payload = it.payload as NodePayload
+                    val labels = payload.after!!.labels!!
+                    val properties = payload.after!!.properties
+                    labels == listOf("Person") && properties == mapOf("name" to "Andrea")
+                            && it.meta.operation == OperationType.created
+                            && it.schema.properties == mapOf("name" to "String")
+                            && it.schema.constraints.isEmpty()
+                }
+            })
+        }
     }
 
     @Test
     fun testProcedure() {
         val config = KafkaConfiguration(bootstrapServers = kafka.bootstrapServers)
-        val consumer = createConsumer(config)
-        consumer.subscribe(listOf("neo4j"))
-        val message = "Hello World"
-        db.execute("CALL streams.publish('neo4j', '$message')").close()
-        val records = consumer.poll(5000)
-        assertEquals(1, records.count())
-        assertEquals(true, records.all {
-            JSONUtils.readValue<StreamsEvent>(it.value()).let {
-                message == it.payload
-            }
-        })
-        consumer.close()
+        createConsumer(config).use { consumer ->
+            consumer.subscribe(listOf("neo4j"))
+            val message = "Hello World"
+            db.execute("CALL streams.publish('neo4j', '$message')").close()
+            val records = consumer.poll(5000)
+            assertEquals(1, records.count())
+            assertEquals(true, records.all {
+                JSONUtils.readValue<StreamsEvent>(it.value()).let {
+                    message == it.payload
+                }
+            })
+        }
     }
 
     @Test
     fun testCantPublishNull() {
         val config = KafkaConfiguration(bootstrapServers = kafka.bootstrapServers)
-        val consumer = createConsumer(config)
-        consumer.subscribe(listOf("neo4j"))
+        createConsumer(config).use { consumer ->
+            consumer.subscribe(listOf("neo4j"))
 
-        assertFailsWith(RuntimeException::class) {
-            db.execute("CALL streams.publish('neo4j', null)")
+            assertFailsWith(RuntimeException::class) {
+                db.execute("CALL streams.publish('neo4j', null)")
+            }
         }
     }
 
     @Test
     fun testProcedureSyncWithNode() {
         val config = KafkaConfiguration(bootstrapServers = kafka.bootstrapServers)
-        val consumer = createConsumer(config)
-        consumer.subscribe(listOf("neo4j"))
-        db.execute("MATCH (n:Baz) DETACH DELETE n").close()
-        db.execute("CREATE (n:Baz {age: 23, name: 'Foo', surname: 'Bar'})").close()
+        createConsumer(config).use { consumer ->
 
-        val recordsCreation = consumer.poll(5000)
-        assertEquals(1, recordsCreation.count())
+            consumer.subscribe(listOf("neo4j"))
+            db.execute("MATCH (n:Baz) DETACH DELETE n").close()
+            db.execute("CREATE (n:Baz {age: 23, name: 'Foo', surname: 'Bar'})").close()
 
-        val result = db.execute("MATCH (n:Baz) \n" +
-                "CALL streams.publish.sync('neo4j', n) \n" +
-                "YIELD value \n" +
-                "RETURN value")
-        assertTrue { result.hasNext() }
-        val resultMap = (result.next())["value"] as Map<String, Any>
+            val recordsCreation = consumer.poll(5000)
+            assertEquals(1, recordsCreation.count())
 
-        assertNotNull(resultMap["offset"])
-        assertNotNull(resultMap["partition"])
-        assertNotNull(resultMap["keySize"])
-        assertNotNull(resultMap["valueSize"])
-        assertNotNull(resultMap["timestamp"])
+            db.execute("MATCH (n:Baz) \n" +
+                    "CALL streams.publish.sync('neo4j', n) \n" +
+                    "YIELD value \n" +
+                    "RETURN value").use { result ->
+                assertTrue { result.hasNext() }
+                val resultMap = (result.next())["value"] as Map<String, Any>
 
-        assertFalse { result.hasNext() }
-        result.close()
+                assertNotNull(resultMap["offset"])
+                assertNotNull(resultMap["partition"])
+                assertNotNull(resultMap["keySize"])
+                assertNotNull(resultMap["valueSize"])
+                assertNotNull(resultMap["timestamp"])
 
-        val records = consumer.poll(5000)
-        assertEquals(1, records.count())
-        assertEquals(3, ((records.map {
-            JSONUtils.readValue<StreamsEvent>(it.value())
-            .let { it.payload }
-        }[0] as Map<String, Any>)["properties"] as Map<String, Any>).size )
-        consumer.close()
+                assertFalse { result.hasNext() }
+            }
+
+            val records = consumer.poll(5000)
+            assertEquals(1, records.count())
+            assertEquals(3, ((records.map {
+                JSONUtils.readValue<StreamsEvent>(it.value())
+                        .let { it.payload }
+            }[0] as Map<String, Any>)["properties"] as Map<String, Any>).size)
+        }
     }
 
     @Test
     fun testProcedureSync() {
         val config = KafkaConfiguration(bootstrapServers = kafka.bootstrapServers)
-        val consumer = createConsumer(config)
-        consumer.subscribe(listOf("syncTopic"))
-        val message = "Hello World"
-        val result =  db.execute("CALL streams.publish.sync('syncTopic', '$message')")
-        assertTrue { result.hasNext() }
-        val resultMap = (result.next())["value"] as Map<String, Any>
-        assertNotNull(resultMap["offset"])
-        assertNotNull(resultMap["partition"])
-        assertNotNull(resultMap["keySize"])
-        assertNotNull(resultMap["valueSize"])
-        assertNotNull(resultMap["timestamp"])
+        createConsumer(config).use { consumer ->
+            consumer.subscribe(listOf("syncTopic"))
+            val message = "Hello World"
+            db.execute("CALL streams.publish.sync('syncTopic', '$message')").use { result ->
+                assertTrue { result.hasNext() }
+                val resultMap = (result.next())["value"] as Map<String, Any>
+                assertNotNull(resultMap["offset"])
+                assertNotNull(resultMap["partition"])
+                assertNotNull(resultMap["keySize"])
+                assertNotNull(resultMap["valueSize"])
+                assertNotNull(resultMap["timestamp"])
 
-        assertFalse { result.hasNext() }
-        result.close()
-
-        val records = consumer.poll(5000)
-        assertEquals(1, records.count())
-        assertEquals(true, records.all {
-            JSONUtils.readValue<StreamsEvent>(it.value()).let {
-                message == it.payload
+                assertFalse { result.hasNext() }
             }
-        })
-        consumer.close()
+
+            val records = consumer.poll(5000)
+            assertEquals(1, records.count())
+            assertEquals(true, records.all {
+                JSONUtils.readValue<StreamsEvent>(it.value()).let {
+                    message == it.payload
+                }
+            })
+        }
     }
 
     private fun getRecordCount(config: KafkaConfiguration, topic: String): Int {
@@ -308,23 +310,23 @@ class KafkaEventRouterIT {
     @Test
     fun testCreateNodeWithConstraints() {
         val config = KafkaConfiguration(bootstrapServers = kafka.bootstrapServers)
-        val consumer = createConsumer(config)
-        consumer.subscribe(listOf("personConstraints"))
-        db.execute("CREATE (:PersonConstr {name:'Andrea'})").close()
-        val records = consumer.poll(5000)
-        assertEquals(1, records.count())
-        assertEquals(true, records.all {
-            JSONUtils.asStreamsTransactionEvent(it.value()).let {
-                val payload = it.payload as NodePayload
-                val labels = payload.after!!.labels!!
-                val properties = payload.after!!.properties
-                labels == listOf("PersonConstr") && properties == mapOf("name" to "Andrea")
-                        && it.meta.operation == OperationType.created
-                        && it.schema.properties == mapOf("name" to "String")
-                        && it.schema.constraints == listOf(Constraint("PersonConstr", setOf("name"), StreamsConstraintType.UNIQUE))
-            }
-        })
-        consumer.close()
+        createConsumer(config).use { consumer ->
+            consumer.subscribe(listOf("personConstraints"))
+            db.execute("CREATE (:PersonConstr {name:'Andrea'})").close()
+            val records = consumer.poll(5000)
+            assertEquals(1, records.count())
+            assertEquals(true, records.all {
+                JSONUtils.asStreamsTransactionEvent(it.value()).let {
+                    val payload = it.payload as NodePayload
+                    val labels = payload.after!!.labels!!
+                    val properties = payload.after!!.properties
+                    labels == listOf("PersonConstr") && properties == mapOf("name" to "Andrea")
+                            && it.meta.operation == OperationType.created
+                            && it.schema.properties == mapOf("name" to "String")
+                            && it.schema.constraints == listOf(Constraint("PersonConstr", setOf("name"), StreamsConstraintType.UNIQUE))
+                }
+            })
+        }
     }
 
     @Test
@@ -337,74 +339,74 @@ class KafkaEventRouterIT {
             |MERGE (p)-[:BOUGHT]->(pp)
         """.trimMargin())
         val config = KafkaConfiguration(bootstrapServers = kafka.bootstrapServers)
-        val consumer = createConsumer(config)
-        consumer.subscribe(listOf("personConstraints", "productConstraints", "boughtConstraints"))
-        val records = consumer.poll(10000)
-        assertEquals(3, records.count())
+        createConsumer(config).use { consumer ->
+            consumer.subscribe(listOf("personConstraints", "productConstraints", "boughtConstraints"))
+            val records = consumer.poll(10000)
+            assertEquals(3, records.count())
 
-        val map = records
-                .map {
-                    val evt = JSONUtils.asStreamsTransactionEvent(it.value())
-                    evt.payload.type to evt
+            val map = records
+                    .map {
+                        val evt = JSONUtils.asStreamsTransactionEvent(it.value())
+                        evt.payload.type to evt
+                    }
+                    .groupBy({ it.first }, { it.second })
+            assertEquals(true, map[EntityType.node].orEmpty().isNotEmpty() && map[EntityType.node].orEmpty().all {
+                val payload = it.payload as NodePayload
+                val (labels, properties) = payload.after!!.labels!! to payload.after!!.properties!!
+                when (labels) {
+                    listOf("ProductConstr") -> properties == mapOf("name" to "My Awesome Product", "price" to "100€")
+                            && it.meta.operation == OperationType.created
+                            && it.schema.properties == mapOf("name" to "String", "price" to "String")
+                            && it.schema.constraints == listOf(Constraint("ProductConstr", setOf("name"), StreamsConstraintType.UNIQUE))
+                    listOf("PersonConstr") -> properties == mapOf("name" to "Andrea")
+                            && it.meta.operation == OperationType.created
+                            && it.schema.properties == mapOf("name" to "String")
+                            && it.schema.constraints == listOf(Constraint("PersonConstr", setOf("name"), StreamsConstraintType.UNIQUE))
+                    else -> false
                 }
-                .groupBy({ it.first }, { it.second })
-        assertEquals(true, map[EntityType.node].orEmpty().isNotEmpty() && map[EntityType.node].orEmpty().all {
-            val payload = it.payload as NodePayload
-            val (labels, properties) = payload.after!!.labels!! to payload.after!!.properties!!
-            when (labels) {
-                listOf("ProductConstr") -> properties == mapOf("name" to "My Awesome Product", "price" to "100€")
+            })
+            assertEquals(true, map[EntityType.relationship].orEmpty().isNotEmpty() && map[EntityType.relationship].orEmpty().all {
+                val payload = it.payload as RelationshipPayload
+                val (start, end, properties) = Triple(payload.start, payload.end, payload.after!!.properties!!)
+                properties.isNullOrEmpty()
+                        && start.ids == mapOf("name" to "Andrea")
+                        && end.ids == mapOf("name" to "My Awesome Product")
                         && it.meta.operation == OperationType.created
-                        && it.schema.properties == mapOf("name" to "String", "price" to "String")
-                        && it.schema.constraints == listOf(Constraint("ProductConstr", setOf("name"), StreamsConstraintType.UNIQUE))
-                listOf("PersonConstr") -> properties == mapOf("name" to "Andrea")
-                        && it.meta.operation == OperationType.created
-                        && it.schema.properties == mapOf("name" to "String")
-                        && it.schema.constraints == listOf(Constraint("PersonConstr", setOf("name"), StreamsConstraintType.UNIQUE))
-                else -> false
-            }
-        })
-        assertEquals(true, map[EntityType.relationship].orEmpty().isNotEmpty() && map[EntityType.relationship].orEmpty().all {
-            val payload = it.payload as RelationshipPayload
-            val (start, end, properties) = Triple(payload.start, payload.end, payload.after!!.properties!!)
-            properties.isNullOrEmpty()
-                    && start.ids == mapOf("name" to "Andrea")
-                    && end.ids == mapOf("name" to "My Awesome Product")
-                    && it.meta.operation == OperationType.created
-                    && it.schema.properties == emptyMap<String, String>()
-                    && it.schema.constraints.toSet() == setOf(
-                            Constraint("PersonConstr", setOf("name"), StreamsConstraintType.UNIQUE),
-                            Constraint("ProductConstr", setOf("name"), StreamsConstraintType.UNIQUE))
-        })
-        consumer.close()
+                        && it.schema.properties == emptyMap<String, String>()
+                        && it.schema.constraints.toSet() == setOf(
+                        Constraint("PersonConstr", setOf("name"), StreamsConstraintType.UNIQUE),
+                        Constraint("ProductConstr", setOf("name"), StreamsConstraintType.UNIQUE))
+            })
+        }
     }
 
     @Test
     fun testDeleteNodeWithTestDeleteTopic() {
         val topic = "testdeletetopic"
         val config = KafkaConfiguration(bootstrapServers = kafka.bootstrapServers)
-        val kafkaConsumer = createConsumer(config)
-        kafkaConsumer.subscribe(listOf(topic))
-        db.execute("CREATE (:Person:ToRemove {name:'John Doe', age:42})-[:KNOWS]->(:Person {name:'Jane Doe', age:36})")
-        org.neo4j.test.assertion.Assert.assertEventually(ThrowingSupplier<Boolean, Exception> {
-            kafkaConsumer.poll(5000).count() > 0
-        }, Matchers.equalTo(true), 30, TimeUnit.SECONDS)
-        db.execute("MATCH (p:Person {name:'John Doe', age:42}) REMOVE p:ToRemove")
-        org.neo4j.test.assertion.Assert.assertEventually(ThrowingSupplier<Boolean, Exception> {
-            kafkaConsumer.poll(5000)
-                    .map { JSONUtils.asStreamsTransactionEvent(it.value()) }
-                    .filter { it.meta.operation == OperationType.updated }
-                    .count() > 0
-        }, Matchers.equalTo(true), 30, TimeUnit.SECONDS)
-        db.execute("MATCH (p:Person) DETACH DELETE p")
-        val count = db.execute("MATCH (p:Person {name:'John Doe', age:42}) RETURN count(p) AS count")
-                .columnAs<Long>("count").next()
-        assertEquals(0, count)
-        org.neo4j.test.assertion.Assert.assertEventually(ThrowingSupplier<Boolean, Exception> {
-            kafkaConsumer.poll(5000)
-                    .map { JSONUtils.asStreamsTransactionEvent(it.value()) }
-                    .filter { it.meta.operation == OperationType.deleted }
-                    .count() > 0
-        }, Matchers.equalTo(true), 30, TimeUnit.SECONDS)
-        kafkaConsumer.close()
+        createConsumer(config).use { kafkaConsumer ->
+            kafkaConsumer.subscribe(listOf(topic))
+            db.execute("CREATE (:Person:ToRemove {name:'John Doe', age:42})-[:KNOWS]->(:Person {name:'Jane Doe', age:36})")
+            org.neo4j.test.assertion.Assert.assertEventually(ThrowingSupplier<Boolean, Exception> {
+                kafkaConsumer.poll(5000).count() > 0
+            }, Matchers.equalTo(true), 30, TimeUnit.SECONDS)
+            db.execute("MATCH (p:Person {name:'John Doe', age:42}) REMOVE p:ToRemove")
+            org.neo4j.test.assertion.Assert.assertEventually(ThrowingSupplier<Boolean, Exception> {
+                kafkaConsumer.poll(5000)
+                        .map { JSONUtils.asStreamsTransactionEvent(it.value()) }
+                        .filter { it.meta.operation == OperationType.updated }
+                        .count() > 0
+            }, Matchers.equalTo(true), 30, TimeUnit.SECONDS)
+            db.execute("MATCH (p:Person) DETACH DELETE p")
+            val count = db.execute("MATCH (p:Person {name:'John Doe', age:42}) RETURN count(p) AS count")
+                    .columnAs<Long>("count").next()
+            assertEquals(0, count)
+            org.neo4j.test.assertion.Assert.assertEventually(ThrowingSupplier<Boolean, Exception> {
+                kafkaConsumer.poll(5000)
+                        .map { JSONUtils.asStreamsTransactionEvent(it.value()) }
+                        .filter { it.meta.operation == OperationType.deleted }
+                        .count() > 0
+            }, Matchers.equalTo(true), 30, TimeUnit.SECONDS)
+        }
     }
 }

--- a/producer/src/test/kotlin/streams/mocks/MockStreamsEventRouter.kt
+++ b/producer/src/test/kotlin/streams/mocks/MockStreamsEventRouter.kt
@@ -7,20 +7,21 @@ import org.neo4j.logging.internal.LogService
 import streams.StreamsEventRouter
 import streams.events.StreamsEvent
 import streams.events.StreamsTransactionEvent
+import streams.toMap
 
 class MockStreamsEventRouter(logService: LogService? = null, config: Config? = null): StreamsEventRouter(logService, config) {
 
     private fun fakeRecordMetadata(topic: String) = RecordMetadata(
             TopicPartition(topic, 0),
             0, 1, 2, 3, 4, 5
-    )
+    ).toMap()
 
     override fun sendEvents(topic: String, streamsTransactionEvents: List<out StreamsEvent>) {
         events.addAll(streamsTransactionEvents as List<StreamsTransactionEvent>)
     }
 
-    override fun sendEventsSync(topic: String, streamsTransactionEvents: List<out StreamsEvent>): List<RecordMetadata?> {
-        val result = mutableListOf<RecordMetadata>()
+    override fun sendEventsSync(topic: String, streamsTransactionEvents: List<out StreamsEvent>): List<Map<String, Any>> {
+        val result = mutableListOf<Map<String, Any>>()
         streamsTransactionEvents.forEach {
             result.add(fakeRecordMetadata(topic))
         }

--- a/producer/src/test/kotlin/streams/mocks/MockStreamsEventRouter.kt
+++ b/producer/src/test/kotlin/streams/mocks/MockStreamsEventRouter.kt
@@ -15,21 +15,16 @@ class MockStreamsEventRouter(logService: LogService? = null, config: Config? = n
             0, 1, 2, 3, 4, 5
     )
 
-    private fun addRecordMetadata(topic: String , streamsTransactionEvents: List<out StreamsEvent>) : List<RecordMetadata?>{
+    override fun sendEvents(topic: String, streamsTransactionEvents: List<out StreamsEvent>) {
+        events.addAll(streamsTransactionEvents as List<StreamsTransactionEvent>)
+    }
+
+    override fun sendEventsSync(topic: String, streamsTransactionEvents: List<out StreamsEvent>): List<RecordMetadata?> {
         val result = mutableListOf<RecordMetadata>()
         streamsTransactionEvents.forEach {
             result.add(fakeRecordMetadata(topic))
         }
         return result
-    }
-
-    override fun sendEvents(topic: String, streamsTransactionEvents: List<out StreamsEvent>, sync: Boolean): List<RecordMetadata?> {
-        events.addAll(streamsTransactionEvents as List<StreamsTransactionEvent>)
-        return addRecordMetadata(topic, streamsTransactionEvents)
-    }
-
-    override suspend fun sendEventsSync(topic: String, streamsTransactionEvents: List<out StreamsEvent>): List<RecordMetadata?> {
-        return addRecordMetadata(topic, streamsTransactionEvents)
     }
 
     override fun start() {}


### PR DESCRIPTION
Fixes neo4j-contrib#349
Fixes neo4j-contrib#158

One sentence summary of the change.

## Proposed Changes (Mandatory)

A brief list of proposed changes in order to fix the issue:

  - Added `streams.publish.sync` procedure
  - Added `sendEventsSync` in `StreamsEventRouter.kt`
  - Added `throw RuntimeException("Payload may not be null")` in `streams.publish` and `streams.publish.sync` procedures
