### PR TITLE
Use new parameter format [docs only]

### DIFF
--- a/doc/asciidoc/consumer/index.adoc
+++ b/doc/asciidoc/consumer/index.adoc
@@ -60,7 +60,7 @@ Under the hood the Sink inject the event object as a parameter in this way
 
 [source,cypher]
 ----
-UNWIND {events} AS event
+UNWIND $events AS event
 MERGE (n:Label {id: event.id})
     ON CREATE SET n += event.properties
 ----
@@ -72,7 +72,7 @@ Where `{events}` is a json list, so continuing with the example above a possible
 :params events => [{id:"alice@example.com",properties:{name:"Alice",age:32}},
     {id:"bob@example.com",properties:{name:"Bob",age:42}}]
 
-UNWIND {events} AS event
+UNWIND $events AS event
 MERGE (n:Label {id: event.id})
     ON CREATE SET n += event.properties
 ----


### PR DESCRIPTION
The parameter format in the doc is outdated and an error is thrown if used with `Neo4j 4.x`.

Fixes #<Replace with the number of the issue, Mandatory>

One sentence summary of the change.

## Proposed Changes (Mandatory)

A brief list of proposed changes in order to fix the issue:

  -
  -
  -
