### PR TITLE
Only commit if topicMap is not empty

### DIFF
--- a/consumer/src/main/kotlin/streams/kafka/KafkaManualCommitEventConsumer.kt
+++ b/consumer/src/main/kotlin/streams/kafka/KafkaManualCommitEventConsumer.kt
@@ -63,7 +63,7 @@ class KafkaManualCommitEventConsumer(config: KafkaSinkConfiguration,
     }
 
     private fun commitData(commit: Boolean, topicMap: Map<TopicPartition, OffsetAndMetadata>) {
-        if (commit) {
+        if (commit && topicMap.isNotEmpty()) {
             if (asyncCommit) {
                 if (log.isDebugEnabled) {
                     log.debug("Committing data in async")


### PR DESCRIPTION
Fixes #377 

This really only changes the logging behavior. The commit on an empty map was a no-op anyway

## Proposed Changes (Mandatory)

A brief list of proposed changes in order to fix the issue:

  - Check whether the topicMap is empty before committing