### PR TITLE
fixes #358: Dynamic Configuration

### DIFF
--- a/common/src/main/kotlin/streams/configuration/StreamsConfig.kt
+++ b/common/src/main/kotlin/streams/configuration/StreamsConfig.kt
@@ -1,0 +1,78 @@
+package streams.configuration
+
+import org.neo4j.kernel.internal.GraphDatabaseAPI
+import org.neo4j.logging.Log
+import org.neo4j.logging.internal.LogService
+import org.neo4j.plugin.configuration.ConfigurationLifecycle
+import org.neo4j.plugin.configuration.ConfigurationLifecycleUtils
+import org.neo4j.plugin.configuration.EventType
+import org.neo4j.plugin.configuration.listners.ConfigurationLifecycleListener
+import streams.utils.StreamsUtils
+import java.io.File
+import java.util.concurrent.ConcurrentHashMap
+
+class StreamsConfig(triggerPeriod: Int = DEFAULT_TRIGGER_PERIOD, log: Log) {
+
+    companion object {
+        @JvmStatic private val cache = ConcurrentHashMap<String, StreamsConfig>()
+
+        private const val DEFAULT_TRIGGER_PERIOD: Int = 10000
+
+        private const val SUN_JAVA_COMMAND = "sun.java.command"
+        private const val CONF_DIR_ARG = "config-dir="
+        private const val DEFAULT_PATH = "."
+
+        fun getNeo4jConfFolder(): String { // sun.java.command=com.neo4j.server.enterprise.CommercialEntryPoint --home-dir=/home/myid/neo4j-enterprise-4.0.0-alpha09mr02 --config-dir=/home/myid/neo4j-enterprise-4.0.0-alpha09mr02/conf
+            val command = System.getProperty(SUN_JAVA_COMMAND, "")
+            return command.split("--")
+                    .map(String::trim)
+                    .filter { it.startsWith(CONF_DIR_ARG) }
+                    .map { it.substring(CONF_DIR_ARG.length) }
+                    .firstOrNull() ?: DEFAULT_PATH
+        }
+
+        fun getInstance(db: GraphDatabaseAPI): StreamsConfig = cache.computeIfAbsent(StreamsUtils.getName(db)) {
+            StreamsConfig(log = db.dependencyResolver
+                    .resolveDependency(LogService::class.java)
+                    .getUserLog(StreamsConfig::class.java))
+        }
+
+        fun removeInstance(db: GraphDatabaseAPI): StreamsConfig? = cache.remove(StreamsUtils.getName(db))
+    }
+
+    private val configLifecycle: ConfigurationLifecycle
+
+    init {
+        val neo4jConfFolder = System.getenv().getOrDefault("NEO4J_CONF", getNeo4jConfFolder())
+        configLifecycle = ConfigurationLifecycle(triggerPeriod,
+                "$neo4jConfFolder${File.separator}streams.conf",
+                true, log, true, "streams.", "kafka.")
+    }
+
+    fun setProperty(key: String, value: Any, save: Boolean = true) {
+        configLifecycle.setProperty(key, value, save)
+    }
+
+    fun setProperties(map: Map<String, Any>, save: Boolean = true) {
+        configLifecycle.setProperties(map, save)
+    }
+
+    fun reload() {
+        configLifecycle.reload()
+    }
+
+    fun start() {
+        configLifecycle.start()
+    }
+
+    fun getConfiguration(): MutableMap<String, Any> = ConfigurationLifecycleUtils.toMap(configLifecycle.configuration)
+
+    fun addConfigurationLifecycleListener(evt: EventType,
+                                          listener: ConfigurationLifecycleListener) {
+        configLifecycle.addConfigurationLifecycleListener(evt, listener)
+    }
+
+    fun stop(shutdown: Boolean = false) {
+        configLifecycle.stop(shutdown)
+    }
+}

--- a/common/src/main/kotlin/streams/configuration/StreamsConfig.kt
+++ b/common/src/main/kotlin/streams/configuration/StreamsConfig.kt
@@ -57,6 +57,14 @@ class StreamsConfig(triggerPeriod: Int = DEFAULT_TRIGGER_PERIOD, log: Log) {
         configLifecycle.setProperties(map, save)
     }
 
+    fun removeProperty(key: String, save: Boolean = true) {
+        configLifecycle.removeProperty(key, save)
+    }
+
+    fun removeProperties(keys: Collection<String>, save: Boolean = true) {
+        configLifecycle.removeProperties(keys, save)
+    }
+
     fun reload() {
         configLifecycle.reload()
     }

--- a/common/src/main/kotlin/streams/configuration/StreamsConfigProcedures.kt
+++ b/common/src/main/kotlin/streams/configuration/StreamsConfigProcedures.kt
@@ -7,6 +7,13 @@ import org.neo4j.procedure.*
 import streams.events.KeyValueResult
 import java.util.stream.Stream
 
+data class StreamsConfigProceduresConfiguration(val save: Boolean) {
+    constructor(map: Map<String, Any>?): this(map.orEmpty()
+        .getOrDefault("save", "true")
+        .toString()
+        .toBoolean())
+}
+
 class StreamsConfigProcedures {
 
     @JvmField @Context
@@ -27,11 +34,24 @@ class StreamsConfigProcedures {
         }
         val map = properties.mapValues { it.value.toString() }
         val instance = StreamsConfig.getInstance(db as GraphDatabaseAPI)
-        val save = config.orEmpty()
-                .getOrDefault("save", "true")
-                .toString()
-                .toBoolean()
-        instance.setProperties(map, save)
+        val cfg = StreamsConfigProceduresConfiguration(config)
+        instance.setProperties(map, cfg.save)
+        return get()
+    }
+
+    @Admin
+    @Procedure
+    @Description("""
+        streams.configuration.remove(<properties_list>, <config_map>) YIELD name, value
+    """)
+    fun remove(@Name(value = "keys") properties: List<String>,
+            @Name(value = "config", defaultValue = "{}") config: Map<String, Any>?): Stream<KeyValueResult> {
+        if (properties.isNullOrEmpty()) {
+            throw RuntimeException("Property must be not empty")
+        }
+        val instance = StreamsConfig.getInstance(db as GraphDatabaseAPI)
+        val cfg = StreamsConfigProceduresConfiguration(config)
+        instance.removeProperties(properties, cfg.save)
         return get()
     }
 

--- a/common/src/main/kotlin/streams/configuration/StreamsConfigProcedures.kt
+++ b/common/src/main/kotlin/streams/configuration/StreamsConfigProcedures.kt
@@ -1,0 +1,48 @@
+package streams.configuration
+
+import org.neo4j.graphdb.GraphDatabaseService
+import org.neo4j.kernel.internal.GraphDatabaseAPI
+import org.neo4j.logging.Log
+import org.neo4j.procedure.*
+import streams.events.KeyValueResult
+import java.util.stream.Stream
+
+class StreamsConfigProcedures {
+
+    @JvmField @Context
+    var log: Log? = null
+
+    @JvmField @Context
+    var db: GraphDatabaseService? = null
+
+    @Admin
+    @Procedure
+    @Description("""
+        streams.configuration.set(<properties_map>, <config_map>) YIELD name, value
+    """)
+    fun set(@Name(value = "properties") properties: Map<String, Any>?,
+                @Name(value = "config", defaultValue = "{}") config: Map<String, Any>?): Stream<KeyValueResult> {
+        if (properties.isNullOrEmpty()) {
+            throw RuntimeException("Property must be not empty")
+        }
+        val map = properties.mapValues { it.value.toString() }
+        val instance = StreamsConfig.getInstance(db as GraphDatabaseAPI)
+        val save = config.orEmpty()
+                .getOrDefault("save", "true")
+                .toString()
+                .toBoolean()
+        instance.setProperties(map, save)
+        return get()
+    }
+
+    @Admin
+    @Procedure
+    @Description("""
+        streams.configuration.get() YIELD name, value
+    """)
+    fun get(): Stream<KeyValueResult> = StreamsConfig.getInstance(db as GraphDatabaseAPI)
+            .getConfiguration()
+            .entries
+            .map { KeyValueResult(it.key, it.value) }
+            .stream()
+}

--- a/common/src/main/kotlin/streams/events/ProcedureResults.kt
+++ b/common/src/main/kotlin/streams/events/ProcedureResults.kt
@@ -1,0 +1,4 @@
+package streams.events
+
+class StreamResult(@JvmField val event: Map<String, *>)
+class KeyValueResult(@JvmField val name: String, @JvmField val value: Any?)

--- a/common/src/main/kotlin/streams/utils/StreamsUtils.kt
+++ b/common/src/main/kotlin/streams/utils/StreamsUtils.kt
@@ -2,6 +2,7 @@ package streams.utils
 
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.delay
+import org.neo4j.kernel.internal.GraphDatabaseAPI
 
 object StreamsUtils {
 
@@ -25,7 +26,7 @@ object StreamsUtils {
         }
     }
 
-    fun blockUntilTrueOrTimeout(timeout: Long, delay: Long = 1000, action: () -> Boolean): Boolean = runBlocking {
+    fun blockUntilFalseOrTimeout(timeout: Long, delay: Long = 1000, action: () -> Boolean): Boolean = runBlocking {
         val start = System.currentTimeMillis()
         var success = action()
         while (System.currentTimeMillis() - start < timeout && !success) {
@@ -34,5 +35,7 @@ object StreamsUtils {
         }
         success
     }
+
+    fun getName(db: GraphDatabaseAPI) = db.databaseLayout().databaseDirectory().absolutePath
 
 }

--- a/common/src/test/kotlin/streams/configuration/StreamsConfigProceduresIT.kt
+++ b/common/src/test/kotlin/streams/configuration/StreamsConfigProceduresIT.kt
@@ -1,0 +1,41 @@
+package streams.configuration
+
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.neo4j.kernel.impl.proc.Procedures
+import org.neo4j.kernel.internal.GraphDatabaseAPI
+import org.neo4j.test.TestGraphDatabaseFactory
+import kotlin.streams.toList
+import kotlin.test.assertEquals
+
+@Suppress("DEPRECATION")
+class StreamsConfigProceduresIT {
+
+    private lateinit var db: GraphDatabaseAPI
+
+    @Before
+    fun setUp() {
+        db = TestGraphDatabaseFactory()
+                .newImpermanentDatabaseBuilder()
+                .newGraphDatabase() as GraphDatabaseAPI
+    }
+
+    @After
+    fun tearDown() {
+        db.shutdown()
+    }
+
+    @Test
+    fun `should set properties`() {
+        db.dependencyResolver.resolveDependency(Procedures::class.java)
+                .registerProcedure(StreamsConfigProcedures::class.java, true)
+        val props = mapOf("streams.procedures.enabled" to "true")
+        val actual = db.execute("CALL streams.configuration.set(\$props, {save: false})", mapOf("props" to props))
+                .stream()
+                .toList()
+        assertEquals(1, actual.size)
+        val expected = mapOf("name" to "streams.procedures.enabled", "value" to "true")
+        assertEquals(expected, actual[0])
+    }
+}

--- a/common/src/test/kotlin/streams/configuration/StreamsConfigProceduresIT.kt
+++ b/common/src/test/kotlin/streams/configuration/StreamsConfigProceduresIT.kt
@@ -38,4 +38,21 @@ class StreamsConfigProceduresIT {
         val expected = mapOf("name" to "streams.procedures.enabled", "value" to "true")
         assertEquals(expected, actual[0])
     }
+
+    @Test
+    fun `should remove properties`() {
+        db.dependencyResolver.resolveDependency(Procedures::class.java)
+            .registerProcedure(StreamsConfigProcedures::class.java, true)
+        val props = mapOf("streams.procedures.enabled" to "true")
+        val actual = db.execute("CALL streams.configuration.set(\$props, {save: false})", mapOf("props" to props))
+            .stream()
+            .toList()
+        assertEquals(1, actual.size)
+        val expected = mapOf("name" to "streams.procedures.enabled", "value" to "true")
+        assertEquals(expected, actual[0])
+        val actualRemoved = db.execute("CALL streams.configuration.remove(\$props, {save: false})", mapOf("props" to props.keys))
+            .stream()
+            .toList()
+        assertEquals(0, actualRemoved.size)
+    }
 }

--- a/consumer/pom.xml
+++ b/consumer/pom.xml
@@ -122,6 +122,7 @@
                                     <sourceDirs>
                                         <sourceDir>${project.basedir}/src/test/kotlin/integrations</sourceDir>
                                         <sourceDir>${project.basedir}/src/test/kotlin/streams</sourceDir>
+                                        <sourceDir>${project.basedir}/src/test/kotlin/extension</sourceDir>
                                     </sourceDirs>
                                 </configuration>
                             </execution>

--- a/consumer/src/main/kotlin/streams/StreamsEventSinkAvailabilityListener.kt
+++ b/consumer/src/main/kotlin/streams/StreamsEventSinkAvailabilityListener.kt
@@ -1,139 +1,68 @@
 package streams
 
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import org.neo4j.kernel.availability.AvailabilityListener
 import org.neo4j.kernel.internal.GraphDatabaseAPI
-import streams.procedures.StreamsSinkProcedures
-import streams.service.TopicUtils
-import streams.utils.Neo4jUtils
+import org.neo4j.plugin.configuration.EventType
+import streams.configuration.StreamsConfig
 import streams.utils.StreamsUtils
 import java.util.concurrent.ConcurrentHashMap
 
 class StreamsEventSinkAvailabilityListener(dependencies: StreamsEventSinkExtensionFactory.Dependencies): AvailabilityListener {
     private val db = dependencies.graphdatabaseAPI()
     private val logService = dependencies.log()
-    private val configuration = dependencies.config()
-    private val log = logService.getUserLog(StreamsEventSinkAvailabilityListener::class.java)
-
-    private var eventSink: StreamsEventSink? = null
-    private val streamsSinkConfiguration: StreamsSinkConfiguration
-    private val streamsTopicService: StreamsTopicService
-    private val streamsQueryExecution: StreamsEventSinkQueryExecution
 
     private val mutex = Mutex()
 
-    init {
-        streamsSinkConfiguration = StreamsSinkConfiguration.from(configuration)
-        streamsTopicService = StreamsTopicService(db)
-        streamsTopicService.setAll(streamsSinkConfiguration.topics)
-        val strategyMap = TopicUtils.toStrategyMap(streamsSinkConfiguration.topics,
-                streamsSinkConfiguration.sourceIdStrategyConfig)
-        streamsQueryExecution = StreamsEventSinkQueryExecution(streamsTopicService, db,
-                logService.getUserLog(StreamsEventSinkQueryExecution::class.java),
-                strategyMap)
-    }
+    private val streamsConfig = StreamsConfig.getInstance(db)
+    private val listener = StreamsSinkConfigurationListener(db, logService.getUserLog(StreamsSinkConfigurationListener::class.java))
 
+    init {
+        streamsConfig.addConfigurationLifecycleListener(EventType.CONFIGURATION_INITIALIZED,
+                listener)
+    }
 
     override fun available() {
         runBlocking {
             mutex.withLock {
                 setAvailable(db, true)
-                if (eventSink == null) {
-                    // Create the Sink if not exists
-                    eventSink = StreamsEventSinkFactory
-                            .getStreamsEventSink(configuration,
-                                    streamsQueryExecution,
-                                    streamsTopicService,
-                                    log,
-                                    db)
-                }
-            }
-        }
-        try {
-            log.info("Initialising the Streams Sink module")
-
-            // start the Sink
-            if (Neo4jUtils.isCluster(db, log)) {
-                log.info("The Sink module is running in a cluster, checking for the ${Neo4jUtils.LEADER}")
-                Neo4jUtils.waitForTheLeader(db, log) { initSinkModule() }
-            } else {
-                runInASingleInstance()
-            }
-        } catch (e: Exception) {
-            log.error("Error initializing the streaming sink:", e)
-        }
-
-        // Register required services for the Procedures
-        StreamsSinkProcedures.registerStreamsSinkConfiguration(streamsSinkConfiguration)
-        StreamsSinkProcedures.registerStreamsEventConsumerFactory(eventSink!!.getEventConsumerFactory())
-        StreamsSinkProcedures.registerStreamsEventSinkConfigMapper(eventSink!!.getEventSinkConfigMapper())
-        StreamsSinkProcedures.registerStreamsEventSink(eventSink!!)
-    }
-
-    private fun runInASingleInstance() {
-        // check if is writeable instance
-        Neo4jUtils.executeInWriteableInstance(db) {
-            if (streamsSinkConfiguration.clusterOnly) {
-                log.info("""
-                        |Cannot init the Streams Sink module as is forced to work only in a cluster env, 
-                        |please check the value of `streams.${StreamsSinkConfigurationConstants.CLUSTER_ONLY}`
-                    """.trimMargin())
-            } else {
-                initSinkModule()
+                streamsConfig.start()
             }
         }
     }
 
-    private fun initSinkModule() {
-        if (streamsSinkConfiguration.checkApocTimeout > -1) {
-            waitForApoc()
-        } else {
-            initSink()
-        }
-    }
-
-    private fun waitForApoc() {
-        GlobalScope.launch(Dispatchers.IO) {
-            val success = StreamsUtils.blockUntilTrueOrTimeout(streamsSinkConfiguration.checkApocTimeout, streamsSinkConfiguration.checkApocInterval) {
-                val hasApoc = Neo4jUtils.hasApoc(db)
-                if (!hasApoc && log.isDebugEnabled) {
-                    log.debug("APOC not loaded yet, next check in ${streamsSinkConfiguration.checkApocInterval} ms")
-                }
-                hasApoc
-            }
-            if (success) {
-                initSink()
-            } else {
-                log.info("Streams Sink plugin not loaded as APOC are not installed")
+    override fun unavailable() {
+        runBlocking {
+            mutex.withLock {
+                setAvailable(db, false)
+                streamsConfig.stop()
             }
         }
     }
 
-    private fun initSink() {
-        eventSink?.start()
-        eventSink?.printInvalidTopics()
-    }
-
-    override fun unavailable() = runBlocking {
-        mutex.withLock {
-            setAvailable(db, false)
-            eventSink?.stop()
+    fun shutdown() {
+        runBlocking {
+            mutex.withLock {
+                streamsConfig.stop(true)
+                remove(db)
+            }
         }
-        Unit
     }
 
     companion object {
+        // this is necessary in case for local testing with a causal cluster
         @JvmStatic private val available = ConcurrentHashMap<String, Boolean>()
 
-        fun isAvailable(db: GraphDatabaseAPI) = available.getOrDefault(db.databaseLayout().databaseDirectory().absolutePath, false)
+        fun isAvailable(db: GraphDatabaseAPI) = available.getOrDefault(StreamsUtils.getName(db), false)
 
-        fun setAvailable(db: GraphDatabaseAPI, isAvailable: Boolean): Unit = available.set(db.databaseLayout().databaseDirectory().absolutePath, isAvailable)
+        fun setAvailable(db: GraphDatabaseAPI, isAvailable: Boolean): Unit = available.set(StreamsUtils.getName(db), isAvailable)
 
-        fun remove(db: GraphDatabaseAPI) = available.remove(db.databaseLayout().databaseDirectory().absolutePath)
+        fun remove(db: GraphDatabaseAPI) {
+            available.remove(StreamsUtils.getName(db))
+            StreamsConfig.removeInstance(db)
+        }
+
     }
 }

--- a/consumer/src/main/kotlin/streams/StreamsEventSinkExtensionFactory.kt
+++ b/consumer/src/main/kotlin/streams/StreamsEventSinkExtensionFactory.kt
@@ -34,8 +34,7 @@ class StreamsEventSinkExtensionFactory : KernelExtensionFactory<StreamsEventSink
 
         override fun stop() {
             try {
-                streamsAvailabilityListener.unavailable()
-                StreamsEventSinkAvailabilityListener.remove(dependencies.graphdatabaseAPI())
+                streamsAvailabilityListener.shutdown()
             } catch (e : Throwable) {
                 val message = e.message ?: "Generic error, please check the stack trace:"
                 streamsLog.error(message, e)

--- a/consumer/src/main/kotlin/streams/StreamsSinkConfigurationListener.kt
+++ b/consumer/src/main/kotlin/streams/StreamsSinkConfigurationListener.kt
@@ -1,0 +1,178 @@
+package streams
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import org.apache.commons.configuration2.ImmutableConfiguration
+import org.neo4j.kernel.internal.GraphDatabaseAPI
+import org.neo4j.logging.Log
+import org.neo4j.plugin.configuration.ConfigurationLifecycleUtils
+import org.neo4j.plugin.configuration.EventType
+import org.neo4j.plugin.configuration.listners.ConfigurationLifecycleListener
+import streams.configuration.StreamsConfig
+import streams.kafka.KafkaSinkConfiguration
+import streams.procedures.StreamsSinkProcedures
+import streams.service.TopicUtils
+import streams.utils.KafkaValidationUtils
+import streams.utils.Neo4jUtils
+import streams.utils.StreamsUtils
+
+class StreamsSinkConfigurationListener(private val db: GraphDatabaseAPI,
+                                       private val log: Log) : ConfigurationLifecycleListener {
+
+    private val mutex = Mutex()
+
+    var eventSink: StreamsEventSink? = null
+
+    private val streamsTopicService = StreamsTopicService()
+
+    private var lastConfig: KafkaSinkConfiguration? = null
+
+    private val producerConfig = KafkaValidationUtils.getProducerProperties()
+
+    private fun KafkaSinkConfiguration.excludeSourceProps() = this.asProperties()
+        ?.filterNot { producerConfig.contains(it.key) || it.key.toString().startsWith("streams.source") }
+
+    // visible for testing
+    fun isConfigurationChanged(configMap: Map<String, String>) = when (configMap
+        .getOrDefault("streams.sink", "streams.kafka.KafkaEventSink")) {
+        "streams.kafka.KafkaEventSink" ->  {
+            // we validate all properties except for the ones related to the Producer
+            // we use this strategy because there are some properties related to the Confluent Platform
+            // that we're not able to track from the Apache Packages
+            // i.e. the Schema Registry
+            val kafkaConfig = KafkaSinkConfiguration.create(configMap)
+            val config = kafkaConfig.excludeSourceProps()
+            val lastConfig = this.lastConfig?.excludeSourceProps()
+            val streamsConfig = kafkaConfig.streamsSinkConfiguration
+            config != lastConfig || streamsConfig != this.lastConfig?.streamsSinkConfiguration
+        }
+        else -> true
+    }
+
+    override fun onShutdown() {
+        runBlocking {
+            mutex.withLock {
+                shutdown()
+            }
+        }
+    }
+
+    private fun shutdown() {
+        val isShuttingDown = eventSink != null
+        if (isShuttingDown) {
+            log.info("[Sink] Shutting down the Streams Sink Module")
+        }
+        eventSink?.stop()
+        eventSink = null
+        StreamsSinkProcedures.unregisterStreamsEventSink(db)
+        if (isShuttingDown) {
+            log.info("[Sink] Shutdown of the Streams Sink Module completed")
+        }
+    }
+
+    override fun onConfigurationChange(evt: EventType, config: ImmutableConfiguration) {
+        if (config.isEmpty) {
+            return
+        }
+        runBlocking {
+            mutex.withLock {
+                log.info("[Sink] An event change is detected ${evt.name}")
+                val configMap = ConfigurationLifecycleUtils.toMap(config)
+                    .mapValues { it.value.toString() }
+                if (!isConfigurationChanged(configMap)) {
+                    log.info("[Sink] The configuration is not changed so the module will not restarted")
+                    return@runBlocking
+                }
+                shutdown()
+                if (log.isDebugEnabled) {
+                    log.debug("[Sink] The new configuration is: $configMap")
+                }
+                start(configMap)
+            }
+        }
+    }
+
+    private fun start(configMap: Map<String, String>) {
+        lastConfig = KafkaSinkConfiguration.create(configMap)
+        val streamsSinkConfiguration = lastConfig!!.streamsSinkConfiguration
+        streamsTopicService.clearAll()
+        streamsTopicService.setAll(streamsSinkConfiguration.topics)
+
+        val strategyMap = TopicUtils.toStrategyMap(streamsSinkConfiguration.topics,
+                streamsSinkConfiguration.sourceIdStrategyConfig)
+        val streamsQueryExecution = StreamsEventSinkQueryExecution(streamsTopicService, db,
+                log, strategyMap)
+
+        eventSink = StreamsEventSinkFactory
+                .getStreamsEventSink(configMap,
+                        streamsQueryExecution,
+                        streamsTopicService,
+                        log,
+                        db)
+        try {
+            if (streamsSinkConfiguration.enabled) {
+                log.info("[Sink] The Streams Sink module is starting")
+                if (Neo4jUtils.isCluster(db, log)) {
+                    Neo4jUtils.waitForTheLeader(db, log) { initSinkModule(streamsSinkConfiguration) }
+                } else {
+                    runInASingleInstance(streamsSinkConfiguration)
+                }
+            }
+        } catch (e: Exception) {
+            log.warn("Cannot start the Streams Sink module because the following exception", e)
+        }
+
+        log.info("[Sink] Registering the Streams Sink procedures")
+        StreamsSinkProcedures.registerStreamsEventSink(db, eventSink!!)
+    }
+
+    private fun initSink() {
+        eventSink?.start()
+        eventSink?.printInvalidTopics()
+    }
+
+    private fun runInASingleInstance(streamsSinkConfiguration: StreamsSinkConfiguration) {
+        // check if is writeable instance
+        Neo4jUtils.executeInWriteableInstance(db) {
+            if (streamsSinkConfiguration.clusterOnly) {
+                log.info("""
+                        |Cannot init the Streams Sink module as is forced to work only in a cluster env, 
+                        |please check the value of `${StreamsSinkConfigurationConstants.CLUSTER_ONLY}`
+                    """.trimMargin())
+            } else {
+                initSinkModule(streamsSinkConfiguration)
+            }
+        }
+    }
+
+    private fun initSinkModule(streamsSinkConfiguration: StreamsSinkConfiguration) {
+        if (streamsSinkConfiguration.checkApocTimeout > -1) {
+            waitForApoc()
+        } else {
+            initSink()
+        }
+    }
+
+    private fun waitForApoc() {
+        GlobalScope.launch(Dispatchers.IO) {
+            val success = StreamsUtils.blockUntilFalseOrTimeout(eventSink!!.streamsSinkConfiguration.checkApocTimeout,
+                    eventSink!!.streamsSinkConfiguration.checkApocInterval) {
+                val hasApoc = Neo4jUtils.hasApoc(db)
+                if (!hasApoc && log.isDebugEnabled) {
+                    log.debug("[Sink] APOC not loaded yet, next check in ${eventSink!!.streamsSinkConfiguration.checkApocInterval} ms")
+                }
+                hasApoc
+            }
+            if (success) {
+                initSink()
+            } else {
+                log.info("[Sink] Streams Sink plugin not loaded as APOC are not installed")
+            }
+        }
+    }
+
+}

--- a/consumer/src/main/kotlin/streams/StreamsTopicService.kt
+++ b/consumer/src/main/kotlin/streams/StreamsTopicService.kt
@@ -3,16 +3,13 @@ package streams
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
-import org.neo4j.kernel.internal.GraphDatabaseAPI
 import streams.service.TopicType
 import streams.service.Topics
 import streams.utils.Neo4jUtils
 import java.util.Collections
 import java.util.concurrent.ConcurrentHashMap
 
-class StreamsTopicService(db: GraphDatabaseAPI) {
-    private val log = Neo4jUtils.getLogService(db).getUserLog(StreamsTopicService::class.java)
-
+class StreamsTopicService() {
     private val mutex = Mutex()
 
     private val storage = ConcurrentHashMap<TopicType, Any>()

--- a/consumer/src/test/kotlin/enterprise/KafkaNeo4jClusterRecoveryIT.kt
+++ b/consumer/src/test/kotlin/enterprise/KafkaNeo4jClusterRecoveryIT.kt
@@ -8,8 +8,10 @@ import kotlinx.coroutines.runBlocking
 import org.apache.commons.io.FileUtils
 import org.apache.kafka.clients.producer.ProducerRecord
 import org.hamcrest.CoreMatchers.equalTo
+import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import org.neo4j.causalclustering.core.consensus.roles.Role
 import org.neo4j.causalclustering.discovery.Cluster
 import org.neo4j.causalclustering.discovery.CoreClusterMember
 import org.neo4j.consistency.ConsistencyCheckService
@@ -22,7 +24,11 @@ import org.neo4j.logging.NullLogProvider
 import org.neo4j.test.DbRepresentation
 import org.neo4j.test.assertion.Assert.assertEventually
 import org.neo4j.test.causalclustering.ClusterRule
+import streams.configuration.StreamsConfig
+import streams.events.StreamsPluginStatus
+import streams.procedures.StreamsSinkProcedures
 import streams.serialization.JSONUtils
+import streams.utils.StreamsUtils
 import java.io.File
 import java.nio.file.Files
 import java.nio.file.Path
@@ -53,14 +59,40 @@ class KafkaNeo4jClusterRecoveryIT: KafkaEventSinkBase() {
             .withSharedCoreParam(Settings.setting("dbms.tx_log.rotation.size", Settings.STRING, ""), "1M")
             .withSharedCoreParam(Settings.setting("streams.check.writeable.instance.interval", Settings.STRING, ""), "100")
             .withSharedCoreParam(Settings.setting("streams.cluster.only", Settings.STRING, ""), "true")
+            .withSharedCoreParam(Settings.setting("streams.sink.poll.interval", Settings.STRING, ""), "1000")
             .withSharedCoreParam(Settings.setting("unsupported.dbms.tx_log.fail_on_corrupted_log_files", Settings.STRING, ""), "false")
             .withNumberOfCoreMembers(3)
             .withNumberOfReadReplicas(0)
 
+    private lateinit var cluster: Cluster<*>
+
+    @Before
+    fun before() {
+        val declaredField = clusterRule.javaClass.getDeclaredField("coreParams")
+        declaredField.isAccessible = true
+        val configMap: Map<String, String> = declaredField.get(clusterRule) as Map<String, String>
+        cluster = clusterRule.startCluster()
+        cluster.awaitLeader()
+        if (configMap.isNotEmpty()) {
+            println("Applying the following configuration to the cluster $configMap")
+            cluster.coreMembers().forEach {
+                StreamsConfig.getInstance(it.database())
+                        .setProperties(configMap, false)
+            }
+        }
+        val success = StreamsUtils.blockUntilFalseOrTimeout(100000, 1000) {
+            StreamsSinkProcedures.hasStatus(cluster.getMemberWithRole(Role.LEADER).database(), StreamsPluginStatus.RUNNING)
+        }
+        if (success) {
+            println("Plugin successfully started")
+        } else {
+            println("Plugin not started")
+        }
+    }
+
     @Test
     fun shouldBeConsistentAfterShutdown() {
         // given
-        val cluster = clusterRule.startCluster()
         initClusterData(cluster)
         fireSomeLoadAtTheCluster(cluster)
         val storeDirs = cluster.getStoreDirs()
@@ -88,7 +120,6 @@ class KafkaNeo4jClusterRecoveryIT: KafkaEventSinkBase() {
     @Test
     fun singleServerWithinClusterShouldBeConsistentAfterRestart() {
         // given
-        val cluster = clusterRule.startCluster()
         val clusterSize = cluster.numberOfCoreMembersReportedByTopology()
         initClusterData(cluster)
         //fireSomeLoadAtTheCluster(cluster)
@@ -119,7 +150,7 @@ class KafkaNeo4jClusterRecoveryIT: KafkaEventSinkBase() {
         // then
         assertEventually("All cores have the same data",
                 ThrowingSupplier<Int, Exception> { cluster.getDbRepresentations().size },
-                equalTo(1), 10, TimeUnit.SECONDS)
+                equalTo(1), 30, TimeUnit.SECONDS)
         cluster.shutdown()
         storeDirs.forEach { storeDir: File -> assertConsistent(storeDir) }
     }
@@ -145,7 +176,6 @@ class KafkaNeo4jClusterRecoveryIT: KafkaEventSinkBase() {
             val metadata = kafkaProducer.send(producerRecord).get()
             println("Sent record $it to topic ${metadata.topic()}")
         }
-        delay(30000)
         assertEventually("The data should be consumed successfully",
                 ThrowingSupplier<Int, Exception> {
                     val atomicCount = AtomicInteger()
@@ -156,6 +186,6 @@ class KafkaNeo4jClusterRecoveryIT: KafkaEventSinkBase() {
                     }
                     atomicCount.get()
                 },
-                equalTo(records), 5, TimeUnit.SECONDS)
+                equalTo(records), 30, TimeUnit.SECONDS)
     }
 }

--- a/consumer/src/test/kotlin/extension/GraphDatabaseBuilderExtension.kt
+++ b/consumer/src/test/kotlin/extension/GraphDatabaseBuilderExtension.kt
@@ -1,0 +1,45 @@
+package extension
+
+import org.neo4j.graphdb.GraphDatabaseService
+import org.neo4j.graphdb.factory.GraphDatabaseBuilder
+import org.neo4j.kernel.internal.GraphDatabaseAPI
+import streams.configuration.StreamsConfig
+import streams.events.StreamsPluginStatus
+import streams.procedures.StreamsSinkProcedures
+import streams.utils.StreamsUtils
+
+fun GraphDatabaseBuilder.newDatabase(initialPluginStatus: StreamsPluginStatus = StreamsPluginStatus.RUNNING): GraphDatabaseService {
+    val configField = try {
+        this.javaClass.superclass.getDeclaredField("config")
+    } catch (e: Exception) {
+        this.javaClass.getDeclaredField("config")
+    }
+    configField.isAccessible = true
+    val config: Map<String, Any> = configField.get(this) as Map<String, Any>
+    val db = newGraphDatabase() as GraphDatabaseAPI
+    // as the Configuration System now lives "outside" Neo4j
+    // in order to apply the configuration we wait for the
+    // database to be available and the we apply the configuration
+    // taken from the GraphDatabaseBuilder `config` param
+    if (db.isAvailable(30000)) {
+        println("Setting Config from APIs: $config")
+        if (config.isNotEmpty()) {
+            StreamsConfig.getInstance(db).setProperties(config, false)
+        }
+    } else {
+        throw RuntimeException("Cannot set Config because database is not available")
+    }
+    // the status check is important because allows us to define the expected
+    // initial state of the streams plugin
+    // for instance in same cases i.e procedures test we don't subscribe any topics
+    // this means that the expected status of the plugin at the startup is STOPPED
+    // because we don't allow to start the database with the plugin in a inconsistent state
+    val success = StreamsUtils.blockUntilFalseOrTimeout(180000, 1000) {
+        StreamsSinkProcedures.hasStatus(db, initialPluginStatus)
+    }
+    if (!success && StreamsSinkProcedures.isRegistered(db)) {
+        db.shutdown()
+        throw RuntimeException("Cannot start the Sink properly")
+    }
+    return db
+}

--- a/consumer/src/test/kotlin/integrations/kafka/KafkaEventSinkAvro.kt
+++ b/consumer/src/test/kotlin/integrations/kafka/KafkaEventSinkAvro.kt
@@ -1,10 +1,9 @@
 package integrations.kafka
 
 import io.confluent.kafka.serializers.KafkaAvroDeserializer
-import kotlinx.coroutines.runBlocking
+import extension.newDatabase
 import org.apache.avro.SchemaBuilder
 import org.apache.avro.generic.GenericRecordBuilder
-import org.apache.commons.lang3.exception.ExceptionUtils
 import org.apache.kafka.clients.producer.ProducerRecord
 import org.hamcrest.Matchers
 import org.junit.Test
@@ -12,7 +11,6 @@ import org.neo4j.function.ThrowingSupplier
 import org.neo4j.graphdb.Node
 import org.neo4j.kernel.internal.GraphDatabaseAPI
 import org.neo4j.test.assertion.Assert
-import streams.serialization.JSONUtils
 import java.util.*
 import java.util.concurrent.TimeUnit
 
@@ -27,7 +25,7 @@ class KafkaEventSinkAvro : KafkaEventSinkBase() {
         graphDatabaseBuilder.setConfig("kafka.key.deserializer", KafkaAvroDeserializer::class.java.name)
         graphDatabaseBuilder.setConfig("kafka.value.deserializer", KafkaAvroDeserializer::class.java.name)
         graphDatabaseBuilder.setConfig("kafka.schema.registry.url", KafkaEventSinkSuiteIT.schemaRegistry.getSchemaRegistryUrl())
-        db = graphDatabaseBuilder.newGraphDatabase() as GraphDatabaseAPI
+        db = graphDatabaseBuilder.newDatabase() as GraphDatabaseAPI
 
         val PLACE_SCHEMA = SchemaBuilder.builder("com.namespace")
                 .record("Place").fields()
@@ -75,7 +73,7 @@ class KafkaEventSinkAvro : KafkaEventSinkBase() {
         graphDatabaseBuilder.setConfig("kafka.value.deserializer", KafkaAvroDeserializer::class.java.name)
         graphDatabaseBuilder.setConfig("kafka.schema.registry.url", KafkaEventSinkSuiteIT.schemaRegistry.getSchemaRegistryUrl())
         graphDatabaseBuilder.setConfig("streams.sink.topic.pattern.node.$topic","(:Place{!name})")
-        db = graphDatabaseBuilder.newGraphDatabase() as GraphDatabaseAPI
+        db = graphDatabaseBuilder.newDatabase() as GraphDatabaseAPI
 
         val PLACE_SCHEMA = SchemaBuilder.builder("com.namespace")
                 .record("Place").fields()

--- a/consumer/src/test/kotlin/integrations/kafka/KafkaEventSinkCUDFormat.kt
+++ b/consumer/src/test/kotlin/integrations/kafka/KafkaEventSinkCUDFormat.kt
@@ -1,5 +1,6 @@
 package integrations.kafka
 
+import extension.newDatabase
 import org.apache.kafka.clients.producer.ProducerRecord
 import org.hamcrest.Matchers
 import org.junit.Test
@@ -37,7 +38,7 @@ class KafkaEventSinkCUDFormat : KafkaEventSinkBase() {
         }
         val topic = UUID.randomUUID().toString()
         graphDatabaseBuilder.setConfig("streams.sink.topic.cud", topic)
-        db = graphDatabaseBuilder.newGraphDatabase() as GraphDatabaseAPI
+        db = graphDatabaseBuilder.newDatabase() as GraphDatabaseAPI
 
         // when
         list.forEach {
@@ -76,7 +77,7 @@ class KafkaEventSinkCUDFormat : KafkaEventSinkBase() {
         val key = "_id"
         val topic = UUID.randomUUID().toString()
         graphDatabaseBuilder.setConfig("streams.sink.topic.cud", topic)
-        db = graphDatabaseBuilder.newGraphDatabase() as GraphDatabaseAPI
+        db = graphDatabaseBuilder.newDatabase() as GraphDatabaseAPI
         val idList = db.beginTx().use {
             db.execute("UNWIND range(1, 10) AS id CREATE (:Foo:Bar {key: id})").close()
             assertEquals(10, db.allNodes.count())
@@ -140,7 +141,7 @@ class KafkaEventSinkCUDFormat : KafkaEventSinkBase() {
         }
         val topic = UUID.randomUUID().toString()
         graphDatabaseBuilder.setConfig("streams.sink.topic.cud", topic)
-        db = graphDatabaseBuilder.newGraphDatabase() as GraphDatabaseAPI
+        db = graphDatabaseBuilder.newDatabase() as GraphDatabaseAPI
         db.beginTx().use {
             db.execute("UNWIND range(1, 10) AS id CREATE (n:Foo:Bar {key: id})").close()
             assertEquals(10, db.allNodes.count())
@@ -178,7 +179,7 @@ class KafkaEventSinkCUDFormat : KafkaEventSinkBase() {
         }
         val topic = UUID.randomUUID().toString()
         graphDatabaseBuilder.setConfig("streams.sink.topic.cud", topic)
-        db = graphDatabaseBuilder.newGraphDatabase() as GraphDatabaseAPI
+        db = graphDatabaseBuilder.newDatabase() as GraphDatabaseAPI
         db.beginTx().use {
             db.execute("UNWIND range(1, 5) AS id CREATE (s:Foo:Bar {key: id})-[:MY_REL]->(u:Foo:Bar {key: id + 1})").close()
             assertEquals(10, db.allNodes.count())
@@ -215,7 +216,7 @@ class KafkaEventSinkCUDFormat : KafkaEventSinkBase() {
         }
         val topic = UUID.randomUUID().toString()
         graphDatabaseBuilder.setConfig("streams.sink.topic.cud", topic)
-        db = graphDatabaseBuilder.newGraphDatabase() as GraphDatabaseAPI
+        db = graphDatabaseBuilder.newDatabase() as GraphDatabaseAPI
         db.beginTx().use {
             db.execute("""
                 UNWIND range(1, 10) AS id
@@ -266,7 +267,7 @@ class KafkaEventSinkCUDFormat : KafkaEventSinkBase() {
         }
         val topic = UUID.randomUUID().toString()
         graphDatabaseBuilder.setConfig("streams.sink.topic.cud", topic)
-        db = graphDatabaseBuilder.newGraphDatabase() as GraphDatabaseAPI
+        db = graphDatabaseBuilder.newDatabase() as GraphDatabaseAPI
         db.beginTx().use {
             db.execute("UNWIND range(1, 10) AS id CREATE (:Foo:Bar {key: id})-[:$rel_type{id: id}]->(:FooBar{key: id})").close()
             assertEquals(10, db.allRelationships.count())
@@ -306,7 +307,7 @@ class KafkaEventSinkCUDFormat : KafkaEventSinkBase() {
         val rel_type = "MY_REL"
         val topic = UUID.randomUUID().toString()
         graphDatabaseBuilder.setConfig("streams.sink.topic.cud", topic)
-        db = graphDatabaseBuilder.newGraphDatabase() as GraphDatabaseAPI
+        db = graphDatabaseBuilder.newDatabase() as GraphDatabaseAPI
         val idMap = db.beginTx().use {
             db.execute("UNWIND range(1, 10) AS id CREATE (:Foo:Bar {key: id})-[:$rel_type{id: id}]->(:FooBar{key: id})").close()
             assertEquals(10, db.allRelationships.count())

--- a/consumer/src/test/kotlin/integrations/kafka/KafkaEventSinkCommit.kt
+++ b/consumer/src/test/kotlin/integrations/kafka/KafkaEventSinkCommit.kt
@@ -2,6 +2,7 @@ package integrations.kafka
 
 import integrations.kafka.KafkaTestUtils.createConsumer
 import kotlinx.coroutines.runBlocking
+import extension.newDatabase
 import org.apache.kafka.clients.consumer.ConsumerConfig
 import org.apache.kafka.clients.producer.ProducerRecord
 import org.apache.kafka.common.TopicPartition
@@ -20,7 +21,7 @@ class KafkaEventSinkCommit : KafkaEventSinkBase() {
         val topic = UUID.randomUUID().toString()
         graphDatabaseBuilder.setConfig("streams.sink.topic.cypher.$topic", cypherQueryTemplate)
         graphDatabaseBuilder.setConfig("kafka.${ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG}", "false")
-        db = graphDatabaseBuilder.newGraphDatabase() as GraphDatabaseAPI
+        db = graphDatabaseBuilder.newDatabase() as GraphDatabaseAPI
         val partition = 0
         var producerRecord = ProducerRecord(topic, partition, UUID.randomUUID().toString(), JSONUtils.writeValueAsBytes(data))
         kafkaProducer.send(producerRecord).get()
@@ -49,7 +50,7 @@ class KafkaEventSinkCommit : KafkaEventSinkBase() {
         graphDatabaseBuilder.setConfig("streams.sink.topic.cypher.$topic", cypherQueryTemplate)
         graphDatabaseBuilder.setConfig("kafka.${ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG}", "false")
         graphDatabaseBuilder.setConfig("kafka.streams.commit.async", "true")
-        db = graphDatabaseBuilder.newGraphDatabase() as GraphDatabaseAPI
+        db = graphDatabaseBuilder.newDatabase() as GraphDatabaseAPI
         val partition = 0
         var producerRecord = ProducerRecord(topic, partition, UUID.randomUUID().toString(), JSONUtils.writeValueAsBytes(data))
         kafkaProducer.send(producerRecord).get()
@@ -86,7 +87,7 @@ class KafkaEventSinkCommit : KafkaEventSinkBase() {
         graphDatabaseBuilder.setConfig("streams.sink.topic.cypher.${customer.first}", customer.second)
         graphDatabaseBuilder.setConfig("streams.sink.topic.cypher.${bought.first}", bought.second)
         graphDatabaseBuilder.setConfig("kafka.${ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG}", "false")
-        db = graphDatabaseBuilder.newGraphDatabase() as GraphDatabaseAPI
+        db = graphDatabaseBuilder.newDatabase() as GraphDatabaseAPI
 
         val props = mapOf("id" to 1, "name" to "My Awesome Product")
         var producerRecord = ProducerRecord(product.first, UUID.randomUUID().toString(),

--- a/consumer/src/test/kotlin/integrations/kafka/KafkaEventSinkDLQ.kt
+++ b/consumer/src/test/kotlin/integrations/kafka/KafkaEventSinkDLQ.kt
@@ -1,6 +1,7 @@
 package integrations.kafka
 
 import integrations.kafka.KafkaTestUtils.createConsumer
+import extension.newDatabase
 import org.apache.kafka.clients.producer.ProducerRecord
 import org.apache.kafka.common.serialization.ByteArrayDeserializer
 import org.hamcrest.Matchers
@@ -23,7 +24,7 @@ class KafkaEventSinkDLQ : KafkaEventSinkBase() {
         graphDatabaseBuilder.setConfig("streams.sink."+ErrorService.ErrorConfig.DLQ_TOPIC, dlqTopic)
         graphDatabaseBuilder.setConfig("streams.sink."+ErrorService.ErrorConfig.DLQ_HEADERS, "true")
         graphDatabaseBuilder.setConfig("streams.sink."+ErrorService.ErrorConfig.DLQ_HEADER_PREFIX, "__streams.errors.")
-        db = graphDatabaseBuilder.newGraphDatabase() as GraphDatabaseAPI
+        db = graphDatabaseBuilder.newDatabase() as GraphDatabaseAPI
         val data = mapOf("id" to null, "name" to "Andrea", "surname" to "Santurbano")
 
         var producerRecord = ProducerRecord(topic, UUID.randomUUID().toString(), JSONUtils.writeValueAsBytes(data))
@@ -63,7 +64,7 @@ class KafkaEventSinkDLQ : KafkaEventSinkBase() {
         graphDatabaseBuilder.setConfig("streams.sink."+ErrorService.ErrorConfig.DLQ_TOPIC, dlqTopic)
         graphDatabaseBuilder.setConfig("streams.sink."+ErrorService.ErrorConfig.DLQ_HEADERS, "true")
         graphDatabaseBuilder.setConfig("streams.sink."+ErrorService.ErrorConfig.DLQ_HEADER_PREFIX, "__streams.errors.")
-        db = graphDatabaseBuilder.newGraphDatabase() as GraphDatabaseAPI
+        db = graphDatabaseBuilder.newDatabase() as GraphDatabaseAPI
 
         val data = """{id: 1, "name": "Andrea", "surname": "Santurbano"}"""
 

--- a/consumer/src/test/kotlin/integrations/kafka/KafkaEventSinkNoConfigurationIT.kt
+++ b/consumer/src/test/kotlin/integrations/kafka/KafkaEventSinkNoConfigurationIT.kt
@@ -1,10 +1,12 @@
 package integrations.kafka
 
 import io.confluent.kafka.serializers.KafkaAvroDeserializer
+import extension.newDatabase
 import org.junit.Test
 import org.neo4j.kernel.internal.GraphDatabaseAPI
 import org.neo4j.test.TestGraphDatabaseFactory
 import org.testcontainers.containers.GenericContainer
+import streams.events.StreamsPluginStatus
 import kotlin.test.assertEquals
 
 
@@ -29,9 +31,10 @@ class KafkaEventSinkNoConfigurationIT {
                 .setConfig("kafka.bootstrap.servers", "")
                 .setConfig("streams.sink.enabled", "true")
                 .setConfig("streams.sink.topic.cypher.$topic", "CREATE (p:Place{name: event.name, coordinates: event.coordinates, citizens: event.citizens})")
-                .newGraphDatabase() as GraphDatabaseAPI
+                .newDatabase(StreamsPluginStatus.STOPPED) as GraphDatabaseAPI
         val count = db.execute("MATCH (n) RETURN COUNT(n) AS count").columnAs<Long>("count").next()
         assertEquals(0L, count)
+        db.shutdown()
     }
 
     @Test
@@ -47,9 +50,10 @@ class KafkaEventSinkNoConfigurationIT {
                 .setConfig("streams.sink.topic.cypher.$topic", "CREATE (p:Place{name: event.name, coordinates: event.coordinates, citizens: event.citizens})")
                 .setConfig("kafka.key.deserializer", KafkaAvroDeserializer::class.java.name)
                 .setConfig("kafka.value.deserializer", KafkaAvroDeserializer::class.java.name)
-                .newGraphDatabase() as GraphDatabaseAPI
+                .newDatabase(StreamsPluginStatus.STOPPED) as GraphDatabaseAPI
         val count = db.execute("MATCH (n) RETURN COUNT(n) AS count").columnAs<Long>("count").next()
         assertEquals(0L, count)
         fakeWebServer.stop()
+        db.shutdown()
     }
 }

--- a/consumer/src/test/kotlin/integrations/kafka/KafkaEventSinkNoTopicAutocreationIT.kt
+++ b/consumer/src/test/kotlin/integrations/kafka/KafkaEventSinkNoTopicAutocreationIT.kt
@@ -1,6 +1,7 @@
 package integrations.kafka
 
 import integrations.kafka.KafkaTestUtils.createProducer
+import extension.newDatabase
 import org.apache.kafka.clients.admin.AdminClient
 import org.apache.kafka.clients.admin.NewTopic
 import org.apache.kafka.clients.producer.KafkaProducer
@@ -19,7 +20,6 @@ import streams.serialization.JSONUtils
 import streams.utils.StreamsUtils
 import java.util.*
 import java.util.concurrent.TimeUnit
-import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 class KafkaEventSinkNoTopicAutoCreationIT {
@@ -81,7 +81,7 @@ class KafkaEventSinkNoTopicAutoCreationIT {
                 .setConfig("streams.sink.enabled", "true")
                 .setConfig("streams.sink.topic.cypher.$notRegisteredTopic", "MERGE (p:NotRegisteredTopic{name: event.name})")
                 .setConfig("streams.sink.topic.cypher.$topic", "MERGE (p:Person{name: event.name})")
-                .newGraphDatabase() as GraphDatabaseAPI
+                .newDatabase() as GraphDatabaseAPI
         val kafkaProducer: KafkaProducer<String, ByteArray> = createProducer(kafka = kafka)
 
         // when
@@ -97,5 +97,6 @@ class KafkaEventSinkNoTopicAutoCreationIT {
             val topics = client.listTopics().names().get()
             count == 1L && !topics.contains(notRegisteredTopic)
         }, Matchers.equalTo(true), 30, TimeUnit.SECONDS)
+        db.shutdown()
     }
 }

--- a/consumer/src/test/kotlin/integrations/kafka/KafkaEventSinkPattern.kt
+++ b/consumer/src/test/kotlin/integrations/kafka/KafkaEventSinkPattern.kt
@@ -1,6 +1,7 @@
 package integrations.kafka
 
 import kotlinx.coroutines.runBlocking
+import extension.newDatabase
 import org.apache.kafka.clients.producer.KafkaProducer
 import org.apache.kafka.clients.producer.ProducerConfig
 import org.apache.kafka.clients.producer.ProducerRecord
@@ -11,7 +12,6 @@ import org.neo4j.function.ThrowingSupplier
 import org.neo4j.kernel.internal.GraphDatabaseAPI
 import org.neo4j.test.assertion.Assert
 import streams.serialization.JSONUtils
-import java.io.PrintWriter
 import java.util.*
 import java.util.concurrent.TimeUnit
 import kotlin.test.assertEquals
@@ -22,7 +22,7 @@ class KafkaEventSinkPattern : KafkaEventSinkBase() {
         val topic = UUID.randomUUID().toString()
         graphDatabaseBuilder.setConfig("streams.sink.topic.pattern.node.$topic",
                 "(:User{!userId,name,surname,address.city})")
-        db = graphDatabaseBuilder.newGraphDatabase() as GraphDatabaseAPI
+        db = graphDatabaseBuilder.newDatabase() as GraphDatabaseAPI
 
         val data = mapOf("userId" to 1, "name" to "Andrea", "surname" to "Santurbano",
                 "address" to mapOf("city" to "Venice", "CAP" to "30100"))
@@ -41,7 +41,7 @@ class KafkaEventSinkPattern : KafkaEventSinkBase() {
         val topic = UUID.randomUUID().toString()
         graphDatabaseBuilder.setConfig("streams.sink.topic.pattern.relationship.$topic",
                 "(:User{!sourceId,sourceName,sourceSurname})-[:KNOWS]->(:User{!targetId,targetName,targetSurname})")
-        db = graphDatabaseBuilder.newGraphDatabase() as GraphDatabaseAPI
+        db = graphDatabaseBuilder.newDatabase() as GraphDatabaseAPI
         val data = mapOf("sourceId" to 1, "sourceName" to "Andrea", "sourceSurname" to "Santurbano",
                 "targetId" to 1, "targetName" to "Michael", "targetSurname" to "Hunger", "since" to 2014)
 
@@ -62,7 +62,7 @@ class KafkaEventSinkPattern : KafkaEventSinkBase() {
         val topic = UUID.randomUUID().toString()
         graphDatabaseBuilder.setConfig("streams.sink.topic.pattern.node.$topic",
                 "(:User{!userId,name,surname})")
-        db = graphDatabaseBuilder.newGraphDatabase() as GraphDatabaseAPI
+        db = graphDatabaseBuilder.newDatabase() as GraphDatabaseAPI
 
         db.execute("CREATE (u:User{userId: 1, name: 'Andrea', surname: 'Santurbano'})").close()
         val count = db.execute("MATCH (n:User) RETURN count(n) AS count").columnAs<Long>("count").next()
@@ -71,7 +71,6 @@ class KafkaEventSinkPattern : KafkaEventSinkBase() {
 
         val kafkaProperties = Properties()
         kafkaProperties[ProducerConfig.BOOTSTRAP_SERVERS_CONFIG] = KafkaEventSinkSuiteIT.kafka.bootstrapServers
-        kafkaProperties["zookeeper.connect"] = KafkaEventSinkSuiteIT.kafka.envMap["KAFKA_ZOOKEEPER_CONNECT"]
         kafkaProperties["group.id"] = "neo4j"
         kafkaProperties[ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG] = ByteArraySerializer::class.java
         kafkaProperties[ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG] = ByteArraySerializer::class.java

--- a/consumer/src/test/kotlin/integrations/kafka/KafkaEventSinkSimple.kt
+++ b/consumer/src/test/kotlin/integrations/kafka/KafkaEventSinkSimple.kt
@@ -2,6 +2,7 @@ package integrations.kafka
 
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
+import extension.newDatabase
 import org.apache.kafka.clients.producer.ProducerRecord
 import org.hamcrest.Matchers
 import org.junit.Test
@@ -13,21 +14,20 @@ import org.neo4j.test.assertion.Assert
 import streams.events.StreamsPluginStatus
 import streams.procedures.StreamsSinkProcedures
 import streams.serialization.JSONUtils
-import java.util.*
+import java.util.UUID
 import java.util.concurrent.TimeUnit
 import java.util.stream.Collectors
 import kotlin.test.assertEquals
 
 class KafkaEventSinkSimple: KafkaEventSinkBase() {
 
-    private val topics = listOf("shouldWriteCypherQuery")
-
     @Test
-    fun shouldWriteDataFromSink() = runBlocking {
-        graphDatabaseBuilder.setConfig("streams.sink.topic.cypher.shouldWriteCypherQuery", cypherQueryTemplate)
-        db = graphDatabaseBuilder.newGraphDatabase() as GraphDatabaseAPI
+    fun shouldWriteDataFromSink() {
+        val topic = UUID.randomUUID().toString()
+        graphDatabaseBuilder.setConfig("streams.sink.topic.cypher.$topic", cypherQueryTemplate)
+        db = graphDatabaseBuilder.newDatabase() as GraphDatabaseAPI
 
-        val producerRecord = ProducerRecord(topics[0], UUID.randomUUID().toString(), JSONUtils.writeValueAsBytes(data))
+        val producerRecord = ProducerRecord(topic, UUID.randomUUID().toString(), JSONUtils.writeValueAsBytes(data))
         kafkaProducer.send(producerRecord).get()
         val props = data
                 .flatMap {
@@ -47,16 +47,14 @@ class KafkaEventSinkSimple: KafkaEventSinkBase() {
             val result = db.execute(query, mapOf("props" to props)).columnAs<Long>("count")
             result.hasNext() && result.next() == 1L && !result.hasNext()
         }, Matchers.equalTo(true), 30, TimeUnit.SECONDS)
-
     }
 
     @Test
     fun shouldNotWriteDataFromSinkWithNoTopicLoaded() = runBlocking {
-        db = graphDatabaseBuilder.newGraphDatabase() as GraphDatabaseAPI
+        db = graphDatabaseBuilder.newDatabase(StreamsPluginStatus.STOPPED) as GraphDatabaseAPI
 
-        val producerRecord = ProducerRecord(topics[0], UUID.randomUUID().toString(), JSONUtils.writeValueAsBytes(data))
+        val producerRecord = ProducerRecord(UUID.randomUUID().toString(), UUID.randomUUID().toString(), JSONUtils.writeValueAsBytes(data))
         kafkaProducer.send(producerRecord).get()
-        delay(5000)
 
         Assert.assertEventually(ThrowingSupplier<Boolean, Exception> {
             val query = """
@@ -69,22 +67,29 @@ class KafkaEventSinkSimple: KafkaEventSinkBase() {
 
     @Test
     fun shouldNotStartInASingleInstance() {
+        val topic = UUID.randomUUID().toString()
         db = graphDatabaseBuilder
-                .setConfig("streams.sink.topic.cypher.shouldWriteCypherQuery", cypherQueryTemplate)
+                .setConfig("streams.sink.topic.cypher.$topic", cypherQueryTemplate)
                 .setConfig("streams.cluster.only", "true")
-                .newGraphDatabase() as GraphDatabaseAPI
+                .newDatabase(StreamsPluginStatus.STOPPED) as GraphDatabaseAPI
         db.dependencyResolver.resolveDependency(Procedures::class.java)
                 .registerProcedure(StreamsSinkProcedures::class.java, true)
 
         val expectedRunning = listOf(mapOf("name" to "status", "value" to StreamsPluginStatus.STOPPED.toString()))
 
-        // when
-        val result = db.execute("CALL streams.sink.status()")
+        Assert.assertEventually(ThrowingSupplier<Boolean, Exception> {
+            try {
+                // when
+                val result = db.execute("CALL streams.sink.status()")
 
-        // then
-        val actual = result.stream()
-                .collect(Collectors.toList())
-        assertEquals(expectedRunning, actual)
+                // then
+                val actual = result.stream()
+                        .collect(Collectors.toList())
+                expectedRunning == actual
+            } catch (e: Exception) {
+                false
+            }
+        }, Matchers.equalTo(true), 30, TimeUnit.SECONDS)
     }
 
     @Test
@@ -99,7 +104,7 @@ class KafkaEventSinkSimple: KafkaEventSinkBase() {
         graphDatabaseBuilder.setConfig("streams.sink.topic.cypher.${product.first}", product.second)
         graphDatabaseBuilder.setConfig("streams.sink.topic.cypher.${customer.first}", customer.second)
         graphDatabaseBuilder.setConfig("streams.sink.topic.cypher.${bought.first}", bought.second)
-        db = graphDatabaseBuilder.newGraphDatabase() as GraphDatabaseAPI
+        db = graphDatabaseBuilder.newDatabase() as GraphDatabaseAPI
 
         val props = mapOf("id" to 1, "name" to "My Awesome Product")
         var producerRecord = ProducerRecord(product.first, UUID.randomUUID().toString(),
@@ -119,8 +124,9 @@ class KafkaEventSinkSimple: KafkaEventSinkBase() {
     @Test
     fun `should stop and start the sink via procedures`() = runBlocking {
         // given
-        graphDatabaseBuilder.setConfig("streams.sink.topic.cypher.shouldWriteCypherQuery", cypherQueryTemplate)
-        db = graphDatabaseBuilder.newGraphDatabase() as GraphDatabaseAPI
+        val topic = UUID.randomUUID().toString()
+        graphDatabaseBuilder.setConfig("streams.sink.topic.cypher.$topic", cypherQueryTemplate)
+        db = graphDatabaseBuilder.newDatabase() as GraphDatabaseAPI
         db.dependencyResolver.resolveDependency(Procedures::class.java)
                 .registerProcedure(StreamsSinkProcedures::class.java, true)
 
@@ -128,7 +134,7 @@ class KafkaEventSinkSimple: KafkaEventSinkBase() {
         org.junit.Assert.assertEquals(mapOf("name" to "status", "value" to StreamsPluginStatus.STOPPED.toString()), stopped.next())
         org.junit.Assert.assertFalse(stopped.hasNext())
 
-        val producerRecord = ProducerRecord(topics[0], UUID.randomUUID().toString(), JSONUtils.writeValueAsBytes(data))
+        val producerRecord = ProducerRecord(topic, UUID.randomUUID().toString(), JSONUtils.writeValueAsBytes(data))
         kafkaProducer.send(producerRecord).get()
         val props = data
                 .flatMap {
@@ -162,10 +168,12 @@ class KafkaEventSinkSimple: KafkaEventSinkBase() {
 
     @Test
     fun `neo4j should start normally in case kafka is not reachable`() {
-        db = graphDatabaseBuilder.setConfig("streams.sink.topic.cypher.shouldWriteCypherQuery", cypherQueryTemplate)
+        // given
+        val topic = UUID.randomUUID().toString()
+        db = graphDatabaseBuilder.setConfig("streams.sink.topic.cypher.$topic", cypherQueryTemplate)
                 .setConfig("kafka.bootstrap.servers", "foo")
                 .setConfig("kafka.default.api.timeout.ms", "5000")
-                .newGraphDatabase() as GraphDatabaseAPI
+                .newDatabase(StreamsPluginStatus.STOPPED) as GraphDatabaseAPI
         db.dependencyResolver.resolveDependency(Procedures::class.java)
                 .registerProcedure(StreamsSinkProcedures::class.java, true)
 

--- a/consumer/src/test/kotlin/integrations/kafka/KafkaEventSinkSuiteIT.kt
+++ b/consumer/src/test/kotlin/integrations/kafka/KafkaEventSinkSuiteIT.kt
@@ -6,6 +6,7 @@ import org.junit.BeforeClass
 import org.junit.runner.RunWith
 import org.junit.runners.Suite
 import org.testcontainers.containers.KafkaContainer
+import org.testcontainers.containers.Network
 import streams.utils.StreamsUtils
 
 @RunWith(Suite::class)
@@ -45,14 +46,15 @@ class KafkaEventSinkSuiteIT {
         fun setUpContainer() {
             StreamsUtils.ignoreExceptions({
                 kafka = KafkaContainer(confluentPlatformVersion)
+                    .withNetwork(Network.newNetwork())
                 kafka.start()
                 schemaRegistry = SchemaRegistryContainer(confluentPlatformVersion)
                         .withKafka(kafka)
                 schemaRegistry.start()
                 isRunning = true
             }, IllegalStateException::class.java)
-            assumeTrue("Kafka must be running", kafka.isRunning)
-            assumeTrue("Schema Registry must be running", schemaRegistry.isRunning)
+            assumeTrue("Kafka must be running", this::kafka.isInitialized && kafka.isRunning)
+            assumeTrue("Schema Registry must be running", this::schemaRegistry.isInitialized && schemaRegistry.isRunning)
             assumeTrue("isRunning must be true", isRunning)
         }
 
@@ -66,4 +68,18 @@ class KafkaEventSinkSuiteIT {
             }, UninitializedPropertyAccessException::class.java)
         }
     }
+
+//    @Rule
+//    @JvmField
+//    var testName = TestName()
+//
+//    @Before
+//    fun before() {
+//        println("Starting test ${testName.methodName}")
+//    }
+//
+//    @After
+//    fun after() {
+//        println("Ending test ${testName.methodName}")
+//    }
 }

--- a/consumer/src/test/kotlin/integrations/kafka/KafkaStreamsSinkProcedures.kt
+++ b/consumer/src/test/kotlin/integrations/kafka/KafkaStreamsSinkProcedures.kt
@@ -3,6 +3,7 @@ package integrations.kafka
 import integrations.kafka.KafkaTestUtils.createConsumer
 import io.confluent.kafka.serializers.KafkaAvroDeserializer
 import kotlinx.coroutines.*
+import extension.newDatabase
 import org.apache.avro.SchemaBuilder
 import org.apache.avro.generic.GenericRecordBuilder
 import org.apache.kafka.clients.producer.ProducerRecord
@@ -37,7 +38,7 @@ class KafkaStreamsSinkProcedures : KafkaEventSinkBase() {
     @Test
     fun shouldConsumeDataFromProcedureWithSinkDisabled() {
         graphDatabaseBuilder.setConfig("streams.sink.enabled", "false")
-        db = graphDatabaseBuilder.newGraphDatabase() as GraphDatabaseAPI
+        db = graphDatabaseBuilder.newDatabase(StreamsPluginStatus.STOPPED) as GraphDatabaseAPI
         db.dependencyResolver.resolveDependency(Procedures::class.java)
                 .registerProcedure(StreamsSinkProcedures::class.java, true)
         val topic = "bar"
@@ -46,7 +47,7 @@ class KafkaStreamsSinkProcedures : KafkaEventSinkBase() {
 
     @Test
     fun shouldConsumeDataFromProcedure() {
-        db = graphDatabaseBuilder.newGraphDatabase() as GraphDatabaseAPI
+        db = graphDatabaseBuilder.newDatabase(StreamsPluginStatus.STOPPED) as GraphDatabaseAPI
         db.dependencyResolver.resolveDependency(Procedures::class.java)
                 .registerProcedure(StreamsSinkProcedures::class.java, true)
         val topic = "foo"
@@ -55,7 +56,7 @@ class KafkaStreamsSinkProcedures : KafkaEventSinkBase() {
 
     @Test
     fun shouldTimeout() {
-        db = graphDatabaseBuilder.newGraphDatabase() as GraphDatabaseAPI
+        db = graphDatabaseBuilder.newDatabase(StreamsPluginStatus.STOPPED) as GraphDatabaseAPI
         db.dependencyResolver.resolveDependency(Procedures::class.java)
                 .registerProcedure(StreamsSinkProcedures::class.java, true)
         val result = db.execute("CALL streams.consume('foo1', {timeout: 2000}) YIELD event RETURN event")
@@ -64,7 +65,7 @@ class KafkaStreamsSinkProcedures : KafkaEventSinkBase() {
 
     @Test
     fun shouldReadArrayOfJson() {
-        db = graphDatabaseBuilder.newGraphDatabase() as GraphDatabaseAPI
+        db = graphDatabaseBuilder.newDatabase(StreamsPluginStatus.STOPPED) as GraphDatabaseAPI
         db.dependencyResolver.resolveDependency(Procedures::class.java)
                 .registerProcedure(StreamsSinkProcedures::class.java, true)
         val topic = "array-topic"
@@ -85,7 +86,7 @@ class KafkaStreamsSinkProcedures : KafkaEventSinkBase() {
 
     @Test
     fun shouldReadSimpleDataType() {
-        db = graphDatabaseBuilder.newGraphDatabase() as GraphDatabaseAPI
+        db = graphDatabaseBuilder.newDatabase(StreamsPluginStatus.STOPPED) as GraphDatabaseAPI
         db.dependencyResolver.resolveDependency(Procedures::class.java)
                 .registerProcedure(StreamsSinkProcedures::class.java, true)
         val topic = "simple-data"
@@ -117,7 +118,7 @@ class KafkaStreamsSinkProcedures : KafkaEventSinkBase() {
 
     @Test
     fun shouldReadATopicPartitionStartingFromAnOffset() = runBlocking {
-        db = graphDatabaseBuilder.newGraphDatabase() as GraphDatabaseAPI
+        db = graphDatabaseBuilder.newDatabase(StreamsPluginStatus.STOPPED) as GraphDatabaseAPI
         db.dependencyResolver.resolveDependency(Procedures::class.java)
                 .registerProcedure(StreamsSinkProcedures::class.java, true)
         val topic = "read-from-range"
@@ -147,7 +148,7 @@ class KafkaStreamsSinkProcedures : KafkaEventSinkBase() {
 
     @Test
     fun shouldReadFromLatest() = runBlocking {
-        db = graphDatabaseBuilder.newGraphDatabase() as GraphDatabaseAPI
+        db = graphDatabaseBuilder.newDatabase(StreamsPluginStatus.STOPPED) as GraphDatabaseAPI
         db.dependencyResolver.resolveDependency(Procedures::class.java)
                 .registerProcedure(StreamsSinkProcedures::class.java, true)
         val topic = "simple-data-from-latest"
@@ -181,7 +182,7 @@ class KafkaStreamsSinkProcedures : KafkaEventSinkBase() {
 
     @Test
     fun shouldNotCommit() {
-        db = graphDatabaseBuilder.newGraphDatabase() as GraphDatabaseAPI
+        db = graphDatabaseBuilder.newDatabase(StreamsPluginStatus.STOPPED) as GraphDatabaseAPI
         db.dependencyResolver.resolveDependency(Procedures::class.java)
                 .registerProcedure(StreamsSinkProcedures::class.java, true)
         val topic = "simple-data"
@@ -212,7 +213,7 @@ class KafkaStreamsSinkProcedures : KafkaEventSinkBase() {
 
     @Test
     fun `should consume AVRO messages`() {
-        db = graphDatabaseBuilder.newGraphDatabase() as GraphDatabaseAPI
+        db = graphDatabaseBuilder.newDatabase(StreamsPluginStatus.STOPPED) as GraphDatabaseAPI
         db.dependencyResolver.resolveDependency(Procedures::class.java)
                 .registerProcedure(StreamsSinkProcedures::class.java, true)
         val PLACE_SCHEMA = SchemaBuilder.builder("com.namespace")
@@ -249,7 +250,7 @@ class KafkaStreamsSinkProcedures : KafkaEventSinkBase() {
     @Test
     fun `should report the streams sink config`() {
         // given
-        db = graphDatabaseBuilder.newGraphDatabase() as GraphDatabaseAPI
+        db = graphDatabaseBuilder.newDatabase(StreamsPluginStatus.STOPPED) as GraphDatabaseAPI
         db.dependencyResolver.resolveDependency(Procedures::class.java)
                 .registerProcedure(StreamsSinkProcedures::class.java, true)
         val expected = mapOf("invalid_topics" to emptyList<String>(),
@@ -279,7 +280,7 @@ class KafkaStreamsSinkProcedures : KafkaEventSinkBase() {
     fun `should report the streams sink status RUNNING`() = runBlocking {
         // given
         graphDatabaseBuilder.setConfig("streams.sink.topic.cypher.shouldWriteCypherQuery", cypherQueryTemplate)
-        db = graphDatabaseBuilder.newGraphDatabase() as GraphDatabaseAPI
+        db = graphDatabaseBuilder.newDatabase() as GraphDatabaseAPI
         db.dependencyResolver.resolveDependency(Procedures::class.java)
                 .registerProcedure(StreamsSinkProcedures::class.java, true)
         val expectedRunning = listOf(mapOf("name" to "status", "value" to StreamsPluginStatus.RUNNING.toString()))
@@ -297,7 +298,7 @@ class KafkaStreamsSinkProcedures : KafkaEventSinkBase() {
     fun `should report the streams sink status STOPPED`() {
         // given
         graphDatabaseBuilder.setConfig("streams.sink.topic.cypher.shouldWriteCypherQuery", cypherQueryTemplate)
-        db = graphDatabaseBuilder.newGraphDatabase() as GraphDatabaseAPI
+        db = graphDatabaseBuilder.newDatabase() as GraphDatabaseAPI
         db.dependencyResolver.resolveDependency(Procedures::class.java)
                 .registerProcedure(StreamsSinkProcedures::class.java, true)
         val expectedRunning = listOf(mapOf("name" to "status", "value" to StreamsPluginStatus.STOPPED.toString()))

--- a/consumer/src/test/kotlin/integrations/kafka/KafkaTestUtils.kt
+++ b/consumer/src/test/kotlin/integrations/kafka/KafkaTestUtils.kt
@@ -19,7 +19,6 @@ object KafkaTestUtils {
                               vararg topics: String): KafkaConsumer<K, V> {
         val props = Properties()
         props[ProducerConfig.BOOTSTRAP_SERVERS_CONFIG] = kafka.bootstrapServers
-        props["zookeeper.connect"] = kafka.envMap["KAFKA_ZOOKEEPER_CONNECT"]
         props["group.id"] = "neo4j"
         props["enable.auto.commit"] = "true"
         props[ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG] = keyDeserializer
@@ -41,7 +40,6 @@ object KafkaTestUtils {
                               valueSerializer: String = ByteArraySerializer::class.java.name): KafkaProducer<K, V> {
         val props = Properties()
         props[ProducerConfig.BOOTSTRAP_SERVERS_CONFIG] = kafka.bootstrapServers
-        props["zookeeper.connect"] = kafka.envMap["KAFKA_ZOOKEEPER_CONNECT"]
         props["group.id"] = "neo4j"
         props[ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG] = keySerializer
         props[ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG] = valueSerializer

--- a/consumer/src/test/kotlin/streams/StreamsEventSinkQueryExecutionTest.kt
+++ b/consumer/src/test/kotlin/streams/StreamsEventSinkQueryExecutionTest.kt
@@ -1,12 +1,13 @@
 package streams
 
+import extension.newDatabase
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
-import org.neo4j.graphdb.GraphDatabaseService
 import org.neo4j.kernel.internal.GraphDatabaseAPI
 import org.neo4j.logging.NullLog
 import org.neo4j.test.TestGraphDatabaseFactory
+import streams.events.StreamsPluginStatus
 import streams.kafka.KafkaSinkConfiguration
 import streams.service.StreamsSinkEntity
 import streams.service.TopicType
@@ -21,10 +22,10 @@ class StreamsEventSinkQueryExecutionTest {
     fun setUp() {
         db = TestGraphDatabaseFactory()
                 .newImpermanentDatabaseBuilder()
-                .newGraphDatabase() as GraphDatabaseAPI
+                .newDatabase(StreamsPluginStatus.STOPPED) as GraphDatabaseAPI
         val kafkaConfig = KafkaSinkConfiguration(streamsSinkConfiguration = StreamsSinkConfiguration(topics = Topics(cypherTopics = mapOf("shouldWriteCypherQuery" to "MERGE (n:Label {id: event.id})\n" +
                 "    ON CREATE SET n += event.properties"))))
-        val streamsTopicService = StreamsTopicService(db)
+        val streamsTopicService = StreamsTopicService()
         streamsTopicService.set(TopicType.CYPHER, kafkaConfig.streamsSinkConfiguration.topics.cypherTopics)
         streamsEventSinkQueryExecution = StreamsEventSinkQueryExecution(streamsTopicService, db as GraphDatabaseAPI,
                 NullLog.getInstance(), emptyMap())

--- a/consumer/src/test/kotlin/streams/StreamsSinkConfigurationListenerTest.kt
+++ b/consumer/src/test/kotlin/streams/StreamsSinkConfigurationListenerTest.kt
@@ -1,0 +1,45 @@
+package streams
+
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mockito
+import org.neo4j.kernel.internal.GraphDatabaseAPI
+import org.neo4j.logging.NullLog
+import streams.kafka.KafkaSinkConfiguration
+import streams.serialization.JSONUtils
+import streams.service.Topics
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class StreamsSinkConfigurationListenerTest {
+    private lateinit var db: GraphDatabaseAPI
+    private lateinit var streamsSinkConfigurationListener: StreamsSinkConfigurationListener
+
+    private val kafkaConfig = mapOf("streams.sink.topic.cypher.my-topic" to "CREATE (n:Label)")
+
+    @Before
+    fun setUp() {
+        db = Mockito.mock(GraphDatabaseAPI::class.java)
+        streamsSinkConfigurationListener = StreamsSinkConfigurationListener(db, NullLog.getInstance())
+        val field = StreamsSinkConfigurationListener::class.java.getDeclaredField("lastConfig")
+        field.isAccessible = true
+        field.set(streamsSinkConfigurationListener, KafkaSinkConfiguration.create(kafkaConfig))
+    }
+
+    @After
+    fun tearDown() {
+        db.shutdown()
+    }
+
+    @Test
+    fun `test configuration changes`() {
+        val autoOffset = kafkaConfig + mapOf("kafka.auto.offset.reset" to "latest")
+        assertTrue { streamsSinkConfigurationListener.isConfigurationChanged(autoOffset) }
+        val sourceEnabled = kafkaConfig + mapOf("streams.source.enabled" to "true")
+        assertFalse { streamsSinkConfigurationListener.isConfigurationChanged(sourceEnabled) }
+        val transactionalId = kafkaConfig + mapOf("kafka.transactional.id" to "foo")
+        assertFalse { streamsSinkConfigurationListener.isConfigurationChanged(transactionalId) }
+    }
+
+}

--- a/consumer/src/test/kotlin/streams/StreamsTopicServiceTest.kt
+++ b/consumer/src/test/kotlin/streams/StreamsTopicServiceTest.kt
@@ -1,12 +1,7 @@
 package streams
 
-import org.junit.After
 import org.junit.Before
 import org.junit.Test
-import org.neo4j.kernel.impl.core.EmbeddedProxySPI
-import org.neo4j.kernel.impl.core.GraphProperties
-import org.neo4j.kernel.internal.GraphDatabaseAPI
-import org.neo4j.test.TestGraphDatabaseFactory
 import streams.kafka.KafkaSinkConfiguration
 import streams.service.TopicType
 import streams.service.Topics
@@ -14,26 +9,15 @@ import kotlin.test.assertEquals
 
 class StreamsTopicServiceTest {
 
-    private lateinit var db: GraphDatabaseAPI
     private lateinit var streamsTopicService: StreamsTopicService
     private lateinit var kafkaConfig: KafkaSinkConfiguration
-    private lateinit var graphProperties: GraphProperties
 
     @Before
     fun setUp() {
-        db = TestGraphDatabaseFactory()
-                .newImpermanentDatabaseBuilder()
-                .newGraphDatabase() as GraphDatabaseAPI
         kafkaConfig = KafkaSinkConfiguration(streamsSinkConfiguration = StreamsSinkConfiguration(topics = Topics(cypherTopics = mapOf("shouldWriteCypherQuery" to "MERGE (n:Label {id: event.id})\n" +
                 "    ON CREATE SET n += event.properties"))))
-        streamsTopicService = StreamsTopicService(db)
+        streamsTopicService = StreamsTopicService()
         streamsTopicService.set(TopicType.CYPHER, kafkaConfig.streamsSinkConfiguration.topics.cypherTopics)
-        graphProperties = db.dependencyResolver.resolveDependency(EmbeddedProxySPI::class.java).newGraphPropertiesProxy()
-    }
-
-    @After
-    fun tearDown() {
-        db.shutdown()
     }
 
     private fun assertProperty(entry: Map.Entry<String, String>) {

--- a/consumer/src/test/kotlin/streams/utils/Neo4jUtilsTest.kt
+++ b/consumer/src/test/kotlin/streams/utils/Neo4jUtilsTest.kt
@@ -1,9 +1,11 @@
 package streams.utils
 
+import extension.newDatabase
 import org.junit.*
 import org.neo4j.kernel.internal.GraphDatabaseAPI
 import org.neo4j.test.TestGraphDatabaseFactory
 import streams.StreamsEventSinkAvailabilityListener
+import streams.events.StreamsPluginStatus
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
@@ -16,7 +18,7 @@ class Neo4jUtilsTest {
         fun setUp() {
             db = TestGraphDatabaseFactory()
                     .newImpermanentDatabaseBuilder()
-                    .newGraphDatabase() as GraphDatabaseAPI
+                    .newDatabase(StreamsPluginStatus.STOPPED) as GraphDatabaseAPI
         }
 
         @AfterClass

--- a/doc/asciidoc/index.adoc
+++ b/doc/asciidoc/index.adoc
@@ -22,6 +22,7 @@ The guide covers the following areas:
 
 * <<_project_overview>> -- Project overview
 * <<_quick_start>> -- Get Started Fast with the most Common Scenarios
+* <<neo4j_configuration_system>> -- Understand how the configuration system works
 * <<neo4j_streams_source>> -- How to configure Neo4j Streams as Source
 * <<neo4j_streams_sink>> -- How to configure Neo4j Streams as Sink
 * <<neo4j_streams_procedures>> -- How to use Neo4j Streams Procedures
@@ -38,6 +39,8 @@ The guide covers the following areas:
 include::overview/index.adoc[]
 
 include::quickstart/index.adoc[]
+
+include::overview/configuration.adoc[]
 
 include::streams/index.adoc[]
 

--- a/doc/asciidoc/neo4j-cluster/index.adoc
+++ b/doc/asciidoc/neo4j-cluster/index.adoc
@@ -43,7 +43,9 @@ For further information on routing drivers, see the link:https://neo4j.com/docs/
 When using Neo4j Streams as a plugin together with a cluster, there are several things to keep in mind:
 
 * The plugin must be present in the plugins directory of _all cluster members_, and not just one.
-* The configuration settings must be present in _all of the neo4j.conf files_, not just one.
+* The configuration settings must be present in:
+   - *all neo4j.conf files* for versions prior of `3.5.13`;
+   - *all streams.conf files* for versions since `3.5.13`.
 
 Through the course of the cluster lifecycle, the leader may change; for this reason the plugin must be everywhere,
 and not just on the leader.
@@ -56,14 +58,54 @@ published on the leader as well.  In practical terms, this means that as new dat
 the leader that will be publishing that data back out to Kafka, if you have the producer configured.
 
 The neo4j streams utility procedures, in particular `CALL streams.publish`, can work on any cluster member, or
-read replica.  `CALL streams.consume` may also be used on any cluster member, however it is important to keep in
+read replica. `CALL streams.consume` may also be used on any cluster member, however it is important to keep in
 mind that due to the way clustering in Neo4j works, using `streams.consume` together with write operations will
 not work on a cluster follower or read replica, as only the leader can process writes.
+
+==== Update the configuration via procedures (since version 3.5.13)
+
+N.b. this mode implies that `streams.procedures.enabled` is set to `true`
+
+In a causal cluster composed by 3 `CORE` members you can use Kafka in order to update
+the configuration to all the nodes by executing a single query from the `LEADER`.
+
+In order to do that we leverage the `apoc.periodic.repeat` procedure.
+
+You need to "install" the following query in all core nodes
+
+[source,cypher]
+----
+CALL apoc.periodic.repeat("streams.update.config", "
+  CALL dbms.cluster.role() YIELD role
+  WHERE role <> 'LEADER'
+  CALL streams.consume('neo4j-kafka-config', {`kafka.group.id`: '<one-id-per-core-instance>', timeout: 2000}) YIELD event
+  CALL streams.configuration.set(event.data.payload) YIELD name, value
+  RETURN name, value
+", 5)
+----
+
+*N.b.* is important to define one `kafka.group.id` per CORE instance in
+order to allow them to consume the same topic independently.
+
+Then every time that you need to update the configuration you can use
+the following template that must be executed from the `LEADER`:
+
+[source,cypher]
+----
+WITH {`streams.sink.topic.cypher.mytopic`: "CREATE (p:Person{name: event.name, surname: event.surname})"} AS event
+CALL streams.publish('neo4j-kafka-config', event)
+CALL streams.configuration.set(event) YIELD name, value
+RETURN name, value
+----
+
+(The `event` variable map is the map of the properties that you want to change)
+
+automatically the configuration gets updated inside every `CORE` node.
 
 === Remote Clients
 
 Sometimes there will be remote applications that talk to Neo4j via official drivers, that want to use
-streams functionality.  Best practices in these cases are:
+streams functionality. Best practices in these cases are:
 
 * Always use a `bolt+routing://` driver URI when communicating with the cluster in the client application.
 * Use link:https://neo4j.com/docs/driver-manual/current/sessions-transactions/#driver-transactions[Explicit Write Transactions] in

--- a/doc/asciidoc/overview/configuration.adoc
+++ b/doc/asciidoc/overview/configuration.adoc
@@ -39,11 +39,13 @@ and `Source` with the new configuration.
 
 === Procedure based changes
 
-From version `3.5.13` you'll find two new procedures:
+From version `3.5.13` you'll find three new procedures:
 
 * `streams.configuration.get` returns the current configuration
 * `streams.configuration.set({<plugin_config_map>}, {<procedure_config>})` that applies
 the new configuration and returns it
+* `streams.configuration.remove({<plugin_config_keys_list>}, {<procedure_config>})` that removes
+the provided configuration keys and returns the new configuration status
 
 ==== `streams.configuration.get`
 
@@ -108,8 +110,7 @@ You'll have this following output (it's related to *your* configuration 😄)
 
 ==== `streams.configuration.set`
 
-This procedure applies the map of configuration parameters passed as first argument
-and the procedure configuration parameters passed as second argument.
+This procedure applies the map of configuration parameters passed as first argument.
 
 Input Parameters:
 
@@ -122,7 +123,7 @@ Input Parameters:
 |This map represents the set of configurations applied to the `Sink` and the `Source`
 
 |`procedure_config`
-|The configuration value
+|The configuration map
 
 |===
 
@@ -196,9 +197,95 @@ You'll have this following output (it's related to *your* configuration 😄)
 
 |===
 
+==== `streams.configuration.remove`
+
+This procedure removes the provided list of keys from the configuration.
+
+Input Parameters:
+
+[cols="2*",options="header"]
+|===
+|Variable Name
+|Description
+
+|`plugin_config_keys_list`
+|This list represents the properties set that will be removed from the configuration.
+
+|`procedure_config`
+|The configuration map
+
+|===
+
+Output Parameters:
+
+[cols="2*",options="header"]
+|===
+|Variable Name
+|Description
+
+|`name`
+|The configuration name
+
+|`value`
+|The configuration value
+
+|===
+
+Following the accepted parameters for the `procedure_config`:
+
+[cols="2*",options="header"]
+|===
+|Configuration Name
+|Description
+
+|`save`
+|(Boolean, default `true`) if persist or not the configuration
+into the file in order to have it back once the database is restarted
+for whatever reason
+
+|===
+
+So given the following procedure call:
+
+[source,cypher]
+----
+CALL streams.configuration.remove([`kafka.zookeeper.connect`], {save: false}) YIELD name, value
+RETURN name, value
+----
+
+You'll have this following output (it's related to *your* configuration 😄)
+
+[cols="2*",options="header"]
+|===
+|name
+|value
+
+|"streams.sink.topic.cypher.test"
+|"CREATE (p:Person{name: event.name, surname: event.surname})"
+
+|"streams.sink.errors.tolerance"
+|"all"
+
+|"kafka.default.api.timeout.ms"
+|"5000"
+
+|"kafka.bootstrap.servers"
+|"broker:9093"
+
+|"streams.sink.errors.log.include.messages"
+|"true"
+
+|"streams.sink.enabled"
+|"true"
+
+|"streams.sink.errors.log.enable"
+|"true"
+
+|===
+
 ====== What happens when we change a configuration properties from procedure
 
-When we change the configuration properties from `streams.configuration.set`,
+When we change the configuration properties from `streams.configuration.set/remove`,
 under-the-hood `Sink` and `Source` modules are reloaded. So use it carefully
 because it has an impact in your Stream flow.
 

--- a/doc/asciidoc/overview/configuration.adoc
+++ b/doc/asciidoc/overview/configuration.adoc
@@ -1,0 +1,222 @@
+[#neo4j_configuration_system]
+== Configuration system overview
+
+=== Location of Configuration Information
+
+For versions prior to `3.5.13` the configuration management works statically
+with the properties provided inside the `neo4j.conf` file; since the version `3.5.13`
+we introduced a new configuration systems based on dynamic reloading that relies
+on the `streams.conf` file inside `$NEO4J_HOME/conf`.
+
+=== Breaking Changes
+
+We deprecated the `neo4j.conf` file based configuration, so you need to define
+a new `streams.conf` file inside `$NEO4J_HOME/conf` and put in there all the
+required configuration.
+
+==== Note about usage with Docker
+
+The official Neo4j Docker image uses a particular naming convention for environment
+variables in order to transform them into properties inside the `neo4j.conf` file.
+In order to be compliant with that behaviour you can still use them without changing anything
+in your configuration, under-the-hood from version `3.5.13` system
+will save them inside the `streams.conf` file instead.
+
+=== How it behaves
+
+You can interact with the new configuration system in two ways:
+
+* By changing the `streams.conf` manually
+* By applying new configurations via procedures
+
+*You must consider that every change applied to the configuration causes
+the reload of the plugins so you must use this feature very carefully.*
+
+=== File based changes
+
+Every change inside the `streams.conf` is gathered and reloads the Streams `Sink`
+and `Source` with the new configuration.
+
+=== Procedure based changes
+
+From version `3.5.13` you'll find two new procedures:
+
+* `streams.configuration.get` returns the current configuration
+* `streams.configuration.set({<plugin_config_map>}, {<procedure_config>})` that applies
+the new configuration and returns it
+
+==== `streams.configuration.get`
+
+This procedure returns the current configuration applied to both `Sink` and `Source`
+plugin.
+
+Output Parameters:
+
+[cols="2*",options="header"]
+|===
+|Variable Name
+|Description
+
+|`name`
+|The configuration name
+
+|`value`
+|The configuration value
+
+|===
+
+So given the following procedure call:
+
+[source,cypher]
+----
+CALL streams.configuration.get() YIELD name, value
+RETURN name, value
+----
+
+You'll have this following output (it's related to *your* configuration 😄)
+
+[cols="2*",options="header"]
+|===
+|name
+|value
+
+|"streams.sink.topic.cypher.test"
+|"CREATE (p:Person{name: event.name, surname: event.surname})"
+
+|"streams.sink.errors.tolerance"
+|"all"
+
+|"kafka.default.api.timeout.ms"
+|"5000"
+
+|"kafka.bootstrap.servers"
+|"broker:9093"
+
+|"streams.sink.errors.log.include.messages"
+|"true"
+
+|"streams.sink.enabled"
+|"true"
+
+|"streams.sink.errors.log.enable"
+|"true"
+
+|"kafka.zookeeper.connect"
+|"zookeeper:2181"
+
+|===
+
+==== `streams.configuration.set`
+
+This procedure applies the map of configuration parameters passed as first argument
+and the procedure configuration parameters passed as second argument.
+
+Input Parameters:
+
+[cols="2*",options="header"]
+|===
+|Variable Name
+|Description
+
+|`plugin_config_map`
+|This map represents the set of configurations applied to the `Sink` and the `Source`
+
+|`procedure_config`
+|The configuration value
+
+|===
+
+Output Parameters:
+
+[cols="2*",options="header"]
+|===
+|Variable Name
+|Description
+
+|`name`
+|The configuration name
+
+|`value`
+|The configuration value
+
+|===
+
+Following the accepted parameters for the `procedure_config`:
+
+[cols="2*",options="header"]
+|===
+|Configuration Name
+|Description
+
+|`save`
+|(Boolean, default `true`) if persist or not the configuration
+into the file in order to have it back once the database is restarted
+for whatever reason
+
+|===
+
+So given the following procedure call:
+
+[source,cypher]
+----
+CALL streams.configuration.set({`streams.sink.topic.cypher.test`: 'CREATE (p:Person{name: event.name, surname: event.surname, fullName: event.name + ' ' + event.surname})'}, {save: false}) YIELD name, value
+RETURN name, value
+----
+
+You'll have this following output (it's related to *your* configuration 😄)
+
+[cols="2*",options="header"]
+|===
+|name
+|value
+
+|"streams.sink.topic.cypher.test"
+|"CREATE (p:Person{name: event.name, surname: event.surname})"
+
+|"streams.sink.errors.tolerance"
+|"all"
+
+|"kafka.default.api.timeout.ms"
+|"5000"
+
+|"kafka.bootstrap.servers"
+|"broker:9093"
+
+|"streams.sink.errors.log.include.messages"
+|"true"
+
+|"streams.sink.enabled"
+|"true"
+
+|"streams.sink.errors.log.enable"
+|"true"
+
+|"kafka.zookeeper.connect"
+|"zookeeper:2181"
+
+|===
+
+====== What happens when we change a configuration properties from procedure
+
+When we change the configuration properties from `streams.configuration.set`,
+under-the-hood `Sink` and `Source` modules are reloaded. So use it carefully
+because it has an impact in your Stream flow.
+
+*N.b.* The Source/Sink module will be restarted only if there are changes in the
+configuration related to itself; this means that if you have both active and
+you change properties related to the Sink, only it will be restarted.
+
+*What happens into the `Source` module*
+
+During the reload process the transaction event handler gets unplugged, this
+means that all transaction evens that happen during reload period are not
+caught by the Source, so they are *lost*.
+
+*What happens into the `Sink` module*
+
+During the reload process the Sink gets stopped, this should not have
+any impact in your ingestion process because it will restart from the last
+committed messages, so there is no data loss.
+
+
+

--- a/pom.xml
+++ b/pom.xml
@@ -33,16 +33,18 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>
-        <kotlin.version>1.3.0</kotlin.version>
-        <kotlin.coroutines.version>1.0.0</kotlin.coroutines.version>
+        <kotlin.version>1.3.72</kotlin.version>
+        <kotlin.coroutines.version>1.3.9</kotlin.coroutines.version>
         <neo4j.version>3.5.21</neo4j.version>
         <kafka.version>2.3.0</kafka.version>
         <jackson.version>2.9.7</jackson.version>
         <kotlin.compiler.incremental>true</kotlin.compiler.incremental>
         <neo4j.java.driver.version>1.7.5</neo4j.java.driver.version>
-        <testcontainers.version>1.9.1</testcontainers.version>
+        <testcontainers.version>1.15.1</testcontainers.version>
         <avro.version>1.8.2</avro.version>
         <kafka.avro.serializer.version>5.2.2</kafka.avro.serializer.version>
+        <hamcrest.version>1.3</hamcrest.version>
+        <neo4j.configuration-lifecycle.version>65750ed701</neo4j.configuration-lifecycle.version>
     </properties>
 
     <organization>
@@ -97,17 +99,42 @@
                 <artifactId>neo4j-causal-clustering</artifactId>
                 <version>${neo4j.version}</version>
                 <type>test-jar</type>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.slf4j</groupId>
+                        <artifactId>slf4j-nop</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>com.neo4j</groupId>
                 <artifactId>neo4j-causal-clustering</artifactId>
                 <version>${neo4j.version}</version>
                 <scope>test</scope>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.slf4j</groupId>
+                        <artifactId>slf4j-nop</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
         </dependencies>
     </dependencyManagement>
 
+    <repositories>
+        <repository>
+            <id>jitpack.io</id>
+            <name>Jitpack</name>
+            <url>https://jitpack.io</url>
+        </repository>
+    </repositories>
+
     <dependencies>
+        <dependency>
+            <groupId>com.github.conker84</groupId>
+            <artifactId>neo4j-configuration-lifecycle</artifactId>
+            <version>${neo4j.configuration-lifecycle.version}</version>
+        </dependency>
 
         <dependency>
             <groupId>org.neo4j</groupId>
@@ -155,7 +182,7 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>2.7.5</version>
+            <version>3.3.3</version>
             <scope>test</scope>
         </dependency>
 
@@ -214,21 +241,27 @@
         <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-core</artifactId>
-            <version>1.3</version>
+            <version>${hamcrest.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-library</artifactId>
-            <version>1.3</version>
+            <version>${hamcrest.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-all</artifactId>
-            <version>1.3</version>
+            <version>${hamcrest.version}</version>
             <scope>test</scope>
         </dependency>
+<!--        <dependency>-->
+<!--            <groupId>org.slf4j</groupId>-->
+<!--            <artifactId>slf4j-simple</artifactId>-->
+<!--            <version>1.7.30</version>-->
+<!--            <scope>test</scope>-->
+<!--        </dependency>-->
 
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
         <avro.version>1.8.2</avro.version>
         <kafka.avro.serializer.version>5.2.2</kafka.avro.serializer.version>
         <hamcrest.version>1.3</hamcrest.version>
-        <neo4j.configuration-lifecycle.version>65750ed701</neo4j.configuration-lifecycle.version>
+        <neo4j.configuration-lifecycle.version>ad59084711</neo4j.configuration-lifecycle.version>
     </properties>
 
     <organization>

--- a/producer/src/main/kotlin/streams/StreamsEventRouter.kt
+++ b/producer/src/main/kotlin/streams/StreamsEventRouter.kt
@@ -1,10 +1,12 @@
 package streams
 
-import org.neo4j.kernel.configuration.Config
-import org.neo4j.logging.internal.LogService
+import org.neo4j.logging.Log
 import streams.events.StreamsEvent
+import streams.events.StreamsPluginStatus
 
-abstract class StreamsEventRouter(val logService: LogService?, val config: Config?) {
+abstract class StreamsEventRouter(config: Map<String, String>, log: Log) {
+
+    abstract val eventRouterConfiguration: StreamsEventRouterConfiguration
 
     abstract fun sendEvents(topic: String, transactionEvents: List<out StreamsEvent>, config: Map<String, Any?> = emptyMap())
 
@@ -16,14 +18,16 @@ abstract class StreamsEventRouter(val logService: LogService?, val config: Confi
 
     open fun printInvalidTopics() {}
 
+    abstract fun status(): StreamsPluginStatus
+
 }
 
 
 object StreamsEventRouterFactory {
-    fun getStreamsEventRouter(logService: LogService, config: Config): StreamsEventRouter {
-        return Class.forName(config.raw.getOrDefault("streams.router", "streams.kafka.KafkaEventRouter"))
-                .getConstructor(LogService::class.java, Config::class.java)
-                .newInstance(logService, config) as StreamsEventRouter
+    fun getStreamsEventRouter(config: Map<String, String>,log: Log): StreamsEventRouter {
+        return Class.forName(config.getOrDefault("streams.router", "streams.kafka.KafkaEventRouter"))
+                .getConstructor(Map::class.java, Log::class.java)
+                .newInstance(config, log) as StreamsEventRouter
     }
 }
 

--- a/producer/src/main/kotlin/streams/StreamsEventRouter.kt
+++ b/producer/src/main/kotlin/streams/StreamsEventRouter.kt
@@ -18,8 +18,6 @@ abstract class StreamsEventRouter(config: Map<String, String>, log: Log) {
 
     open fun printInvalidTopics() {}
 
-    abstract fun status(): StreamsPluginStatus
-
 }
 
 

--- a/producer/src/main/kotlin/streams/StreamsEventRouterAvailabilityListener.kt
+++ b/producer/src/main/kotlin/streams/StreamsEventRouterAvailabilityListener.kt
@@ -7,61 +7,44 @@ import org.neo4j.kernel.availability.AvailabilityListener
 import org.neo4j.kernel.configuration.Config
 import org.neo4j.kernel.internal.GraphDatabaseAPI
 import org.neo4j.logging.internal.LogService
-import streams.procedures.StreamsProcedures
-import streams.utils.StreamsUtils
+import org.neo4j.plugin.configuration.EventType
+import streams.configuration.StreamsConfig
 
 class StreamsEventRouterAvailabilityListener(private val db: GraphDatabaseAPI,
-                                             configuration: Config,
-                                             log: LogService): AvailabilityListener {
-    private val streamsLog = log.getUserLog(StreamsEventRouterAvailabilityListener::class.java)
-    private val txHandler: StreamsTransactionEventHandler
-    private val streamsConstraintsService: StreamsConstraintsService
-    private val streamHandler: StreamsEventRouter
-    private val streamsEventRouterConfiguration: StreamsEventRouterConfiguration
-    private var registered = false
-
+                                             logService: LogService): AvailabilityListener {
     private val mutex = Mutex()
 
+    private val streamsConfig = StreamsConfig.getInstance(db)
+    private val listener = StreamsRouterConfigurationListener(db, logService.getUserLog(StreamsRouterConfigurationListener::class.java))
+
     init {
-        streamsLog.info("Initialising the Streams Source module")
-        streamHandler = StreamsEventRouterFactory.getStreamsEventRouter(log, configuration)
-        streamsEventRouterConfiguration = StreamsEventRouterConfiguration.from(configuration.raw)
-        StreamsProcedures.registerEventRouter(eventRouter = streamHandler)
-        StreamsProcedures.registerEventRouterConfiguration(eventRouterConfiguration = streamsEventRouterConfiguration)
-        streamsConstraintsService = StreamsConstraintsService(db, streamsEventRouterConfiguration.schemaPollingInterval)
-        txHandler = StreamsTransactionEventHandler(streamHandler, streamsConstraintsService, streamsEventRouterConfiguration)
-        streamsLog.info("Streams Source module initialised")
+        streamsConfig.addConfigurationLifecycleListener(EventType.CONFIGURATION_INITIALIZED,
+                listener)
     }
 
-    private fun registerTransactionEventHandler() = runBlocking {
-        mutex.withLock {
-            if (streamsEventRouterConfiguration.enabled && !registered) {
-                streamHandler.start()
-                streamHandler.printInvalidTopics()
-                db.registerTransactionEventHandler(txHandler)
-                streamsConstraintsService.start()
-                registered = true
-            }
-        }
-    }
-
-    private fun unregisterTransactionEventHandler() = runBlocking {
-        mutex.withLock {
-            if (streamsEventRouterConfiguration.enabled && registered) {
-                StreamsUtils.ignoreExceptions({ streamsConstraintsService.close() },
-                        UninitializedPropertyAccessException::class.java)
-                StreamsUtils.ignoreExceptions({ db.unregisterTransactionEventHandler(txHandler) },
-                        UninitializedPropertyAccessException::class.java)
-                registered = false
-            }
-        }
-    }
     override fun available() {
-        registerTransactionEventHandler()
+        runBlocking {
+            mutex.withLock {
+                streamsConfig.start()
+            }
+        }
     }
 
     override fun unavailable() {
-        unregisterTransactionEventHandler()
+        runBlocking {
+            mutex.withLock {
+                streamsConfig.stop()
+            }
+        }
+    }
+
+    fun shutdown() {
+        runBlocking {
+            mutex.withLock {
+                streamsConfig.stop(true)
+                StreamsConfig.removeInstance(db)
+            }
+        }
     }
 
 }

--- a/producer/src/main/kotlin/streams/StreamsExtensionFactory.kt
+++ b/producer/src/main/kotlin/streams/StreamsExtensionFactory.kt
@@ -33,13 +33,13 @@ class StreamsEventRouterLifecycle(db: GraphDatabaseAPI,
                                   configuration: Config,
                                   private val availabilityGuard: AvailabilityGuard,
                                   log: LogService): LifecycleAdapter() {
-    private val streamsEventRouterAvailabilityListener = StreamsEventRouterAvailabilityListener(db, configuration, log)
+    private val streamsEventRouterAvailabilityListener = StreamsEventRouterAvailabilityListener(db, log)
 
     override fun start() {
         availabilityGuard.addListener(streamsEventRouterAvailabilityListener)
     }
 
     override fun stop() {
-        streamsEventRouterAvailabilityListener.unavailable()
+        streamsEventRouterAvailabilityListener.shutdown()
     }
 }

--- a/producer/src/main/kotlin/streams/StreamsRouterConfigurationListener.kt
+++ b/producer/src/main/kotlin/streams/StreamsRouterConfigurationListener.kt
@@ -1,0 +1,124 @@
+package streams
+
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import org.apache.commons.configuration2.ImmutableConfiguration
+import org.neo4j.kernel.internal.GraphDatabaseAPI
+import org.neo4j.logging.Log
+import org.neo4j.plugin.configuration.ConfigurationLifecycleUtils
+import org.neo4j.plugin.configuration.EventType
+import org.neo4j.plugin.configuration.listners.ConfigurationLifecycleListener
+import streams.kafka.KafkaConfiguration
+import streams.procedures.StreamsProcedures
+import streams.utils.KafkaValidationUtils
+
+class StreamsRouterConfigurationListener(private val db: GraphDatabaseAPI,
+                                         private val log: Log) : ConfigurationLifecycleListener {
+    private val mutex = Mutex()
+
+    private var txHandler: StreamsTransactionEventHandler? = null
+    private var streamsConstraintsService: StreamsConstraintsService? = null
+    private var streamsEventRouter: StreamsEventRouter? = null
+    private var streamsEventRouterConfiguration: StreamsEventRouterConfiguration? = null
+
+    private var lastConfig: KafkaConfiguration? = null
+
+    private val consumerConfig = KafkaValidationUtils.getConsumerProperties()
+
+    private fun KafkaConfiguration.excludeSinkProps() = this.asProperties()
+        ?.filterNot { consumerConfig.contains(it.key)
+                || it.key.toString().startsWith("streams.sink")
+                // these are not yet used by the streams Source module
+                || it.key == "streams.cluster.only"
+                || it.key == "streams.check.apoc.timeout"
+                || it.key == "streams.check.apoc.interval" }
+
+    override fun onShutdown() {
+        runBlocking {
+            mutex.withLock {
+                shutdown()
+            }
+        }
+    }
+
+    // visible for testing
+    fun isConfigurationChanged(configMap: Map<String, String>) = when (configMap
+        .getOrDefault("streams.router", "streams.kafka.KafkaEventRouter")) {
+        "streams.kafka.KafkaEventRouter" ->  {
+            // we validate all properties except for the ones related to the Consumer
+            // we use this strategy because there are some properties related to the Confluent Platform
+            // that we're not able to track from the Apache Packages
+            // i.e. the Schema Registry
+            val config = KafkaConfiguration.create(configMap).excludeSinkProps()
+            val lastConfig = lastConfig?.excludeSinkProps()
+            val streamsConfig = StreamsEventRouterConfiguration.from(configMap)
+            config != lastConfig || streamsConfig != streamsEventRouterConfiguration
+        }
+        else -> true
+    }
+
+    private fun shutdown() {
+        val isShuttingDown = txHandler != null
+        if (isShuttingDown) {
+            log.info("[Sink] Shutting down the Streams Source Module")
+        }
+        if (streamsEventRouterConfiguration?.enabled == true) {
+            streamsConstraintsService?.close()
+            streamsEventRouter?.stop()
+            streamsEventRouter = null
+            StreamsProcedures.unregisterEventRouter(db)
+            if (txHandler != null) {
+                db.unregisterTransactionEventHandler(txHandler)
+                txHandler = null
+            }
+        }
+        if (isShuttingDown) {
+            log.info("[Source] Shutdown of the Streams Source Module completed")
+        }
+    }
+
+    private fun start(configMap: Map<String, String>) {
+        lastConfig = KafkaConfiguration.create(configMap)
+        streamsEventRouterConfiguration = StreamsEventRouterConfiguration.from(configMap)
+        streamsEventRouter = StreamsEventRouterFactory.getStreamsEventRouter(configMap, log)
+        if (streamsConstraintsService == null) {
+            streamsConstraintsService = StreamsConstraintsService(db, streamsEventRouterConfiguration!!.schemaPollingInterval)
+        }
+        if (streamsEventRouterConfiguration?.enabled == true || streamsEventRouterConfiguration?.proceduresEnabled == true) {
+            streamsConstraintsService!!.start()
+            streamsEventRouter!!.start()
+        }
+        if (streamsEventRouterConfiguration?.enabled == true) {
+            txHandler = StreamsTransactionEventHandler(streamsEventRouter!!, streamsConstraintsService!!)
+            streamsEventRouter!!.printInvalidTopics()
+            db.registerTransactionEventHandler(txHandler)
+        }
+        StreamsProcedures.registerEventRouter(db, streamsEventRouter!!)
+        log.info("[Source] Streams Source module initialised")
+    }
+
+    override fun onConfigurationChange(evt: EventType, config: ImmutableConfiguration) {
+        if (config.isEmpty) {
+            return
+        }
+        runBlocking {
+            mutex.withLock {
+                log.info("[Source] An event change is detected ${evt.name}")
+                val configMap = ConfigurationLifecycleUtils.toMap(config)
+                    .mapValues { it.value.toString() }
+                if (!isConfigurationChanged(configMap)) {
+                    log.info("[Source] The configuration is not changed so the module will not restarted")
+                    return@runBlocking
+                }
+                log.info("[Source] Shutting down the Streams Source Module")
+                shutdown()
+                log.info("[Source] Initialising the Streams Source module")
+                if (log.isDebugEnabled) {
+                    log.debug("[Source] The new configuration is: $configMap")
+                }
+                start(configMap)
+            }
+        }
+    }
+}

--- a/producer/src/main/kotlin/streams/StreamsTransactionEventHandler.kt
+++ b/producer/src/main/kotlin/streams/StreamsTransactionEventHandler.kt
@@ -12,9 +12,10 @@ import java.util.concurrent.atomic.AtomicInteger
 
 
 class StreamsTransactionEventHandler(private val router: StreamsEventRouter,
-                                     private val streamsConstraintsService: StreamsConstraintsService,
-                                     private val configuration: StreamsEventRouterConfiguration)
+                                     private val streamsConstraintsService: StreamsConstraintsService)
     : TransactionEventHandler<PreviousTransactionData> {
+
+    private val configuration = router.eventRouterConfiguration
 
     private val nodeRoutingLabels = configuration.nodeRouting
             .flatMap { it.labels }

--- a/producer/src/main/kotlin/streams/kafka/KafkaConfiguration.kt
+++ b/producer/src/main/kotlin/streams/kafka/KafkaConfiguration.kt
@@ -76,10 +76,10 @@ data class KafkaConfiguration(val zookeeperConnect: String = "localhost:2181",
         val props = Properties()
         val map = JSONUtils.asMap(this)
                 .filter {
-                    if (it.key == "transactionalId") {
-                        it.value != StringUtils.EMPTY
-                    } else {
-                        true
+                    when (it.key) {
+                        "transactionalId" -> it.value != StringUtils.EMPTY
+                        "extraProperties" -> false
+                        else -> true
                     }
                 }
                 .mapKeys { it.key.toPointCase() }

--- a/producer/src/main/kotlin/streams/kafka/KafkaEventRouter.kt
+++ b/producer/src/main/kotlin/streams/kafka/KafkaEventRouter.kt
@@ -45,10 +45,6 @@ class KafkaEventRouter(private val config: Map<String, String>, private val log:
         else -> StreamsPluginStatus.STOPPED
     }
 
-    override fun status(): StreamsPluginStatus = runBlocking {
-        mutex.withLock(producer) { status(producer) }
-    }
-
     override fun start() = runBlocking {
         mutex.withLock(producer) {
             if (status(producer) == StreamsPluginStatus.RUNNING) {

--- a/producer/src/main/kotlin/streams/procedures/StreamsProcedures.kt
+++ b/producer/src/main/kotlin/streams/procedures/StreamsProcedures.kt
@@ -1,16 +1,29 @@
 package streams.procedures
 
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import org.neo4j.graphdb.GraphDatabaseService
+import org.neo4j.kernel.internal.GraphDatabaseAPI
 import org.neo4j.logging.Log
-import org.neo4j.procedure.*
+import org.neo4j.procedure.Context
+import org.neo4j.procedure.Description
+import org.neo4j.procedure.Mode
+import org.neo4j.procedure.Name
+import org.neo4j.procedure.Procedure
 import streams.StreamsEventRouter
-import streams.StreamsEventRouterConfiguration
 import streams.events.StreamsEventBuilder
-import java.lang.RuntimeException
+import streams.events.StreamsPluginStatus
+import streams.utils.StreamsUtils
+import java.util.concurrent.ConcurrentHashMap
 import java.util.stream.Stream
 
 class StreamsProcedures {
 
     @JvmField @Context var log: Log? = null
+
+    @JvmField @Context
+    var db: GraphDatabaseService? = null
 
     @Procedure(mode = Mode.READ, name = "streams.publish.sync")
     @Description("streams.publish.sync(topic, payload, config) - Allows custom synchronous streaming from Neo4j to the configured stream environment")
@@ -24,8 +37,9 @@ class StreamsProcedures {
 
         val streamsEvent = buildStreamEvent(topic!!, payload!!)
 
-        return eventRouter.sendEventsSync(topic, listOf(streamsEvent), config ?: emptyMap())
-                .map { StreamPublishResult(it) }
+        return getEventRouter(db!!)?.sendEventsSync(topic, listOf(streamsEvent), config ?: emptyMap())
+                ?.map { StreamPublishResult(it) }
+                .orEmpty()
                 .stream()
     }
 
@@ -41,7 +55,7 @@ class StreamsProcedures {
 
         val streamsEvent = buildStreamEvent(topic!!, payload!!)
 
-        eventRouter.sendEvents(topic, listOf(streamsEvent), config ?: emptyMap())
+        getEventRouter(db!!)?.sendEvents(topic, listOf(streamsEvent), config ?: emptyMap())
     }
 
     private fun isTopicNullOrEmpty(topic: String?): Boolean {
@@ -54,7 +68,7 @@ class StreamsProcedures {
     }
 
     private fun checkEnabled() {
-        if (!eventRouterConfiguration.proceduresEnabled) {
+        if (getEventRouter(db!!)?.eventRouterConfiguration?.proceduresEnabled == false) {
             throw RuntimeException("In order to use the procedure you must set streams.procedures.enabled=true")
         }
     }
@@ -68,28 +82,29 @@ class StreamsProcedures {
 
     private fun buildStreamEvent(topic: String, payload: Any) = StreamsEventBuilder()
             .withPayload(payload)
-            .withNodeRoutingConfiguration(eventRouterConfiguration
-                    .nodeRouting
-                    .filter { it.topic == topic }
-                    .firstOrNull())
-            .withRelationshipRoutingConfiguration(eventRouterConfiguration
-                    .relRouting
-                    .filter { it.topic == topic }
-                    .firstOrNull())
+            .withNodeRoutingConfiguration(getEventRouter(db!!)?.eventRouterConfiguration
+                    ?.nodeRouting
+                    ?.filter { it.topic == topic }
+                    ?.firstOrNull())
+            .withRelationshipRoutingConfiguration(getEventRouter(db!!)?.eventRouterConfiguration
+                    ?.relRouting
+                    ?.filter { it.topic == topic }
+                    ?.firstOrNull())
             .withTopic(topic)
             .build()
 
     companion object {
-        private lateinit var eventRouter: StreamsEventRouter
-        private lateinit var eventRouterConfiguration: StreamsEventRouterConfiguration
+        private val cache = ConcurrentHashMap<String, StreamsEventRouter>()
 
-        fun registerEventRouter(eventRouter: StreamsEventRouter) {
-            this.eventRouter = eventRouter
-        }
+        private fun getEventRouter(db: GraphDatabaseService) = cache[StreamsUtils.getName(db as GraphDatabaseAPI)]
 
-        fun registerEventRouterConfiguration(eventRouterConfiguration: StreamsEventRouterConfiguration) {
-            this.eventRouterConfiguration = eventRouterConfiguration
-        }
+        fun registerEventRouter(db: GraphDatabaseAPI, eventRouter: StreamsEventRouter) = cache.put(StreamsUtils.getName(db), eventRouter)
+
+        fun unregisterEventRouter(db: GraphDatabaseAPI) = cache.remove(StreamsUtils.getName(db))
+
+        fun hasStatus(db: GraphDatabaseAPI, status: StreamsPluginStatus) = getEventRouter(db)?.status() == status
+
+        fun isRegistered(db: GraphDatabaseAPI) = getEventRouter(db) != null
     }
 
 }

--- a/producer/src/test/kotlin/extension/GraphDatabaseBuilderExtension.kt
+++ b/producer/src/test/kotlin/extension/GraphDatabaseBuilderExtension.kt
@@ -1,0 +1,36 @@
+package extension
+
+import org.neo4j.graphdb.GraphDatabaseService
+import org.neo4j.graphdb.factory.GraphDatabaseBuilder
+import org.neo4j.kernel.internal.GraphDatabaseAPI
+import streams.configuration.StreamsConfig
+import streams.events.StreamsPluginStatus
+import streams.procedures.StreamsProcedures
+import streams.utils.StreamsUtils
+
+fun GraphDatabaseBuilder.newDatabase(initialPluginStatus: StreamsPluginStatus = StreamsPluginStatus.RUNNING): GraphDatabaseService {
+    val configField = try {
+        this.javaClass.superclass.getDeclaredField("config")
+    } catch (e: Exception) {
+        this.javaClass.getDeclaredField("config")
+    }
+    configField.isAccessible = true
+    val config: Map<String, Any> = configField.get(this) as Map<String, Any>
+    val db = newGraphDatabase() as GraphDatabaseAPI
+    if (db.isAvailable(30000)) {
+        println("Setting Config from APIs: $config")
+        if (config.isNotEmpty()) {
+            StreamsConfig.getInstance(db).setProperties(config, false)
+        }
+    } else {
+        throw RuntimeException("Cannot set Config because database is not available")
+    }
+    val success = StreamsUtils.blockUntilFalseOrTimeout(100000, 1000) {
+        StreamsProcedures.hasStatus(db, initialPluginStatus)
+    }
+    if (!success && StreamsProcedures.isRegistered(db)) {
+        db.shutdown()
+        throw RuntimeException("Cannot start the Sink properly")
+    }
+    return db
+}

--- a/producer/src/test/kotlin/streams/StreamsRouterConfigurationListenerTest.kt
+++ b/producer/src/test/kotlin/streams/StreamsRouterConfigurationListenerTest.kt
@@ -1,0 +1,61 @@
+package streams
+
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mockito
+import org.neo4j.kernel.internal.GraphDatabaseAPI
+import org.neo4j.logging.NullLog
+import streams.kafka.KafkaConfiguration
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class StreamsRouterConfigurationListenerTest {
+    private lateinit var db: GraphDatabaseAPI
+    private lateinit var streamsRouterConfigurationListener: StreamsRouterConfigurationListener
+
+    private val kafkaConfig = mapOf("kafka.zookeeper.connect" to "zookeeper:1234",
+        "kafka.bootstrap.servers" to "kafka:5678",
+        "kafka.acks" to "10",
+        "kafka.num.partitions" to "1",
+        "kafka.retries" to "1",
+        "kafka.batch.size" to "10",
+        "kafka.buffer.memory" to "1000",
+        "kafka.reindex.batch.size" to "1",
+        "kafka.session.timeout.ms" to "1",
+        "kafka.connection.timeout.ms" to "1",
+        "kafka.replication" to "2",
+        "kafka.linger.ms" to "10",
+        "kafka.fetch.min.bytes" to "1234",
+        "kafka.topic.discovery.polling.interval" to "0")
+
+    @Before
+    fun setUp() {
+        db = Mockito.mock(GraphDatabaseAPI::class.java)
+        streamsRouterConfigurationListener = StreamsRouterConfigurationListener(db, NullLog.getInstance())
+        val lastConfig = StreamsRouterConfigurationListener::class.java.getDeclaredField("lastConfig")
+        lastConfig.isAccessible = true
+        lastConfig.set(streamsRouterConfigurationListener, KafkaConfiguration.create(kafkaConfig))
+        val streamsEventRouterConfiguration = StreamsRouterConfigurationListener::class.java.getDeclaredField("streamsEventRouterConfiguration")
+        streamsEventRouterConfiguration.isAccessible = true
+        streamsEventRouterConfiguration.set(streamsRouterConfigurationListener, StreamsEventRouterConfiguration.from(kafkaConfig))
+    }
+
+    @After
+    fun tearDown() {
+        db.shutdown()
+    }
+
+    @Test
+    fun `test configuration changes`() {
+        val transactionalId = kafkaConfig + mapOf("kafka.transactional.id" to "foo")
+        assertTrue { streamsRouterConfigurationListener.isConfigurationChanged(transactionalId) }
+        val sourceCypherTopic = kafkaConfig + mapOf("streams.sink.topic.cypher.my-topic" to "CREATE (n:Label)")
+        assertFalse { streamsRouterConfigurationListener.isConfigurationChanged(sourceCypherTopic) }
+        val autoOffset = kafkaConfig + mapOf("kafka.auto.offset.reset" to "latest")
+        assertFalse { streamsRouterConfigurationListener.isConfigurationChanged(autoOffset) }
+        val clusterOnly = kafkaConfig + mapOf("streams.cluster.only" to "true")
+        assertFalse { streamsRouterConfigurationListener.isConfigurationChanged(clusterOnly) }
+    }
+
+}

--- a/producer/src/test/kotlin/streams/StreamsTransactionEventHandlerRelTest.kt
+++ b/producer/src/test/kotlin/streams/StreamsTransactionEventHandlerRelTest.kt
@@ -42,7 +42,7 @@ class StreamsTransactionEventHandlerRelTest {
         streamsConstraintsService = StreamsConstraintsService(dbMock, 0)
         streamsConstraintsService.start()
         handler = StreamsTransactionEventHandler(MockStreamsEventRouter(),
-                streamsConstraintsService, StreamsEventRouterConfiguration())
+                streamsConstraintsService)
         MockStreamsEventRouter.reset()
     }
 

--- a/producer/src/test/kotlin/streams/StreamsTransactionEventHandlerRelTest.kt
+++ b/producer/src/test/kotlin/streams/StreamsTransactionEventHandlerRelTest.kt
@@ -41,7 +41,7 @@ class StreamsTransactionEventHandlerRelTest {
         Mockito.`when`(dbMock.schema()).thenReturn(schemaMock)
         streamsConstraintsService = StreamsConstraintsService(dbMock, 0)
         streamsConstraintsService.start()
-        handler = StreamsTransactionEventHandler(MockStreamsEventRouter(),
+        handler = StreamsTransactionEventHandler(MockStreamsEventRouter(), dbMock,
                 streamsConstraintsService)
         MockStreamsEventRouter.reset()
     }

--- a/producer/src/test/kotlin/streams/StreamsTransactionEventHandlerTest.kt
+++ b/producer/src/test/kotlin/streams/StreamsTransactionEventHandlerTest.kt
@@ -40,7 +40,7 @@ class StreamsTransactionEventHandlerTest {
         streamsConstraintsService = StreamsConstraintsService(dbMock, 0)
         streamsConstraintsService.start()
         handler = StreamsTransactionEventHandler(MockStreamsEventRouter(),
-                streamsConstraintsService, StreamsEventRouterConfiguration())
+                streamsConstraintsService)
         MockStreamsEventRouter.reset()
     }
 

--- a/producer/src/test/kotlin/streams/StreamsTransactionEventHandlerTest.kt
+++ b/producer/src/test/kotlin/streams/StreamsTransactionEventHandlerTest.kt
@@ -39,7 +39,7 @@ class StreamsTransactionEventHandlerTest {
         Mockito.`when`(dbMock.schema()).thenReturn(schemaMock)
         streamsConstraintsService = StreamsConstraintsService(dbMock, 0)
         streamsConstraintsService.start()
-        handler = StreamsTransactionEventHandler(MockStreamsEventRouter(),
+        handler = StreamsTransactionEventHandler(MockStreamsEventRouter(), dbMock,
                 streamsConstraintsService)
         MockStreamsEventRouter.reset()
     }

--- a/producer/src/test/kotlin/streams/integrations/KafkaEventRouterIT.kt
+++ b/producer/src/test/kotlin/streams/integrations/KafkaEventRouterIT.kt
@@ -518,9 +518,9 @@ class KafkaEventRouterIT {
 
     @Test
     fun testProcedureSyncWithConfig() {
-        AdminClient.create(mapOf("bootstrap.servers" to kafka.bootstrapServers)).use {
+        AdminClient.create(mapOf("bootstrap.servers" to kafka.bootstrapServers)).use { admin ->
             val topic = UUID.randomUUID().toString()
-            it.createTopics(listOf(NewTopic(topic, 5, 1)))
+            admin.createTopics(listOf(NewTopic(topic, 5, 1))).all().get()
             val config = KafkaConfiguration(bootstrapServers = kafka.bootstrapServers)
             createConsumer(config).use { consumer ->
                 consumer.subscribe(listOf(topic))
@@ -551,9 +551,9 @@ class KafkaEventRouterIT {
 
     @Test
     fun testProcedureWithTopicWithMultiplePartitionAndKey() {
-        AdminClient.create(mapOf("bootstrap.servers" to kafka.bootstrapServers)).use {
+        AdminClient.create(mapOf("bootstrap.servers" to kafka.bootstrapServers)).use { admin ->
             val topic = UUID.randomUUID().toString()
-            it.createTopics(listOf(NewTopic(topic, 3, 1)))
+            admin.createTopics(listOf(NewTopic(topic, 3, 1))).all().get()
             val config = KafkaConfiguration(bootstrapServers = kafka.bootstrapServers)
             createConsumer(config).use { consumer ->
                 consumer.subscribe(listOf(topic))
@@ -575,9 +575,9 @@ class KafkaEventRouterIT {
 
     @Test
     fun testProcedureSendMessageToNotExistentPartition() {
-        AdminClient.create(mapOf("bootstrap.servers" to kafka.bootstrapServers)).use {
+        AdminClient.create(mapOf("bootstrap.servers" to kafka.bootstrapServers)).use { admin ->
             val topic = UUID.randomUUID().toString()
-            it.createTopics(listOf(NewTopic(topic, 3, 1)))
+            admin.createTopics(listOf(NewTopic(topic, 3, 1))).all().get()
             val config = KafkaConfiguration(bootstrapServers = kafka.bootstrapServers)
             createConsumer(config).use { consumer ->
                 consumer.subscribe(listOf(topic))

--- a/producer/src/test/kotlin/streams/integrations/StreamsTransactionEventHandlerIT.kt
+++ b/producer/src/test/kotlin/streams/integrations/StreamsTransactionEventHandlerIT.kt
@@ -1,5 +1,6 @@
 package streams.integrations
 
+import extension.newDatabase
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
@@ -23,7 +24,7 @@ class StreamsTransactionEventHandlerIT {
         db = TestGraphDatabaseFactory()
                 .newImpermanentDatabaseBuilder()
                 .setConfig("streams.router", "streams.mocks.MockStreamsEventRouter")
-                .newGraphDatabase()
+                .newDatabase()
     }
 
     @After

--- a/producer/src/test/kotlin/streams/mocks/MockStreamsEventRouter.kt
+++ b/producer/src/test/kotlin/streams/mocks/MockStreamsEventRouter.kt
@@ -2,14 +2,22 @@ package streams.mocks
 
 import org.apache.kafka.clients.producer.RecordMetadata
 import org.apache.kafka.common.TopicPartition
-import org.neo4j.kernel.configuration.Config
-import org.neo4j.logging.internal.LogService
+import org.neo4j.logging.Log
+import org.neo4j.logging.NullLog
 import streams.StreamsEventRouter
+import streams.StreamsEventRouterConfiguration
 import streams.events.StreamsEvent
+import streams.events.StreamsPluginStatus
 import streams.events.StreamsTransactionEvent
 import streams.toMap
+import java.util.concurrent.atomic.AtomicReference
 
-class MockStreamsEventRouter(logService: LogService? = null, config: Config? = null): StreamsEventRouter(logService, config) {
+class MockStreamsEventRouter(map: Map<String, String> = emptyMap(),
+                             log: Log = NullLog.getInstance()): StreamsEventRouter(map, log) {
+
+    override val eventRouterConfiguration: StreamsEventRouterConfiguration = StreamsEventRouterConfiguration()
+
+    private var status = AtomicReference<StreamsPluginStatus>()
 
     private fun fakeRecordMetadata(topic: String) = RecordMetadata(
             TopicPartition(topic, 0),
@@ -28,12 +36,18 @@ class MockStreamsEventRouter(logService: LogService? = null, config: Config? = n
         return result
     }
 
-    override fun start() {}
+    override fun start() {
+        status.set(StreamsPluginStatus.RUNNING)
+    }
 
-    override fun stop() {}
+    override fun stop() {
+        status.set(StreamsPluginStatus.STOPPED)
+    }
+
+    override fun status(): StreamsPluginStatus = status.get()
 
     companion object {
-        var events = mutableListOf<StreamsTransactionEvent>()
+        val events = mutableListOf<StreamsTransactionEvent>()
 
         fun reset() {
             events.clear()

--- a/producer/src/test/kotlin/streams/mocks/MockStreamsEventRouter.kt
+++ b/producer/src/test/kotlin/streams/mocks/MockStreamsEventRouter.kt
@@ -44,8 +44,6 @@ class MockStreamsEventRouter(map: Map<String, String> = emptyMap(),
         status.set(StreamsPluginStatus.STOPPED)
     }
 
-    override fun status(): StreamsPluginStatus = status.get()
-
     companion object {
         val events = mutableListOf<StreamsTransactionEvent>()
 


### PR DESCRIPTION
Fixes #358

**[READ THIS DOCUMENTATION ABOUT THIS PR](https://docs.google.com/document/d/1ZbXOA89HBO2fATHJGc-A6gD4x7bkSfo_Ywet2X6GTYs/edit?usp=sharing)**


This PR adds new features in order to support configuration changes at runtime without the need of restarting the database each time, but simply by changing the new `streams.conf` or by provided procedures. 

## Proposed Changes (Mandatory)

A brief list of proposed changes in order to fix the issue:

  - Added new procedures `streams.configuration.set` and `streams.configuration.get`

Todo:
- [x] Fix broken tests
- [x] Add documentation