### PR TITLE
Fixes #429: [CDC] Schema select randomly the uk in case of multiple unique constraints

### DIFF
--- a/common/src/main/kotlin/streams/utils/SchemaUtils.kt
+++ b/common/src/main/kotlin/streams/utils/SchemaUtils.kt
@@ -13,10 +13,9 @@ object SchemaUtils {
                             && propertyKeys.containsAll(constraint.properties)
                             && labels.contains(constraint.label)
                 }
-                .minBy { it.properties.size }
+                .minWithOrNull((compareBy({ it.properties.size }, {it.properties.sorted().toString()})))
                 ?.properties
                 .orEmpty()
-//                .ifEmpty { propertyKeys }
 
     fun toStreamsTransactionEvent(streamsSinkEntity: StreamsSinkEntity,
                                   evaluation: (StreamsTransactionEvent) -> Boolean)

--- a/common/src/main/kotlin/streams/utils/SchemaUtils.kt
+++ b/common/src/main/kotlin/streams/utils/SchemaUtils.kt
@@ -13,7 +13,7 @@ object SchemaUtils {
                             && propertyKeys.containsAll(constraint.properties)
                             && labels.contains(constraint.label)
                 }
-                .minWithOrNull((compareBy({ it.properties.size }, {it.properties.sorted().toString()})))
+                .minWithOrNull((compareBy({ it.properties.size }, { it.label }, { it.properties.sorted().toString() })))
                 ?.properties
                 .orEmpty()
 

--- a/common/src/main/kotlin/streams/utils/SchemaUtils.kt
+++ b/common/src/main/kotlin/streams/utils/SchemaUtils.kt
@@ -13,6 +13,9 @@ object SchemaUtils {
                             && propertyKeys.containsAll(constraint.properties)
                             && labels.contains(constraint.label)
                 }
+                // we order first by properties.size, then by label name and finally by properties name alphabetically
+                // with properties.sorted() we ensure that ("foo", "bar") and ("bar", "foo") are no different
+                // with toString() we force it.properties to have the natural sort order, that is alphabetically
                 .minWithOrNull((compareBy({ it.properties.size }, { it.label }, { it.properties.sorted().toString() })))
                 ?.properties
                 .orEmpty()

--- a/common/src/test/kotlin/streams/service/sink/strategy/SchemaIngestionStrategyTest.kt
+++ b/common/src/test/kotlin/streams/service/sink/strategy/SchemaIngestionStrategyTest.kt
@@ -227,7 +227,9 @@ class SchemaIngestionStrategyTest {
     }
 
     @Test
-    fun `should create the Schema Query Strategy for relationships with multiple UNIQUE constraints with priority of constraint with less props and first sorted properties list alphabetically`() {
+    fun `should create the Schema Query Strategy for relationships with multiple unique constraints`() {
+        // the Schema Query Strategy leverage the first constraint with lowest properties
+        // with the same size, we take the first sorted properties list alphabetically
 
         (1..50).forEach {
             // given
@@ -302,7 +304,10 @@ class SchemaIngestionStrategyTest {
     }
 
     @Test
-    fun `should create the Schema Query Strategy for relationships with multiple UNIQUE constraints with priority of constraint with less props, first label alphabetically and first sorted properties list alphabetically`() {
+    fun `should create the Schema Query Strategy for relationships with multiple unique constraints and labels`() {
+        // the Schema Query Strategy leverage the first constraint with lowest properties
+        // with the same size, we take the first label in alphabetical order
+        // finally, with same label name, we take the first sorted properties list alphabetically
 
         (1..50).forEach {
             // given

--- a/common/src/test/kotlin/streams/service/sink/strategy/SchemaIngestionStrategyTest.kt
+++ b/common/src/test/kotlin/streams/service/sink/strategy/SchemaIngestionStrategyTest.kt
@@ -232,6 +232,7 @@ class SchemaIngestionStrategyTest {
         // with the same size, we take the first sorted properties list alphabetically
 
         // given
+        // we shuffle the constraints to ensure that the result doesn't depend from the ordering
         val constraintsList = listOf(
                 Constraint(label = "User Ext", type = StreamsConstraintType.UNIQUE, properties = linkedSetOf("address")),
                 Constraint(label = "User Ext", type = StreamsConstraintType.UNIQUE, properties = linkedSetOf("country")),
@@ -240,7 +241,6 @@ class SchemaIngestionStrategyTest {
                 Constraint(label = "Product Ext", type = StreamsConstraintType.UNIQUE, properties = linkedSetOf("code")),
                 Constraint(label = "Product Ext", type = StreamsConstraintType.UNIQUE, properties = linkedSetOf("name"))
         ).shuffled()
-        // we shuffle the constraints to ensure that the result doesn't depend from the ordering
 
         val relSchema = Schema(properties = mapOf("since" to "Long"), constraints = constraintsList)
         val idsStart = mapOf("name" to "Sherlock",
@@ -305,6 +305,7 @@ class SchemaIngestionStrategyTest {
         // finally, with same label name, we take the first sorted properties list alphabetically
 
         // given
+        // we shuffle the constraints to ensure that the result doesn't depend from the ordering
         val constraintsList = listOf(
                 Constraint(label = "User Ext", type = StreamsConstraintType.UNIQUE, properties = linkedSetOf("address")),
                 Constraint(label = "User Ext", type = StreamsConstraintType.UNIQUE, properties = linkedSetOf("country")),
@@ -314,7 +315,6 @@ class SchemaIngestionStrategyTest {
                 Constraint(label = "Product Ext", type = StreamsConstraintType.UNIQUE, properties = linkedSetOf("code")),
                 Constraint(label = "Product Ext", type = StreamsConstraintType.UNIQUE, properties = linkedSetOf("name"))
         ).shuffled()
-        // we shuffle the constraints to ensure that the result doesn't depend from the ordering
 
         val relSchema = Schema(properties = mapOf("since" to "Long"), constraints = constraintsList)
         val idsStart = mapOf("name" to "Sherlock",

--- a/common/src/test/kotlin/streams/service/sink/strategy/SchemaIngestionStrategyTest.kt
+++ b/common/src/test/kotlin/streams/service/sink/strategy/SchemaIngestionStrategyTest.kt
@@ -226,6 +226,81 @@ class SchemaIngestionStrategyTest {
     }
 
     @Test
+    fun `should create the Schema Query Strategy for relationships with multiple UNIQUE constraints with priority of constraint with less props and first in alphabetical order`() {
+
+        (1..50).forEach {
+            // given
+            val constraintsList = listOf(
+                    Constraint(label = "User Ext", type = StreamsConstraintType.UNIQUE, properties = linkedSetOf("address")),
+                    Constraint(label = "User Ext", type = StreamsConstraintType.UNIQUE, properties = linkedSetOf("country")),
+                    Constraint(label = "User Ext", type = StreamsConstraintType.UNIQUE, properties = linkedSetOf("name", "surname")),
+                    Constraint(label = "User Ext", type = StreamsConstraintType.UNIQUE, properties = linkedSetOf("profession", "another_one")),
+                    Constraint(label = "Product Ext", type = StreamsConstraintType.UNIQUE, properties = linkedSetOf("code")),
+                    Constraint(label = "Product Ext", type = StreamsConstraintType.UNIQUE, properties = linkedSetOf("name"))
+            ).shuffled()
+
+            val relSchema = Schema(properties = mapOf("since" to "Long"), constraints = constraintsList)
+            val idsStart = mutableListOf("name" to "Sherlock",
+                    "surname" to "Holmes",
+                    "country" to "UK",
+                    "profession" to "detective",
+                    "another_one" to "foo",
+                    "address" to "Baker Street")
+                    .shuffled()
+                    .toMap()
+
+            val idsEnd = mutableListOf("name" to "My Awesome Product", "code" to 17294)
+                    .shuffled()
+                    .toMap()
+            val cdcDataRelationship = StreamsTransactionEvent(
+                    meta = Meta(timestamp = System.currentTimeMillis(),
+                            username = "user",
+                            txId = 1,
+                            txEventId = 2,
+                            txEventsCount = 3,
+                            operation = OperationType.updated
+                    ),
+                    payload = RelationshipPayload(
+                            id = "2",
+                            start = RelationshipNodeChange(id = "1", labels = listOf("User Ext", "NewLabel"), ids = idsStart),
+                            end = RelationshipNodeChange(id = "2", labels = listOf("Product Ext", "NewLabelA"), ids = idsEnd),
+                            after = RelationshipChange(properties = mapOf("since" to 2014)),
+                            before = null,
+                            label = "HAS BOUGHT"
+                    ),
+                    schema = relSchema
+            )
+            val cdcQueryStrategy = SchemaIngestionStrategy()
+            val txEvents = listOf(StreamsSinkEntity(cdcDataRelationship, cdcDataRelationship))
+
+            // when
+            val relationshipEvents = cdcQueryStrategy.mergeRelationshipEvents(txEvents)
+            val relationshipDeleteEvents = cdcQueryStrategy.deleteRelationshipEvents(txEvents)
+
+            // then
+            assertEquals(0, relationshipDeleteEvents.size)
+            assertEquals(1, relationshipEvents.size)
+            val relQuery = relationshipEvents[0].query
+            val expectedRelQuery = """
+                |${StreamsUtils.UNWIND}
+                |MERGE (start:`User Ext`{address: event.start.address})
+                |MERGE (end:`Product Ext`{code: event.end.code})
+                |MERGE (start)-[r:`HAS BOUGHT`]->(end)
+                |SET r = event.properties
+            """.trimMargin()
+            assertEquals(expectedRelQuery, relQuery.trimIndent())
+            val eventsRelList = relationshipEvents[0].events
+            assertEquals(1, eventsRelList.size)
+            val expectedRelEvents = listOf(
+                    mapOf("start" to mapOf("address" to "Baker Street"),
+                            "end" to mapOf("code" to 17294),
+                            "properties" to mapOf("since" to 2014))
+            )
+            assertEquals(expectedRelEvents, eventsRelList)
+        }
+    }
+
+    @Test
     fun `should create the Schema Query Strategy for node deletes`() {
         // given
         val nodeSchema = Schema(properties = mapOf("name" to "String", "surname" to "String", "comp@ny" to "String"),

--- a/common/src/test/kotlin/streams/service/sink/strategy/SchemaIngestionStrategyTest.kt
+++ b/common/src/test/kotlin/streams/service/sink/strategy/SchemaIngestionStrategyTest.kt
@@ -231,76 +231,71 @@ class SchemaIngestionStrategyTest {
         // the Schema Query Strategy leverage the first constraint with lowest properties
         // with the same size, we take the first sorted properties list alphabetically
 
-        (1..50).forEach {
-            // given
-            val constraintsList = listOf(
-                    Constraint(label = "User Ext", type = StreamsConstraintType.UNIQUE, properties = linkedSetOf("address")),
-                    Constraint(label = "User Ext", type = StreamsConstraintType.UNIQUE, properties = linkedSetOf("country")),
-                    Constraint(label = "User Ext", type = StreamsConstraintType.UNIQUE, properties = linkedSetOf("name", "surname")),
-                    Constraint(label = "User Ext", type = StreamsConstraintType.UNIQUE, properties = linkedSetOf("profession", "another_one")),
-                    Constraint(label = "Product Ext", type = StreamsConstraintType.UNIQUE, properties = linkedSetOf("code")),
-                    Constraint(label = "Product Ext", type = StreamsConstraintType.UNIQUE, properties = linkedSetOf("name"))
-            ).shuffled()
+        // given
+        val constraintsList = listOf(
+                Constraint(label = "User Ext", type = StreamsConstraintType.UNIQUE, properties = linkedSetOf("address")),
+                Constraint(label = "User Ext", type = StreamsConstraintType.UNIQUE, properties = linkedSetOf("country")),
+                Constraint(label = "User Ext", type = StreamsConstraintType.UNIQUE, properties = linkedSetOf("name", "surname")),
+                Constraint(label = "User Ext", type = StreamsConstraintType.UNIQUE, properties = linkedSetOf("profession", "another_one")),
+                Constraint(label = "Product Ext", type = StreamsConstraintType.UNIQUE, properties = linkedSetOf("code")),
+                Constraint(label = "Product Ext", type = StreamsConstraintType.UNIQUE, properties = linkedSetOf("name"))
+        ).shuffled()
+        // we shuffle the constraints to ensure that the result doesn't depend from the ordering
 
-            val relSchema = Schema(properties = mapOf("since" to "Long"), constraints = constraintsList)
-            val idsStart = mutableListOf("name" to "Sherlock",
-                    "surname" to "Holmes",
-                    "country" to "UK",
-                    "profession" to "detective",
-                    "another_one" to "foo",
-                    "address" to "Baker Street")
-                    .shuffled()
-                    .toMap()
+        val relSchema = Schema(properties = mapOf("since" to "Long"), constraints = constraintsList)
+        val idsStart = mapOf("name" to "Sherlock",
+                "surname" to "Holmes",
+                "country" to "UK",
+                "profession" to "detective",
+                "another_one" to "foo",
+                "address" to "Baker Street")
+        val idsEnd = mapOf("name" to "My Awesome Product", "code" to 17294)
 
-            val idsEnd = mutableListOf("name" to "My Awesome Product", "code" to 17294)
-                    .shuffled()
-                    .toMap()
-            val cdcDataRelationship = StreamsTransactionEvent(
-                    meta = Meta(timestamp = System.currentTimeMillis(),
-                            username = "user",
-                            txId = 1,
-                            txEventId = 2,
-                            txEventsCount = 3,
-                            operation = OperationType.updated
-                    ),
-                    payload = RelationshipPayload(
-                            id = "2",
-                            start = RelationshipNodeChange(id = "1", labels = listOf("User Ext", "NewLabel"), ids = idsStart),
-                            end = RelationshipNodeChange(id = "2", labels = listOf("Product Ext", "NewLabelA"), ids = idsEnd),
-                            after = RelationshipChange(properties = mapOf("since" to 2014)),
-                            before = null,
-                            label = "HAS BOUGHT"
-                    ),
-                    schema = relSchema
-            )
-            val cdcQueryStrategy = SchemaIngestionStrategy()
-            val txEvents = listOf(StreamsSinkEntity(cdcDataRelationship, cdcDataRelationship))
+        val cdcDataRelationship = StreamsTransactionEvent(
+                meta = Meta(timestamp = System.currentTimeMillis(),
+                        username = "user",
+                        txId = 1,
+                        txEventId = 2,
+                        txEventsCount = 3,
+                        operation = OperationType.updated
+                ),
+                payload = RelationshipPayload(
+                        id = "2",
+                        start = RelationshipNodeChange(id = "1", labels = listOf("User Ext", "NewLabel"), ids = idsStart),
+                        end = RelationshipNodeChange(id = "2", labels = listOf("Product Ext", "NewLabelA"), ids = idsEnd),
+                        after = RelationshipChange(properties = mapOf("since" to 2014)),
+                        before = null,
+                        label = "HAS BOUGHT"
+                ),
+                schema = relSchema
+        )
+        val cdcQueryStrategy = SchemaIngestionStrategy()
+        val txEvents = listOf(StreamsSinkEntity(cdcDataRelationship, cdcDataRelationship))
 
-            // when
-            val relationshipEvents = cdcQueryStrategy.mergeRelationshipEvents(txEvents)
-            val relationshipDeleteEvents = cdcQueryStrategy.deleteRelationshipEvents(txEvents)
+        // when
+        val relationshipEvents = cdcQueryStrategy.mergeRelationshipEvents(txEvents)
+        val relationshipDeleteEvents = cdcQueryStrategy.deleteRelationshipEvents(txEvents)
 
-            // then
-            assertEquals(0, relationshipDeleteEvents.size)
-            assertEquals(1, relationshipEvents.size)
-            val relQuery = relationshipEvents[0].query
-            val expectedRelQuery = """
-                |${StreamsUtils.UNWIND}
-                |MERGE (start:`User Ext`{address: event.start.address})
-                |MERGE (end:`Product Ext`{code: event.end.code})
-                |MERGE (start)-[r:`HAS BOUGHT`]->(end)
-                |SET r = event.properties
-            """.trimMargin()
-            assertEquals(expectedRelQuery, relQuery.trimIndent())
-            val eventsRelList = relationshipEvents[0].events
-            assertEquals(1, eventsRelList.size)
-            val expectedRelEvents = listOf(
-                    mapOf("start" to mapOf("address" to "Baker Street"),
-                            "end" to mapOf("code" to 17294),
-                            "properties" to mapOf("since" to 2014))
-            )
-            assertEquals(expectedRelEvents, eventsRelList)
-        }
+        // then
+        assertEquals(0, relationshipDeleteEvents.size)
+        assertEquals(1, relationshipEvents.size)
+        val relQuery = relationshipEvents[0].query
+        val expectedRelQuery = """
+            |${StreamsUtils.UNWIND}
+            |MERGE (start:`User Ext`{address: event.start.address})
+            |MERGE (end:`Product Ext`{code: event.end.code})
+            |MERGE (start)-[r:`HAS BOUGHT`]->(end)
+            |SET r = event.properties
+        """.trimMargin()
+        assertEquals(expectedRelQuery, relQuery.trimIndent())
+        val eventsRelList = relationshipEvents[0].events
+        assertEquals(1, eventsRelList.size)
+        val expectedRelEvents = listOf(
+                mapOf("start" to mapOf("address" to "Baker Street"),
+                        "end" to mapOf("code" to 17294),
+                        "properties" to mapOf("since" to 2014))
+        )
+        assertEquals(expectedRelEvents, eventsRelList)
     }
 
     @Test
@@ -309,85 +304,80 @@ class SchemaIngestionStrategyTest {
         // with the same size, we take the first label in alphabetical order
         // finally, with same label name, we take the first sorted properties list alphabetically
 
-        (1..50).forEach {
-            // given
-            val constraintsList = listOf(
-                    Constraint(label = "User Ext", type = StreamsConstraintType.UNIQUE, properties = linkedSetOf("address")),
-                    Constraint(label = "User Ext", type = StreamsConstraintType.UNIQUE, properties = linkedSetOf("country")),
-                    Constraint(label = "User AAA", type = StreamsConstraintType.UNIQUE, properties = linkedSetOf("another_two")),
-                    Constraint(label = "User Ext", type = StreamsConstraintType.UNIQUE, properties = linkedSetOf("name", "surname")),
-                    Constraint(label = "User Ext", type = StreamsConstraintType.UNIQUE, properties = linkedSetOf("profession", "another_one")),
-                    Constraint(label = "Product Ext", type = StreamsConstraintType.UNIQUE, properties = linkedSetOf("code")),
-                    Constraint(label = "Product Ext", type = StreamsConstraintType.UNIQUE, properties = linkedSetOf("name"))
-            ).shuffled()
+        // given
+        val constraintsList = listOf(
+                Constraint(label = "User Ext", type = StreamsConstraintType.UNIQUE, properties = linkedSetOf("address")),
+                Constraint(label = "User Ext", type = StreamsConstraintType.UNIQUE, properties = linkedSetOf("country")),
+                Constraint(label = "User AAA", type = StreamsConstraintType.UNIQUE, properties = linkedSetOf("another_two")),
+                Constraint(label = "User Ext", type = StreamsConstraintType.UNIQUE, properties = linkedSetOf("name", "surname")),
+                Constraint(label = "User Ext", type = StreamsConstraintType.UNIQUE, properties = linkedSetOf("profession", "another_one")),
+                Constraint(label = "Product Ext", type = StreamsConstraintType.UNIQUE, properties = linkedSetOf("code")),
+                Constraint(label = "Product Ext", type = StreamsConstraintType.UNIQUE, properties = linkedSetOf("name"))
+        ).shuffled()
+        // we shuffle the constraints to ensure that the result doesn't depend from the ordering
 
-            val relSchema = Schema(properties = mapOf("since" to "Long"), constraints = constraintsList)
-            val idsStart = mutableListOf("name" to "Sherlock",
-                    "surname" to "Holmes",
-                    "country" to "UK",
-                    "profession" to "detective",
-                    "another_one" to "foo",
-                    "address" to "Baker Street",
-                    "another_two" to "Dunno")
-                    .shuffled()
-                    .toMap()
+        val relSchema = Schema(properties = mapOf("since" to "Long"), constraints = constraintsList)
+        val idsStart = mapOf("name" to "Sherlock",
+                "surname" to "Holmes",
+                "country" to "UK",
+                "profession" to "detective",
+                "another_one" to "foo",
+                "address" to "Baker Street",
+                "another_two" to "Dunno")
+        val idsEnd = mapOf("name" to "My Awesome Product", "code" to 17294)
 
-            val idsEnd = mutableListOf("name" to "My Awesome Product", "code" to 17294)
-                    .shuffled()
-                    .toMap()
-            val cdcDataRelationship = StreamsTransactionEvent(
-                    meta = Meta(timestamp = System.currentTimeMillis(),
-                            username = "user",
-                            txId = 1,
-                            txEventId = 2,
-                            txEventsCount = 3,
-                            operation = OperationType.updated
-                    ),
-                    payload = RelationshipPayload(
-                            id = "2",
-                            start = RelationshipNodeChange(id = "1", labels = listOf("User Ext", "User AAA", "NewLabel"), ids = idsStart),
-                            end = RelationshipNodeChange(id = "2", labels = listOf("Product Ext", "NewLabelA"), ids = idsEnd),
-                            after = RelationshipChange(properties = mapOf("since" to 2014)),
-                            before = null,
-                            label = "HAS BOUGHT"
-                    ),
-                    schema = relSchema
-            )
-            val cdcQueryStrategy = SchemaIngestionStrategy()
-            val txEvents = listOf(StreamsSinkEntity(cdcDataRelationship, cdcDataRelationship))
+        val cdcDataRelationship = StreamsTransactionEvent(
+                meta = Meta(timestamp = System.currentTimeMillis(),
+                        username = "user",
+                        txId = 1,
+                        txEventId = 2,
+                        txEventsCount = 3,
+                        operation = OperationType.updated
+                ),
+                payload = RelationshipPayload(
+                        id = "2",
+                        start = RelationshipNodeChange(id = "1", labels = listOf("User Ext", "User AAA", "NewLabel"), ids = idsStart),
+                        end = RelationshipNodeChange(id = "2", labels = listOf("Product Ext", "NewLabelA"), ids = idsEnd),
+                        after = RelationshipChange(properties = mapOf("since" to 2014)),
+                        before = null,
+                        label = "HAS BOUGHT"
+                ),
+                schema = relSchema
+        )
+        val cdcQueryStrategy = SchemaIngestionStrategy()
+        val txEvents = listOf(StreamsSinkEntity(cdcDataRelationship, cdcDataRelationship))
 
-            // when
-            val relationshipEvents = cdcQueryStrategy.mergeRelationshipEvents(txEvents)
-            val relationshipDeleteEvents = cdcQueryStrategy.deleteRelationshipEvents(txEvents)
+        // when
+        val relationshipEvents = cdcQueryStrategy.mergeRelationshipEvents(txEvents)
+        val relationshipDeleteEvents = cdcQueryStrategy.deleteRelationshipEvents(txEvents)
 
-            // then
-            assertEquals(0, relationshipDeleteEvents.size)
-            assertEquals(1, relationshipEvents.size)
-            val relQuery = relationshipEvents[0].query
-            val expectedRelQueryOne = """
-                |${StreamsUtils.UNWIND}
-                |MERGE (start:`User AAA`:`User Ext`{another_two: event.start.another_two})
-                |MERGE (end:`Product Ext`{code: event.end.code})
-                |MERGE (start)-[r:`HAS BOUGHT`]->(end)
-                |SET r = event.properties
-            """.trimMargin()
-            val expectedRelQueryTwo = """
-                |${StreamsUtils.UNWIND}
-                |MERGE (start:`User Ext`:`User AAA`{another_two: event.start.another_two})
-                |MERGE (end:`Product Ext`{code: event.end.code})
-                |MERGE (start)-[r:`HAS BOUGHT`]->(end)
-                |SET r = event.properties
-            """.trimMargin()
-            assertTrue { listOf(expectedRelQueryOne, expectedRelQueryTwo).contains(relQuery.trimIndent()) }
-            val eventsRelList = relationshipEvents[0].events
-            assertEquals(1, eventsRelList.size)
-            val expectedRelEvents = listOf(
-                    mapOf("start" to mapOf("another_two" to "Dunno"),
-                            "end" to mapOf("code" to 17294),
-                            "properties" to mapOf("since" to 2014))
-            )
-            assertEquals(expectedRelEvents, eventsRelList)
-        }
+        // then
+        assertEquals(0, relationshipDeleteEvents.size)
+        assertEquals(1, relationshipEvents.size)
+        val relQuery = relationshipEvents[0].query
+        val expectedRelQueryOne = """
+            |${StreamsUtils.UNWIND}
+            |MERGE (start:`User AAA`:`User Ext`{another_two: event.start.another_two})
+            |MERGE (end:`Product Ext`{code: event.end.code})
+            |MERGE (start)-[r:`HAS BOUGHT`]->(end)
+            |SET r = event.properties
+        """.trimMargin()
+        val expectedRelQueryTwo = """
+            |${StreamsUtils.UNWIND}
+            |MERGE (start:`User Ext`:`User AAA`{another_two: event.start.another_two})
+            |MERGE (end:`Product Ext`{code: event.end.code})
+            |MERGE (start)-[r:`HAS BOUGHT`]->(end)
+            |SET r = event.properties
+        """.trimMargin()
+        assertTrue { listOf(expectedRelQueryOne, expectedRelQueryTwo).contains(relQuery.trimIndent()) }
+        val eventsRelList = relationshipEvents[0].events
+        assertEquals(1, eventsRelList.size)
+        val expectedRelEvents = listOf(
+                mapOf("start" to mapOf("another_two" to "Dunno"),
+                        "end" to mapOf("code" to 17294),
+                        "properties" to mapOf("since" to 2014))
+        )
+        assertEquals(expectedRelEvents, eventsRelList)
     }
 
     @Test

--- a/common/src/test/kotlin/streams/utils/SchemaUtilsTest.kt
+++ b/common/src/test/kotlin/streams/utils/SchemaUtilsTest.kt
@@ -21,16 +21,17 @@ class SchemaUtilsTest {
     }
 
     @Test
-    fun `getNodeKeys should select (with multiple labels) on of the constraints with lowest properties and, with same size, the first in alphabetical order`() {
+    fun `getNodeKeys should select (with multiple labels) on of the constraints with lowest properties and, with same size, the first label in alphabetical order and, with same label name, the first sorted properties list alphabetically`() {
         val listNodeKeys = (1..50).map {
-            val pair1 = "LabelA" to setOf("foo", "aab")
+            val pair1 = "LabelX" to setOf("foo", "aab")
             val pair2 = "LabelB" to setOf("bar", "foo")
             val pair3 = "LabelC" to setOf("baz", "bar")
             val pair4 = "LabelB" to setOf("bar", "bez")
             val pair5 = "LabelA" to setOf("bar", "baa", "xcv")
             val pair6 = "LabelC" to setOf("aaa", "baa", "xcz")
             val pair7 = "LabelA" to setOf("foo", "aac")
-            val props = mutableListOf(pair1, pair2, pair3, pair4, pair5, pair6, pair7)
+            val pair8 = "LabelA" to setOf("foo", "aaa")
+            val props = mutableListOf(pair1, pair2, pair3, pair4, pair5, pair6, pair7, pair8)
                     .shuffled()
             val constraints = props.map {
                 Constraint(label = it.first, properties = it.second, type = StreamsConstraintType.UNIQUE)
@@ -39,11 +40,11 @@ class SchemaUtilsTest {
         }
         val setNodeKeys = listNodeKeys.toSet()
         assertEquals(1, setNodeKeys.size)
-        assertEquals(setOf("aab", "foo"), setNodeKeys.first())
+        assertEquals(setOf("aaa", "foo"), setNodeKeys.first())
     }
 
     @Test
-    fun `getNodeKeys should select (with one label) on of the constraints with lowest properties and, with same size, the first in alphabetical order`() {
+    fun `getNodeKeys should select (with one label) on of the constraints with lowest properties and, with same size and the same label name, the first sorted properties list alphabetically`() {
         val listNodeKeys = (1..50).map {
             val pair1 = "LabelA" to setOf("foo", "bar")
             val pair2 = "LabelA" to setOf("bar", "foo")

--- a/common/src/test/kotlin/streams/utils/SchemaUtilsTest.kt
+++ b/common/src/test/kotlin/streams/utils/SchemaUtilsTest.kt
@@ -34,18 +34,18 @@ class SchemaUtilsTest {
         val pair6 = "LabelC" to setOf("aaa", "baa", "xcz")
         val pair7 = "LabelA" to setOf("foo", "aac")
         val pair8 = "LabelA" to setOf("foo", "aab")
-        val props = mutableListOf(pair1, pair2, pair3, pair4, pair5, pair6, pair7, pair8)
+        val props = listOf(pair1, pair2, pair3, pair4, pair5, pair6, pair7, pair8)
 
+        // we shuffle the constraints to ensure that the result doesn't depend from the ordering
         val constraints = props.map {
             Constraint(label = it.first, properties = it.second, type = StreamsConstraintType.UNIQUE)
         }.shuffled()
-        // we shuffle the constraints to ensure that the result doesn't depend from the ordering
 
         val propertyKeys = setOf("prop", "prop2", "foo", "bar", "baz", "bez", "aaa", "aab", "baa", "aac", "xcz", "xcv")
-        val actualKey = getNodeKeys(props.map { it.first }, propertyKeys, constraints)
-        val expectedKey = setOf("aab", "foo")
+        val actualKeys = getNodeKeys(props.map { it.first }, propertyKeys, constraints)
+        val expectedKeys = setOf("aab", "foo")
 
-        assertEquals(expectedKey, actualKey)
+        assertEquals(expectedKeys, actualKeys)
     }
 
     @Test
@@ -57,18 +57,18 @@ class SchemaUtilsTest {
         val pair2 = "LabelA" to setOf("bar", "foo")
         val pair3 = "LabelA" to setOf("baz", "bar")
         val pair4 = "LabelA" to setOf("bar", "bez")
-        val props = mutableListOf(pair1, pair2, pair3, pair4)
+        val props = listOf(pair1, pair2, pair3, pair4)
 
+        // we shuffle the constraints to ensure that the result doesn't depend from the ordering
         val constraints = props.map {
             Constraint(label = it.first, properties = it.second, type = StreamsConstraintType.UNIQUE)
         }.shuffled()
-        // we shuffle the constraints to ensure that the result doesn't depend from the ordering
 
         val propertyKeys = setOf("prop", "foo", "bar", "baz", "bez")
-        val actualKey =  getNodeKeys(listOf("LabelA"), propertyKeys, constraints)
-        val expectedKey = setOf("bar", "baz")
+        val actualKeys =  getNodeKeys(listOf("LabelA"), propertyKeys, constraints)
+        val expectedKeys = setOf("bar", "baz")
 
-        assertEquals(expectedKey, actualKey)
+        assertEquals(expectedKeys, actualKeys)
     }
 
     @Test

--- a/common/src/test/kotlin/streams/utils/SchemaUtilsTest.kt
+++ b/common/src/test/kotlin/streams/utils/SchemaUtilsTest.kt
@@ -23,23 +23,23 @@ class SchemaUtilsTest {
     @Test
     fun `getNodeKeys should select (with multiple labels) on of the constraints with lowest properties and, with same size, the first in alphabetical order`() {
         val listNodeKeys = (1..50).map {
-            val pair1 = "LabelA" to setOf("foo", "aaa")
+            val pair1 = "LabelA" to setOf("foo", "aab")
             val pair2 = "LabelB" to setOf("bar", "foo")
             val pair3 = "LabelC" to setOf("baz", "bar")
             val pair4 = "LabelB" to setOf("bar", "bez")
             val pair5 = "LabelA" to setOf("bar", "baa", "xcv")
-            val pair6 = "LabelC" to setOf("baa", "baa", "xcz")
-            val pair7 = "LabelA" to setOf("foo", "aab")
+            val pair6 = "LabelC" to setOf("aaa", "baa", "xcz")
+            val pair7 = "LabelA" to setOf("foo", "aac")
             val props = mutableListOf(pair1, pair2, pair3, pair4, pair5, pair6, pair7)
                     .shuffled()
             val constraints = props.map {
                 Constraint(label = it.first, properties = it.second, type = StreamsConstraintType.UNIQUE)
             }.shuffled()
-            getNodeKeys(props.map { it.first }.shuffled(), setOf("prop", "foo", "bar", "baz", "bez", "aaa", "xcz", "xcv").shuffled().toSet(), constraints)
+            getNodeKeys(props.map { it.first }.shuffled(), setOf("prop", "prop2", "foo", "bar", "baz", "bez", "aaa", "aab", "baa", "aac", "xcz", "xcv").shuffled().toSet(), constraints)
         }
         val setNodeKeys = listNodeKeys.toSet()
         assertEquals(1, setNodeKeys.size)
-        assertEquals(setOf("aaa", "foo"), setNodeKeys.first())
+        assertEquals(setOf("aab", "foo"), setNodeKeys.first())
     }
 
     @Test

--- a/common/src/test/kotlin/streams/utils/SchemaUtilsTest.kt
+++ b/common/src/test/kotlin/streams/utils/SchemaUtilsTest.kt
@@ -21,6 +21,47 @@ class SchemaUtilsTest {
     }
 
     @Test
+    fun `getNodeKeys should select (with multiple labels) on of the constraints with lowest properties and, with same size, the first in alphabetical order`() {
+        val listNodeKeys = (1..50).map {
+            val pair1 = "LabelA" to setOf("foo", "aaa")
+            val pair2 = "LabelB" to setOf("bar", "foo")
+            val pair3 = "LabelC" to setOf("baz", "bar")
+            val pair4 = "LabelB" to setOf("bar", "bez")
+            val pair5 = "LabelA" to setOf("bar", "baa", "xcv")
+            val pair6 = "LabelC" to setOf("baa", "baa", "xcz")
+            val pair7 = "LabelA" to setOf("foo", "aab")
+            val props = mutableListOf(pair1, pair2, pair3, pair4, pair5, pair6, pair7)
+                    .shuffled()
+            val constraints = props.map {
+                Constraint(label = it.first, properties = it.second, type = StreamsConstraintType.UNIQUE)
+            }.shuffled()
+            getNodeKeys(props.map { it.first }.shuffled(), setOf("prop", "foo", "bar", "baz", "bez", "aaa", "xcz", "xcv").shuffled().toSet(), constraints)
+        }
+        val setNodeKeys = listNodeKeys.toSet()
+        assertEquals(1, setNodeKeys.size)
+        assertEquals(setOf("aaa", "foo"), setNodeKeys.first())
+    }
+
+    @Test
+    fun `getNodeKeys should select (with one label) on of the constraints with lowest properties and, with same size, the first in alphabetical order`() {
+        val listNodeKeys = (1..50).map {
+            val pair1 = "LabelA" to setOf("foo", "bar")
+            val pair2 = "LabelA" to setOf("bar", "foo")
+            val pair3 = "LabelA" to setOf("baz", "bar")
+            val pair4 = "LabelA" to setOf("bar", "bez")
+            val props = mutableListOf(pair1, pair2, pair3, pair4)
+                    .shuffled()
+            val constraints = props.map {
+                Constraint(label = it.first, properties = it.second, type = StreamsConstraintType.UNIQUE)
+            }.shuffled()
+            getNodeKeys(listOf("LabelA"), setOf("prop", "foo", "bar", "baz", "bez").shuffled().toSet(), constraints)
+        }
+        val setNodeKeys = listNodeKeys.toSet()
+        assertEquals(1, setNodeKeys.size)
+        assertEquals(setOf("bar", "baz"), setNodeKeys.first())
+    }
+
+    @Test
     fun `getNodeKeys should return empty in case it didn't match anything`() {
         val props = mapOf("LabelA" to setOf("foo", "bar"),
                 "LabelB" to setOf("foo", "bar", "fooBar"),

--- a/common/src/test/kotlin/streams/utils/SchemaUtilsTest.kt
+++ b/common/src/test/kotlin/streams/utils/SchemaUtilsTest.kt
@@ -21,7 +21,10 @@ class SchemaUtilsTest {
     }
 
     @Test
-    fun `getNodeKeys should select (with multiple labels) on of the constraints with lowest properties and, with same size, the first label in alphabetical order and, with same label name, the first sorted properties list alphabetically`() {
+    fun `getNodeKeys should return the key sorted properly`() {
+        // the method getNodeKeys should select (with multiple labels) the constraint with lowest properties
+        // with the same size, we take the first label in alphabetical order
+        // finally, with same label name, we take the first sorted properties list alphabetically
         val listNodeKeys = (1..50).map {
             val pair1 = "LabelX" to setOf("foo", "aab")
             val pair2 = "LabelB" to setOf("bar", "foo")
@@ -44,7 +47,10 @@ class SchemaUtilsTest {
     }
 
     @Test
-    fun `getNodeKeys should select (with one label) on of the constraints with lowest properties and, with same size and the same label name, the first sorted properties list alphabetically`() {
+    fun `getNodeKeys should return the key sorted properly (with one label)`() {
+        // the method getNodeKeys should select the constraint with lowest properties
+        // with the same size, we take the first sorted properties list alphabetically
+
         val listNodeKeys = (1..50).map {
             val pair1 = "LabelA" to setOf("foo", "bar")
             val pair2 = "LabelA" to setOf("bar", "foo")

--- a/common/src/test/kotlin/streams/utils/SchemaUtilsTest.kt
+++ b/common/src/test/kotlin/streams/utils/SchemaUtilsTest.kt
@@ -25,25 +25,27 @@ class SchemaUtilsTest {
         // the method getNodeKeys should select (with multiple labels) the constraint with lowest properties
         // with the same size, we take the first label in alphabetical order
         // finally, with same label name, we take the first sorted properties list alphabetically
-        val listNodeKeys = (1..50).map {
-            val pair1 = "LabelX" to setOf("foo", "aab")
-            val pair2 = "LabelB" to setOf("bar", "foo")
-            val pair3 = "LabelC" to setOf("baz", "bar")
-            val pair4 = "LabelB" to setOf("bar", "bez")
-            val pair5 = "LabelA" to setOf("bar", "baa", "xcv")
-            val pair6 = "LabelC" to setOf("aaa", "baa", "xcz")
-            val pair7 = "LabelA" to setOf("foo", "aac")
-            val pair8 = "LabelA" to setOf("foo", "aaa")
-            val props = mutableListOf(pair1, pair2, pair3, pair4, pair5, pair6, pair7, pair8)
-                    .shuffled()
-            val constraints = props.map {
-                Constraint(label = it.first, properties = it.second, type = StreamsConstraintType.UNIQUE)
-            }.shuffled()
-            getNodeKeys(props.map { it.first }.shuffled(), setOf("prop", "prop2", "foo", "bar", "baz", "bez", "aaa", "aab", "baa", "aac", "xcz", "xcv").shuffled().toSet(), constraints)
-        }
-        val setNodeKeys = listNodeKeys.toSet()
-        assertEquals(1, setNodeKeys.size)
-        assertEquals(setOf("aaa", "foo"), setNodeKeys.first())
+
+        val pair1 = "LabelX" to setOf("foo", "aaa")
+        val pair2 = "LabelB" to setOf("bar", "foo")
+        val pair3 = "LabelC" to setOf("baz", "bar")
+        val pair4 = "LabelB" to setOf("bar", "bez")
+        val pair5 = "LabelA" to setOf("bar", "baa", "xcv")
+        val pair6 = "LabelC" to setOf("aaa", "baa", "xcz")
+        val pair7 = "LabelA" to setOf("foo", "aac")
+        val pair8 = "LabelA" to setOf("foo", "aab")
+        val props = mutableListOf(pair1, pair2, pair3, pair4, pair5, pair6, pair7, pair8)
+
+        val constraints = props.map {
+            Constraint(label = it.first, properties = it.second, type = StreamsConstraintType.UNIQUE)
+        }.shuffled()
+        // we shuffle the constraints to ensure that the result doesn't depend from the ordering
+
+        val propertyKeys = setOf("prop", "prop2", "foo", "bar", "baz", "bez", "aaa", "aab", "baa", "aac", "xcz", "xcv")
+        val actualKey = getNodeKeys(props.map { it.first }, propertyKeys, constraints)
+        val expectedKey = setOf("aab", "foo")
+
+        assertEquals(expectedKey, actualKey)
     }
 
     @Test
@@ -51,21 +53,22 @@ class SchemaUtilsTest {
         // the method getNodeKeys should select the constraint with lowest properties
         // with the same size, we take the first sorted properties list alphabetically
 
-        val listNodeKeys = (1..50).map {
-            val pair1 = "LabelA" to setOf("foo", "bar")
-            val pair2 = "LabelA" to setOf("bar", "foo")
-            val pair3 = "LabelA" to setOf("baz", "bar")
-            val pair4 = "LabelA" to setOf("bar", "bez")
-            val props = mutableListOf(pair1, pair2, pair3, pair4)
-                    .shuffled()
-            val constraints = props.map {
-                Constraint(label = it.first, properties = it.second, type = StreamsConstraintType.UNIQUE)
-            }.shuffled()
-            getNodeKeys(listOf("LabelA"), setOf("prop", "foo", "bar", "baz", "bez").shuffled().toSet(), constraints)
-        }
-        val setNodeKeys = listNodeKeys.toSet()
-        assertEquals(1, setNodeKeys.size)
-        assertEquals(setOf("bar", "baz"), setNodeKeys.first())
+        val pair1 = "LabelA" to setOf("foo", "bar")
+        val pair2 = "LabelA" to setOf("bar", "foo")
+        val pair3 = "LabelA" to setOf("baz", "bar")
+        val pair4 = "LabelA" to setOf("bar", "bez")
+        val props = mutableListOf(pair1, pair2, pair3, pair4)
+
+        val constraints = props.map {
+            Constraint(label = it.first, properties = it.second, type = StreamsConstraintType.UNIQUE)
+        }.shuffled()
+        // we shuffle the constraints to ensure that the result doesn't depend from the ordering
+
+        val propertyKeys = setOf("prop", "foo", "bar", "baz", "bez")
+        val actualKey =  getNodeKeys(listOf("LabelA"), propertyKeys, constraints)
+        val expectedKey = setOf("bar", "baz")
+
+        assertEquals(expectedKey, actualKey)
     }
 
     @Test

--- a/consumer/src/test/kotlin/integrations/kafka/KafkaEventSinkCDCTSE.kt
+++ b/consumer/src/test/kotlin/integrations/kafka/KafkaEventSinkCDCTSE.kt
@@ -176,7 +176,7 @@ class KafkaEventSinkCDCTSE: KafkaEventSinkBaseTSE() {
     }
 
     @Test
-    fun shouldWriteDataFromSinkWithCDCSchemaTopicWithMultipleConstraintsAndMultipleLabelNames() = runBlocking {
+    fun writeDataFromSinkWithCDCSchemaTopicMultipleConstraintsAndLabels() = runBlocking {
         val topic = UUID.randomUUID().toString()
         db.setConfig("streams.sink.topic.cdc.schema", topic)
         db.start()

--- a/consumer/src/test/kotlin/integrations/kafka/KafkaEventSinkCDCTSE.kt
+++ b/consumer/src/test/kotlin/integrations/kafka/KafkaEventSinkCDCTSE.kt
@@ -176,7 +176,7 @@ class KafkaEventSinkCDCTSE: KafkaEventSinkBaseTSE() {
     }
 
     @Test
-    fun shouldWriteDataFromSinkWithCDCSchemaTopicWithMultipleConstraints() = runBlocking {
+    fun shouldWriteDataFromSinkWithCDCSchemaTopicWithMultipleConstraintsAndMultipleLabelNames() = runBlocking {
         val topic = UUID.randomUUID().toString()
         db.setConfig("streams.sink.topic.cdc.schema", topic)
         db.start()
@@ -190,7 +190,7 @@ class KafkaEventSinkCDCTSE: KafkaEventSinkBaseTSE() {
                 Constraint(label = "Writer", type = StreamsConstraintType.UNIQUE, properties = setOf("lastName")),
                 Constraint(label = "Writer", type = StreamsConstraintType.UNIQUE, properties = setOf("firstName")),
         )
-        val relSchema = Schema(properties = mapOf("since" to "Long"), constraints = constraintsCharacter.plus(constraintsWriter) )
+        val relSchema = Schema(properties = mapOf("since" to "Long"), constraints = constraintsCharacter.plus(constraintsWriter))
         val nodeSchemaCharacter = Schema(properties = mapOf("name" to "String", "surname" to "String", "country" to "String", "address" to "String"), constraints = constraintsCharacter)
         val nodeSchemaWriter = Schema(properties = mapOf("firstName" to "String", "lastName" to "String"), constraints = constraintsWriter)
         val cdcDataStart = StreamsTransactionEvent(
@@ -231,7 +231,7 @@ class KafkaEventSinkCDCTSE: KafkaEventSinkBaseTSE() {
                 ),
                 payload = RelationshipPayload(
                         id = "2",
-                        // leverage on first ids alphabetically, that is name, so we take the 2 previously created nodes
+                        // leverage on first label alphabetically and, with the same name, the first ids alphabetically, that is name, so we take the 2 previously created nodes
                         start = RelationshipNodeChange(id = "0", labels = listOf("Character"),
                                 ids = mapOf("name" to "Naruto", "surname" to "Osvaldo", "address" to "Land of Sand")),
                         end = RelationshipNodeChange(id = "1", labels = listOf("Writer"),
@@ -291,6 +291,128 @@ class KafkaEventSinkCDCTSE: KafkaEventSinkBaseTSE() {
         Assert.assertEventually(ThrowingSupplier {
             val query = """
                 |MATCH p = (s:Character)-[r:`HAS WRITTEN`{since:2000}]->(e:Writer)
+                |RETURN count(p) AS count
+                |""".trimMargin()
+            db.execute(query) {
+                val result = it.columnAs<Long>("count")
+                result.hasNext() && result.next() == 1L && !result.hasNext()
+            }
+        }, Matchers.equalTo(true), 30, TimeUnit.SECONDS)
+
+        // create another node
+        countNodes = db.execute(cypherCountNodes) { it.columnAs<Long>("count").next() }
+        assertEquals(4L, countNodes)
+    }
+
+    @Test
+    fun shouldWriteDataFromSinkWithCDCSchemaTopicWithMultipleConstraints() = runBlocking {
+        val topic = UUID.randomUUID().toString()
+        db.setConfig("streams.sink.topic.cdc.schema", topic)
+        db.start()
+
+        val constraints = listOf(
+                Constraint(label = "User", type = StreamsConstraintType.UNIQUE, properties = setOf("name")),
+                Constraint(label = "User", type = StreamsConstraintType.UNIQUE, properties = setOf("country", "address")),
+                Constraint(label = "User", type = StreamsConstraintType.UNIQUE, properties = setOf("surname")),
+        )
+        val relSchema = Schema(properties = mapOf("since" to "Long"), constraints = constraints)
+        val nodeSchema = Schema(properties = mapOf("name" to "String", "surname" to "String", "country" to "String", "address" to "String"), constraints = constraints)
+        val cdcDataStart = StreamsTransactionEvent(
+                meta = Meta(timestamp = System.currentTimeMillis(),
+                        username = "user",
+                        txId = 1,
+                        txEventId = 0,
+                        txEventsCount = 3,
+                        operation = OperationType.created
+                ),
+                payload = NodePayload(id = "0",
+                        before = null,
+                        after = NodeChange(properties = mapOf("name" to "Naruto", "surname" to "Uzumaki", "country" to "Japan", "address" to "Land of Leaf"), labels = listOf("User"))
+                ),
+                schema = nodeSchema
+        )
+        val cdcDataEnd = StreamsTransactionEvent(
+                meta = Meta(timestamp = System.currentTimeMillis(),
+                        username = "user",
+                        txId = 1,
+                        txEventId = 1,
+                        txEventsCount = 3,
+                        operation = OperationType.created
+                ),
+                payload = NodePayload(id = "1",
+                        before = null,
+                        after = NodeChange(properties = mapOf("name" to "Minato", "surname" to "Namikaze", "country" to "Japan", "address" to "Land of Leaf"), labels = listOf("User"))
+                ),
+                schema = nodeSchema
+        )
+        val cdcDataRelationship = StreamsTransactionEvent(
+                meta = Meta(timestamp = System.currentTimeMillis(),
+                        username = "user",
+                        txId = 1,
+                        txEventId = 2,
+                        txEventsCount = 3,
+                        operation = OperationType.created
+                ),
+                payload = RelationshipPayload(
+                        id = "2",
+                        // leverage on first ids alphabetically, that is name, so we take the 2 previously created nodes
+                        start = RelationshipNodeChange(id = "99", labels = listOf("User"), ids = mapOf("name" to "Naruto", "surname" to "Osvaldo", "address" to "Land of Sand")),
+                        end = RelationshipNodeChange(id = "88", labels = listOf("User"), ids = mapOf("name" to "Minato", "surname" to "Franco", "address" to "Land of Fire")),
+                        after = RelationshipChange(properties = mapOf("since" to 2014)),
+                        before = null,
+                        label = "KNOWS WHO"
+                ),
+                schema = relSchema
+        )
+        var producerRecord = ProducerRecord(topic, UUID.randomUUID().toString(), JSONUtils.writeValueAsBytes(cdcDataStart))
+        kafkaProducer.send(producerRecord).get()
+        producerRecord = ProducerRecord(topic, UUID.randomUUID().toString(), JSONUtils.writeValueAsBytes(cdcDataEnd))
+        kafkaProducer.send(producerRecord).get()
+        producerRecord = ProducerRecord(topic, UUID.randomUUID().toString(), JSONUtils.writeValueAsBytes(cdcDataRelationship))
+        kafkaProducer.send(producerRecord).get()
+
+        Assert.assertEventually(ThrowingSupplier {
+            val query = """
+                |MATCH p = (s:User)-[r:`KNOWS WHO` {since: 2014}]->(e:User)
+                |RETURN count(p) AS count
+                |""".trimMargin()
+            db.execute(query) {
+                val result = it.columnAs<Long>("count")
+                result.hasNext() && result.next() == 1L && !result.hasNext()
+            }
+        }, Matchers.equalTo(true), 30, TimeUnit.SECONDS)
+
+        val cypherCountNodes = "MATCH (n) RETURN count(n) AS count"
+        var countNodes = db.execute(cypherCountNodes) { it.columnAs<Long>("count").next() }
+        assertEquals(2L, countNodes)
+
+        // another CDC data, not matching the previously created nodes
+        val cdcDataRelationshipNotMatched = StreamsTransactionEvent(
+                meta = Meta(timestamp = System.currentTimeMillis(),
+                        username = "user",
+                        txId = 1,
+                        txEventId = 2,
+                        txEventsCount = 3,
+                        operation = OperationType.created
+                ),
+                payload = RelationshipPayload(
+                        id = "2",
+                        // leverage on first ids alphabetically, that is name, so create 2 additional nodes
+                        start = RelationshipNodeChange(id = "1", labels = listOf("User"), ids = mapOf("name" to "Invalid", "surname" to "Uzumaki")),
+                        end = RelationshipNodeChange(id = "2", labels = listOf("User"), ids = mapOf("name" to "AnotherInvalid", "surname" to "Namikaze")),
+                        after = RelationshipChange(properties = mapOf("since" to 2000)),
+                        before = null,
+                        label = "KNOWS ANOTHER"
+                ),
+                schema = relSchema
+        )
+
+        producerRecord = ProducerRecord(topic, UUID.randomUUID().toString(), JSONUtils.writeValueAsBytes(cdcDataRelationshipNotMatched))
+        kafkaProducer.send(producerRecord).get()
+
+        Assert.assertEventually(ThrowingSupplier {
+            val query = """
+                |MATCH p = (s:User)-[r:`KNOWS ANOTHER` {since:2000}]->(e:User)
                 |RETURN count(p) AS count
                 |""".trimMargin()
             db.execute(query) {

--- a/consumer/src/test/kotlin/integrations/kafka/KafkaEventSinkCDCTSE.kt
+++ b/consumer/src/test/kotlin/integrations/kafka/KafkaEventSinkCDCTSE.kt
@@ -23,6 +23,7 @@ import streams.setConfig
 import streams.start
 import java.util.UUID
 import java.util.concurrent.TimeUnit
+import kotlin.test.assertEquals
 
 class KafkaEventSinkCDCTSE: KafkaEventSinkBaseTSE() {
 
@@ -172,6 +173,135 @@ class KafkaEventSinkCDCTSE: KafkaEventSinkBaseTSE() {
                 result.hasNext() && result.next() == 1L && !result.hasNext()
             }
         }, Matchers.equalTo(true), 30, TimeUnit.SECONDS)
+    }
+
+    @Test
+    fun shouldWriteDataFromSinkWithCDCSchemaTopicWithMultipleConstraints() = runBlocking {
+        val topic = UUID.randomUUID().toString()
+        db.setConfig("streams.sink.topic.cdc.schema", topic)
+        db.start()
+
+        val constraintsCharacter = listOf(
+                Constraint(label = "Character", type = StreamsConstraintType.UNIQUE, properties = setOf("surname")),
+                Constraint(label = "Character", type = StreamsConstraintType.UNIQUE, properties = setOf("name")),
+                Constraint(label = "Character", type = StreamsConstraintType.UNIQUE, properties = setOf("country", "address")),
+        )
+        val constraintsWriter = listOf(
+                Constraint(label = "Writer", type = StreamsConstraintType.UNIQUE, properties = setOf("lastName")),
+                Constraint(label = "Writer", type = StreamsConstraintType.UNIQUE, properties = setOf("firstName")),
+        )
+        val relSchema = Schema(properties = mapOf("since" to "Long"), constraints = constraintsCharacter.plus(constraintsWriter) )
+        val nodeSchemaCharacter = Schema(properties = mapOf("name" to "String", "surname" to "String", "country" to "String", "address" to "String"), constraints = constraintsCharacter)
+        val nodeSchemaWriter = Schema(properties = mapOf("firstName" to "String", "lastName" to "String"), constraints = constraintsWriter)
+        val cdcDataStart = StreamsTransactionEvent(
+                meta = Meta(timestamp = System.currentTimeMillis(),
+                        username = "user",
+                        txId = 1,
+                        txEventId = 0,
+                        txEventsCount = 3,
+                        operation = OperationType.created
+                ),
+                payload = NodePayload(id = "0",
+                        before = null,
+                        after = NodeChange(properties = mapOf("name" to "Naruto", "surname" to "Uzumaki", "country" to "Japan", "address" to "Land of Leaf"), labels = listOf("Character"))
+                ),
+                schema = nodeSchemaCharacter
+        )
+        val cdcDataEnd = StreamsTransactionEvent(
+                meta = Meta(timestamp = System.currentTimeMillis(),
+                        username = "user",
+                        txId = 1,
+                        txEventId = 1,
+                        txEventsCount = 3,
+                        operation = OperationType.created
+                ),
+                payload = NodePayload(id = "1",
+                        before = null,
+                        after = NodeChange(properties = mapOf("firstName" to "Masashi", "lastName" to "Kishimoto", "address" to "Dunno"), labels = listOf("Writer"))
+                ),
+                schema = nodeSchemaWriter
+        )
+        val cdcDataRelationship = StreamsTransactionEvent(
+                meta = Meta(timestamp = System.currentTimeMillis(),
+                        username = "user",
+                        txId = 1,
+                        txEventId = 2,
+                        txEventsCount = 3,
+                        operation = OperationType.created
+                ),
+                payload = RelationshipPayload(
+                        id = "2",
+                        // leverage on first ids alphabetically, that is name, so we take the 2 previously created nodes
+                        start = RelationshipNodeChange(id = "0", labels = listOf("Character"),
+                                ids = mapOf("name" to "Naruto", "surname" to "Osvaldo", "address" to "Land of Sand")),
+                        end = RelationshipNodeChange(id = "1", labels = listOf("Writer"),
+                                ids = mapOf("firstName" to "Masashi", "lastName" to "Franco")),
+                        after = RelationshipChange(properties = mapOf("since" to 1999)),
+                        before = null,
+                        label = "HAS WRITTEN"
+                ),
+                schema = relSchema
+        )
+        var producerRecord = ProducerRecord(topic, UUID.randomUUID().toString(), JSONUtils.writeValueAsBytes(cdcDataStart))
+        kafkaProducer.send(producerRecord).get()
+        producerRecord = ProducerRecord(topic, UUID.randomUUID().toString(), JSONUtils.writeValueAsBytes(cdcDataEnd))
+        kafkaProducer.send(producerRecord).get()
+        producerRecord = ProducerRecord(topic, UUID.randomUUID().toString(), JSONUtils.writeValueAsBytes(cdcDataRelationship))
+        kafkaProducer.send(producerRecord).get()
+
+        Assert.assertEventually(ThrowingSupplier {
+            val query = """
+                |MATCH p = (s:Character)-[r:`HAS WRITTEN`{since: 1999}]->(e:Writer)
+                |RETURN count(p) AS count
+                |""".trimMargin()
+            db.execute(query) {
+                val result = it.columnAs<Long>("count")
+                result.hasNext() && result.next() == 1L && !result.hasNext()
+            }
+        }, Matchers.equalTo(true), 30, TimeUnit.SECONDS)
+
+        val cypherCountNodes = "MATCH (n) RETURN count(n) AS count"
+        var countNodes = db.execute(cypherCountNodes) { it.columnAs<Long>("count").next() }
+        assertEquals(2L, countNodes)
+
+        // another CDC data, not matching the previously created nodes
+        val cdcDataRelationshipNotMatched = StreamsTransactionEvent(
+                meta = Meta(timestamp = System.currentTimeMillis(),
+                        username = "user",
+                        txId = 1,
+                        txEventId = 2,
+                        txEventsCount = 3,
+                        operation = OperationType.created
+                ),
+                payload = RelationshipPayload(
+                        id = "2",
+                        // leverage on first ids alphabetically, that is name, so create 2 additional nodes
+                        start = RelationshipNodeChange(id = "1", labels = listOf("Character"), ids = mapOf("name" to "Invalid", "surname" to "Uzumaki")),
+                        end = RelationshipNodeChange(id = "2", labels = listOf("Writer"), ids = mapOf("firstName" to "AnotherInvalid", "surname" to "Namikaze")),
+                        after = RelationshipChange(properties = mapOf("since" to 2000)),
+                        before = null,
+                        label = "HAS WRITTEN"
+                ),
+                schema = relSchema
+        )
+
+        producerRecord = ProducerRecord(topic, UUID.randomUUID().toString(), JSONUtils.writeValueAsBytes(cdcDataRelationshipNotMatched))
+        kafkaProducer.send(producerRecord).get()
+
+        Assert.assertEventually(ThrowingSupplier {
+            val query = """
+                |MATCH p = (s:Character)-[r:`HAS WRITTEN`{since:2000}]->(e:Writer)
+                |RETURN count(p) AS count
+                |""".trimMargin()
+            db.execute(query) {
+                val result = it.columnAs<Long>("count")
+                result.hasNext() && result.next() == 1L && !result.hasNext()
+            }
+        }, Matchers.equalTo(true), 30, TimeUnit.SECONDS)
+
+        // create another node
+        countNodes = db.execute(cypherCountNodes) { it.columnAs<Long>("count").next() }
+        assertEquals(4L, countNodes)
     }
 
     @Test

--- a/kafka-connect-neo4j/src/test/kotlin/streams/kafka/connect/sink/Neo4jSinkTaskTest.kt
+++ b/kafka-connect-neo4j/src/test/kotlin/streams/kafka/connect/sink/Neo4jSinkTaskTest.kt
@@ -372,6 +372,197 @@ class Neo4jSinkTaskTest {
     }
 
     @Test
+    fun `should insert data into Neo4j from CDC events with schema strategy and multiple uniqueness constraints merging previous nodes`() {
+        val myTopic = UUID.randomUUID().toString()
+        val props = mapOf(Neo4jSinkConnectorConfig.SERVER_URI to db.boltURI().toString(),
+                Neo4jSinkConnectorConfig.TOPIC_CDC_SCHEMA to myTopic,
+                Neo4jSinkConnectorConfig.AUTHENTICATION_TYPE to AuthenticationType.NONE.toString(),
+                SinkTask.TOPICS_CONFIG to myTopic)
+
+        val constraints = listOf(
+                Constraint(label = "User", type = StreamsConstraintType.UNIQUE, properties = setOf("name")),
+                Constraint(label = "User", type = StreamsConstraintType.UNIQUE, properties = setOf("country", "address")),
+                Constraint(label = "User", type = StreamsConstraintType.UNIQUE, properties = setOf("surname")),
+        )
+        val relSchema = Schema(properties = mapOf("since" to "Long"), constraints = constraints)
+        val nodeSchema = Schema(properties = mapOf("name" to "String", "surname" to "String", "country" to "String", "address" to "String"),
+                constraints = constraints)
+        val cdcDataStart = StreamsTransactionEvent(
+                meta = Meta(timestamp = System.currentTimeMillis(),
+                        username = "user",
+                        txId = 1,
+                        txEventId = 0,
+                        txEventsCount = 3,
+                        operation = OperationType.created
+                ),
+                payload = NodePayload(id = "0",
+                        before = null,
+                        after = NodeChange(properties = mapOf("name" to "Naruto", "surname" to "Uzumaki", "country" to "Japan", "address" to "Land of Leaf"), labels = listOf("User"))
+                ),
+                schema = nodeSchema
+        )
+        val cdcDataEnd = StreamsTransactionEvent(
+                meta = Meta(timestamp = System.currentTimeMillis(),
+                        username = "user",
+                        txId = 1,
+                        txEventId = 1,
+                        txEventsCount = 3,
+                        operation = OperationType.created
+                ),
+                payload = NodePayload(id = "1",
+                        before = null,
+                        after = NodeChange(properties = mapOf("name" to "Minato", "surname" to "Namikaze", "country" to "Japan", "address" to "Land of Leaf"), labels = listOf("User"))
+                ),
+                schema = nodeSchema
+        )
+        val cdcDataRelationship = StreamsTransactionEvent(
+                meta = Meta(timestamp = System.currentTimeMillis(),
+                        username = "user",
+                        txId = 1,
+                        txEventId = 2,
+                        txEventsCount = 3,
+                        operation = OperationType.created
+                ),
+                payload = RelationshipPayload(
+                        id = "2",
+                        // leverage on first ids alphabetically, that is name, so we take the 2 previously created nodes
+                        start = RelationshipNodeChange(id = "99", labels = listOf("User"), ids = mapOf("name" to "Naruto", "surname" to "Osvaldo", "address" to "Land of Sand")),
+                        end = RelationshipNodeChange(id = "88", labels = listOf("User"), ids = mapOf("name" to "Minato", "surname" to "Franco", "address" to "Land of Fire")),
+                        after = RelationshipChange(properties = mapOf("since" to 2014)),
+                        before = null,
+                        label = "KNOWS WHO"
+                ),
+                schema = relSchema
+        )
+
+        val task = Neo4jSinkTask()
+        task.initialize(mock(SinkTaskContext::class.java))
+        task.start(props)
+        val input = listOf(SinkRecord(myTopic, 1, null, null, null, cdcDataStart, 42),
+                SinkRecord(myTopic, 1, null, null, null, cdcDataEnd, 43),
+                SinkRecord(myTopic, 1, null, null, null, cdcDataRelationship, 44))
+
+        task.put(input)
+
+        db.defaultDatabaseService().beginTx().use {
+            val query = """
+                |MATCH p = (s:User)-[r:`KNOWS WHO` {since: 2014}]->(e:User)
+                |RETURN count(p) as count
+                |""".trimMargin()
+            it.execute(query)
+                    .columnAs<Long>("count").use {
+                        assertTrue { it.hasNext() }
+                        val path = it.next()
+                        assertEquals(1, path)
+                        assertFalse { it.hasNext() }
+                    }
+
+            val labels = db.defaultDatabaseService().beginTx()
+                    .use { StreamSupport.stream(it.allLabels.spliterator(), false).map { it.name() }.collect(Collectors.toSet()) }
+            assertEquals(setOf("User"), labels)
+
+            val countUsers = db.defaultDatabaseService().beginTx().use { it.findNodes(Label.label("User")).stream().count() }
+            assertEquals(2L, countUsers)
+        }
+    }
+
+    @Test
+    fun `should insert data into Neo4j from CDC events with schema strategy and multiple uniqueness constraints`() {
+        val myTopic = UUID.randomUUID().toString()
+        val props = mapOf(Neo4jSinkConnectorConfig.SERVER_URI to db.boltURI().toString(),
+                Neo4jSinkConnectorConfig.TOPIC_CDC_SCHEMA to myTopic,
+                Neo4jSinkConnectorConfig.AUTHENTICATION_TYPE to AuthenticationType.NONE.toString(),
+                SinkTask.TOPICS_CONFIG to myTopic)
+
+        val constraints = listOf(
+                Constraint(label = "User", type = StreamsConstraintType.UNIQUE, properties = setOf("name")),
+                Constraint(label = "User", type = StreamsConstraintType.UNIQUE, properties = setOf("surname")),
+                Constraint(label = "User", type = StreamsConstraintType.UNIQUE, properties = setOf("country", "address")),
+        )
+        val relSchema = Schema(properties = mapOf("since" to "Long"), constraints = constraints)
+        val nodeSchema = Schema(properties = mapOf("name" to "String", "surname" to "String", "country" to "String", "address" to "String"),
+                constraints = constraints)
+        val cdcDataStart = StreamsTransactionEvent(
+                meta = Meta(timestamp = System.currentTimeMillis(),
+                        username = "user",
+                        txId = 1,
+                        txEventId = 0,
+                        txEventsCount = 3,
+                        operation = OperationType.created
+                ),
+                payload = NodePayload(id = "0",
+                        before = null,
+                        after = NodeChange(properties = mapOf("name" to "Naruto", "surname" to "Uzumaki", "country" to "Japan", "address" to "Land of Leaf"), labels = listOf("User"))
+                ),
+                schema = nodeSchema
+        )
+        val cdcDataEnd = StreamsTransactionEvent(
+                meta = Meta(timestamp = System.currentTimeMillis(),
+                        username = "user",
+                        txId = 1,
+                        txEventId = 1,
+                        txEventsCount = 3,
+                        operation = OperationType.created
+                ),
+                payload = NodePayload(id = "1",
+                        before = null,
+                        after = NodeChange(properties = mapOf("name" to "Minato", "surname" to "Namikaze", "country" to "Japan", "address" to "Land of Leaf"), labels = listOf("User"))
+                ),
+                schema = nodeSchema
+        )
+        val cdcDataRelationship = StreamsTransactionEvent(
+                meta = Meta(timestamp = System.currentTimeMillis(),
+                        username = "user",
+                        txId = 1,
+                        txEventId = 2,
+                        txEventsCount = 3,
+                        operation = OperationType.created
+                ),
+                payload = RelationshipPayload(
+                        id = "2",
+                        // leverage on first ids alphabetically, that is name, so create 2 additional nodes
+                        start = RelationshipNodeChange(id = "1", labels = listOf("User"), ids = mapOf("name" to "Invalid", "surname" to "Uzumaki")),
+                        end = RelationshipNodeChange(id = "2", labels = listOf("User"), ids = mapOf("name" to "AnotherInvalid", "surname" to "Namikaze")),
+                        after = RelationshipChange(properties = mapOf("since" to 2014)),
+                        before = null,
+                        label = "KNOWS WHO"
+                ),
+                schema = relSchema
+        )
+
+        val task = Neo4jSinkTask()
+        task.initialize(mock(SinkTaskContext::class.java))
+        task.start(props)
+        val input = listOf(
+                SinkRecord(myTopic, 1, null, null, null, cdcDataStart, 42),
+                SinkRecord(myTopic, 1, null, null, null, cdcDataEnd, 43),
+                SinkRecord(myTopic, 1, null, null, null, cdcDataRelationship, 44),
+        )
+        task.put(input)
+
+        db.defaultDatabaseService().beginTx().use {
+            val query = """
+                |MATCH p = (s:User)-[r:`KNOWS WHO` {since: 2014}]->(e:User)
+                |RETURN count(p) as count
+                |""".trimMargin()
+            it.execute(query)
+                    .columnAs<Long>("count").use {
+                        assertTrue { it.hasNext() }
+                        val path = it.next()
+                        assertEquals(1, path)
+                        assertFalse { it.hasNext() }
+                    }
+
+            val labels = db.defaultDatabaseService().beginTx()
+                    .use { StreamSupport.stream(it.allLabels.spliterator(), false).map { it.name() }.collect(Collectors.toSet()) }
+            assertEquals(setOf("User"), labels)
+
+            val countUsers = db.defaultDatabaseService().beginTx().use { it.findNodes(Label.label("User")).stream().count() }
+            assertEquals(4L, countUsers)
+        }
+    }
+
+    @Test
     fun `should delete data into Neo4j from CDC events`() {
         db.defaultDatabaseService().beginTx().use {
             it.execute("""

--- a/kafka-connect-neo4j/src/test/kotlin/streams/kafka/connect/sink/Neo4jSinkTaskTest.kt
+++ b/kafka-connect-neo4j/src/test/kotlin/streams/kafka/connect/sink/Neo4jSinkTaskTest.kt
@@ -372,7 +372,7 @@ class Neo4jSinkTaskTest {
     }
 
     @Test
-    fun `should insert data into Neo4j from CDC events with schema strategy, multiple uniqueness constraints and multiple label names merging previous nodes`() {
+    fun `should insert data into Neo4j from CDC events with schema strategy, multiple constraints and labels`() {
         val myTopic = UUID.randomUUID().toString()
         val props = mapOf(Neo4jSinkConnectorConfig.SERVER_URI to db.boltURI().toString(),
                 Neo4jSinkConnectorConfig.TOPIC_CDC_SCHEMA to myTopic,
@@ -510,7 +510,7 @@ class Neo4jSinkTaskTest {
     }
 
     @Test
-    fun `should insert data into Neo4j from CDC events with schema strategy and multiple uniqueness constraints merging previous nodes`() {
+    fun `should insert data into Neo4j from CDC events with schema strategy and multiple unique constraints merging previous nodes`() {
         val myTopic = UUID.randomUUID().toString()
         val props = mapOf(Neo4jSinkConnectorConfig.SERVER_URI to db.boltURI().toString(),
                 Neo4jSinkConnectorConfig.TOPIC_CDC_SCHEMA to myTopic,

--- a/kafka-connect-neo4j/src/test/kotlin/streams/kafka/connect/sink/Neo4jSinkTaskTest.kt
+++ b/kafka-connect-neo4j/src/test/kotlin/streams/kafka/connect/sink/Neo4jSinkTaskTest.kt
@@ -372,6 +372,144 @@ class Neo4jSinkTaskTest {
     }
 
     @Test
+    fun `should insert data into Neo4j from CDC events with schema strategy, multiple uniqueness constraints and multiple label names merging previous nodes`() {
+        val myTopic = UUID.randomUUID().toString()
+        val props = mapOf(Neo4jSinkConnectorConfig.SERVER_URI to db.boltURI().toString(),
+                Neo4jSinkConnectorConfig.TOPIC_CDC_SCHEMA to myTopic,
+                Neo4jSinkConnectorConfig.AUTHENTICATION_TYPE to AuthenticationType.NONE.toString(),
+                SinkTask.TOPICS_CONFIG to myTopic)
+
+        val constraintsCharacter = listOf(
+                Constraint(label = "Character", type = StreamsConstraintType.UNIQUE, properties = setOf("surname")),
+                Constraint(label = "Character", type = StreamsConstraintType.UNIQUE, properties = setOf("name")),
+                Constraint(label = "Character", type = StreamsConstraintType.UNIQUE, properties = setOf("country", "address")),
+        )
+        val constraintsWriter = listOf(
+                Constraint(label = "Writer", type = StreamsConstraintType.UNIQUE, properties = setOf("lastName")),
+                Constraint(label = "Writer", type = StreamsConstraintType.UNIQUE, properties = setOf("firstName")),
+        )
+        val relSchema = Schema(properties = mapOf("since" to "Long"), constraints = constraintsCharacter.plus(constraintsWriter))
+        val nodeSchemaCharacter = Schema(properties = mapOf("name" to "String", "surname" to "String", "country" to "String", "address" to "String"), constraints = constraintsCharacter)
+        val nodeSchemaWriter = Schema(properties = mapOf("firstName" to "String", "lastName" to "String"), constraints = constraintsWriter)
+        val cdcDataStart = StreamsTransactionEvent(
+                meta = Meta(timestamp = System.currentTimeMillis(),
+                        username = "user",
+                        txId = 1,
+                        txEventId = 0,
+                        txEventsCount = 3,
+                        operation = OperationType.created
+                ),
+                payload = NodePayload(id = "0",
+                        before = null,
+                        after = NodeChange(properties = mapOf("name" to "Naruto", "surname" to "Uzumaki", "country" to "Japan", "address" to "Land of Leaf"), labels = listOf("Character"))
+                ),
+                schema = nodeSchemaCharacter
+        )
+        val cdcDataEnd = StreamsTransactionEvent(
+                meta = Meta(timestamp = System.currentTimeMillis(),
+                        username = "user",
+                        txId = 1,
+                        txEventId = 1,
+                        txEventsCount = 3,
+                        operation = OperationType.created
+                ),
+                payload = NodePayload(id = "1",
+                        before = null,
+                        after = NodeChange(properties = mapOf("firstName" to "Minato", "lastName" to "Namikaze"), labels = listOf("Writer"))
+                ),
+                schema = nodeSchemaWriter
+        )
+        val cdcDataRelationship = StreamsTransactionEvent(
+                meta = Meta(timestamp = System.currentTimeMillis(),
+                        username = "user",
+                        txId = 1,
+                        txEventId = 2,
+                        txEventsCount = 3,
+                        operation = OperationType.created
+                ),
+                payload = RelationshipPayload(
+                        id = "2",
+                        // leverage on first ids alphabetically, that is name, so we take the 2 previously created nodes
+                        start = RelationshipNodeChange(id = "99", labels = listOf("Character"), ids = mapOf("name" to "Naruto", "surname" to "Osvaldo", "address" to "Land of Sand")),
+                        end = RelationshipNodeChange(id = "88", labels = listOf("Writer"), ids = mapOf("firstName" to "Minato", "lastName" to "Franco", "address" to "Land of Fire")),
+                        after = RelationshipChange(properties = mapOf("since" to 2014)),
+                        before = null,
+                        label = "KNOWS WHO"
+                ),
+                schema = relSchema
+        )
+
+        val task = Neo4jSinkTask()
+        task.initialize(mock(SinkTaskContext::class.java))
+        task.start(props)
+        val input = listOf(SinkRecord(myTopic, 1, null, null, null, cdcDataStart, 42),
+                SinkRecord(myTopic, 1, null, null, null, cdcDataEnd, 43),
+                SinkRecord(myTopic, 1, null, null, null, cdcDataRelationship, 44))
+
+        task.put(input)
+
+        db.defaultDatabaseService().beginTx().use {
+            val query = """
+                |MATCH p = (s:Character)-[r:`KNOWS WHO`{since: 2014}]->(e:Writer)
+                |RETURN count(p) AS count
+                |""".trimMargin()
+            it.execute(query)
+                    .columnAs<Long>("count").use {
+                        assertTrue { it.hasNext() }
+                        val path = it.next()
+                        assertEquals(1, path)
+                        assertFalse { it.hasNext() }
+                    }
+
+            val countAllNodes = db.defaultDatabaseService().beginTx().use { it.allNodes.stream().count() }
+            assertEquals(2L, countAllNodes)
+        }
+
+        // another CDC data, not matching the previously created nodes
+        val cdcDataRelationshipNotMatched = StreamsTransactionEvent(
+                meta = Meta(timestamp = System.currentTimeMillis(),
+                        username = "user",
+                        txId = 1,
+                        txEventId = 2,
+                        txEventsCount = 3,
+                        operation = OperationType.created
+                ),
+                payload = RelationshipPayload(
+                        id = "2",
+                        // leverage on first ids alphabetically, that is name, so create 2 additional nodes
+                        start = RelationshipNodeChange(id = "1", labels = listOf("Character"), ids = mapOf("name" to "Invalid", "surname" to "Uzumaki")),
+                        end = RelationshipNodeChange(id = "2", labels = listOf("Writer"), ids = mapOf("firstName" to "AnotherInvalid", "surname" to "Namikaze")),
+                        after = RelationshipChange(properties = mapOf("since" to 1998)),
+                        before = null,
+                        label = "HAS WRITTEN"
+                ),
+                schema = relSchema
+        )
+
+        val inputNotMatched = listOf(SinkRecord(myTopic, 1, null, null, null, cdcDataRelationshipNotMatched, 45))
+
+        task.put(inputNotMatched)
+
+        db.defaultDatabaseService().beginTx().use {
+            val query = """
+                |MATCH p = (s:Character)-[r:`HAS WRITTEN`{since: 1998}]->(e:Writer)
+                |RETURN count(p) AS count
+                |""".trimMargin()
+            it.execute(query)
+                    .columnAs<Long>("count").use {
+                        assertTrue { it.hasNext() }
+                        val path = it.next()
+                        assertEquals(1, path)
+                        assertFalse { it.hasNext() }
+                    }
+
+            val countAllNodes = db.defaultDatabaseService().beginTx().use { it.allNodes.stream().count() }
+            assertEquals(4L, countAllNodes)
+        }
+
+    }
+
+    @Test
     fun `should insert data into Neo4j from CDC events with schema strategy and multiple uniqueness constraints merging previous nodes`() {
         val myTopic = UUID.randomUUID().toString()
         val props = mapOf(Neo4jSinkConnectorConfig.SERVER_URI to db.boltURI().toString(),
@@ -463,6 +601,53 @@ class Neo4jSinkTaskTest {
 
             val countUsers = db.defaultDatabaseService().beginTx().use { it.findNodes(Label.label("User")).stream().count() }
             assertEquals(2L, countUsers)
+        }
+
+
+        // another CDC data, not matching the previously created nodes
+        val cdcDataRelationshipNotMatched = StreamsTransactionEvent(
+                meta = Meta(timestamp = System.currentTimeMillis(),
+                        username = "user",
+                        txId = 1,
+                        txEventId = 2,
+                        txEventsCount = 3,
+                        operation = OperationType.created
+                ),
+                payload = RelationshipPayload(
+                        id = "2",
+                        // leverage on first ids alphabetically, that is name, so create 2 additional nodes
+                        start = RelationshipNodeChange(id = "1", labels = listOf("User"), ids = mapOf("name" to "Invalid", "surname" to "Uzumaki")),
+                        end = RelationshipNodeChange(id = "2", labels = listOf("User"), ids = mapOf("name" to "AnotherInvalid", "surname" to "Namikaze")),
+                        after = RelationshipChange(properties = mapOf("since" to 2000)),
+                        before = null,
+                        label = "HAS WRITTEN"
+                ),
+                schema = relSchema
+        )
+
+        val inputNotMatched = listOf(SinkRecord(myTopic, 1, null, null, null, cdcDataRelationshipNotMatched, 45))
+
+        task.put(inputNotMatched)
+
+        db.defaultDatabaseService().beginTx().use {
+            val query = """
+                |MATCH p = (s:User)-[r:`HAS WRITTEN`{since: 2000}]->(e:User)
+                |RETURN count(p) AS count
+                |""".trimMargin()
+            it.execute(query)
+                    .columnAs<Long>("count").use {
+                        assertTrue { it.hasNext() }
+                        val path = it.next()
+                        assertEquals(1, path)
+                        assertFalse { it.hasNext() }
+                    }
+
+            val labels = db.defaultDatabaseService().beginTx()
+                    .use { StreamSupport.stream(it.allLabels.spliterator(), false).map { it.name() }.collect(Collectors.toSet()) }
+            assertEquals(setOf("User"), labels)
+
+            val countUsers = db.defaultDatabaseService().beginTx().use { it.allNodes.stream().count() }
+            assertEquals(4L, countUsers)
         }
     }
 

--- a/kafka-connect-neo4j/src/test/kotlin/streams/kafka/connect/sink/Neo4jSinkTaskTest.kt
+++ b/kafka-connect-neo4j/src/test/kotlin/streams/kafka/connect/sink/Neo4jSinkTaskTest.kt
@@ -652,7 +652,7 @@ class Neo4jSinkTaskTest {
     }
 
     @Test
-    fun `should insert data into Neo4j from CDC events with schema strategy and multiple uniqueness constraints`() {
+    fun `should insert data into Neo4j from CDC events with schema strategy and multiple unique constraints`() {
         val myTopic = UUID.randomUUID().toString()
         val props = mapOf(Neo4jSinkConnectorConfig.SERVER_URI to db.boltURI().toString(),
                 Neo4jSinkConnectorConfig.TOPIC_CDC_SCHEMA to myTopic,

--- a/producer/src/test/kotlin/streams/integrations/KafkaEventRouterCompactionStrategyTSE.kt
+++ b/producer/src/test/kotlin/streams/integrations/KafkaEventRouterCompactionStrategyTSE.kt
@@ -220,7 +220,7 @@ class KafkaEventRouterCompactionStrategyTSE : KafkaEventRouterBaseTSE() {
         assertEquals(1, recordsThree.count())
         val mapRel: Map<String, Any> = JSONUtils.readValue(recordsThree.first().key())
 
-        keyStart = mapOf("ids" to mapOf("name" to "Sherlock"), "labels" to listOf("Other", "Person"))
+        keyStart = mapOf("ids" to mapOf("address" to "Baker Street"), "labels" to listOf("Other", "Person"))
         assertEquals(keyStart, mapRel["start"])
         assertEquals(keyEnd, mapRel["end"])
         assertEquals(relType, mapRel["label"])
@@ -251,18 +251,19 @@ class KafkaEventRouterCompactionStrategyTSE : KafkaEventRouterBaseTSE() {
         db.execute("CREATE (:Person:Neo4j {name:'Sherlock', surname: 'Holmes', address: 'Baker Street'})")
         val records = kafkaConsumer.poll(Duration.ofSeconds(10))
         assertEquals(1, records.count())
-        var keyNode = mapOf("ids" to mapOf("name" to "Sherlock"), "labels" to listOf("Person", "Neo4j"))
+        var keyNode = mapOf("ids" to mapOf("surname" to "Holmes"), "labels" to listOf("Person", "Neo4j"))
         assertEquals(keyNode, JSONUtils.readValue<Map<*, *>>(records.first().key()))
 
         db.execute("MATCH (p:Person {name:'Sherlock'}) SET p.name='Foo'")
         val recordsTwo = kafkaConsumer.poll(Duration.ofSeconds(10))
         assertEquals(1, recordsTwo.count())
-        keyNode = mapOf("ids" to mapOf("name" to "Foo"), "labels" to listOf("Person", "Neo4j"))
+        keyNode = mapOf("ids" to mapOf("surname" to "Holmes"), "labels" to listOf("Person", "Neo4j"))
         assertEquals(keyNode, JSONUtils.readValue<Map<*, *>>(recordsTwo.first().key()))
 
         db.execute("MATCH (p:Person {name:'Foo'}) SET p.surname='Bar'")
         val recordsThree = kafkaConsumer.poll(Duration.ofSeconds(10))
         assertEquals(1, recordsThree.count())
+        keyNode = mapOf("ids" to mapOf("surname" to "Bar"), "labels" to listOf("Person", "Neo4j"))
         assertEquals(keyNode, JSONUtils.readValue<Map<*, *>>(recordsThree.first().key()))
 
         db.execute("MATCH (p:Person {name:'Foo'}) DETACH DELETE p")


### PR DESCRIPTION
Fixes #429

Sorting by `properties.size`, then by `label` name and finally by `properties` name alphabetically

