### PR TITLE
fixes #402: move to github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: Java CI with Maven
+
+on:
+  push:
+    branches: [ '**' ]
+  pull_request:
+    branches: [ '**' ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+      - name: Cache Maven packages
+        uses: actions/cache@v1
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
+      - name: Build with Maven
+        env:
+          # needed for excluding enterprise tests
+          TRAVIS: true
+        run: mvn -B clean test --file pom.xml --no-transfer-progress

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,0 @@
-language: java
-jdk:
-  - openjdk11
-
-sudo: required
-services:
-  - docker


### PR DESCRIPTION
Fixes #402

Moving to GH Actions as we get a lot of `Could not pull image: toomanyrequests: You have reached your pull rate limit. You may increase the limit by authenticating and upgrading: https://www.docker.com/increase-rate-limit`

## Proposed Changes (Mandatory)

A brief list of proposed changes in order to fix the issue:

  - Removed travis
  - Added GH Actions
