### PR TITLE
Fixes #488: Add logging to the driver config (4.1)

### DIFF
--- a/kafka-connect-neo4j/config/sink-quickstart.properties
+++ b/kafka-connect-neo4j/config/sink-quickstart.properties
@@ -11,4 +11,5 @@ neo4j.server.uri=bolt://neo4j:7687
 neo4j.authentication.basic.username=neo4j
 neo4j.authentication.basic.password=connect
 neo4j.encryption.enabled=false
+neo4j.driver.log.level=INFO
 neo4j.topic.cypher.my-topic=MERGE (p:Person{name: event.name, surname: event.surname}) MERGE (f:Family{name: event.surname}) MERGE (p)-[:BELONGS_TO]->(f)

--- a/kafka-connect-neo4j/src/main/kotlin/streams/kafka/connect/common/Neo4jConnectorConfig.kt
+++ b/kafka-connect-neo4j/src/main/kotlin/streams/kafka/connect/common/Neo4jConnectorConfig.kt
@@ -35,19 +35,6 @@ object ConfigGroup {
 
 enum class ConnectorType { SINK, SOURCE }
 
-enum class DriverLogLevel(var level: Level) {
-    ERROR(Level.SEVERE),
-	INFO(Level.INFO),
-	WARN(Level.WARNING),
-	DEBUG(Level.FINE),
-	TRACE(Level.FINEST);
-
-  // Return 'INFO' if user supplied incorrect level name
-  companion object {
-    fun from(type: String?): DriverLogLevel = values().find { it.name == type } ?: INFO
-  }
-}
-
 open class Neo4jConnectorConfig(configDef: ConfigDef,
                                 originals: Map<*, *>,
                                 private val type: ConnectorType): AbstractConfig(configDef, originals) {
@@ -106,7 +93,7 @@ open class Neo4jConnectorConfig(configDef: ConfigDef,
         batchTimeout = getLong(BATCH_TIMEOUT_MSECS)
         batchSize = getInt(BATCH_SIZE)
 
-        neo4jDriverLogLevel = DriverLogLevel.from(getString(DRIVER_LOG_LEVEL)).level
+        neo4jDriverLogLevel = Level.parse((getString(DRIVER_LOG_LEVEL) ?: DRIVER_LOG_LEVEL_DEFAULT).toUpperCase())
     }
 
     fun hasSecuredURI() = serverUri.any { it.scheme.endsWith("+s", true) || it.scheme.endsWith("+ssc", true) }

--- a/kafka-connect-neo4j/src/main/resources/kafka-connect-neo4j.properties
+++ b/kafka-connect-neo4j/src/main/resources/kafka-connect-neo4j.properties
@@ -36,6 +36,8 @@ neo4j.retry.backoff.msecs=Type: Long;\nDescription: The time in milliseconds to 
   before a retry attempt is made (default 30000).
 neo4j.retry.max.attemps=Type: Int;\nDescription: The maximum number of times to retry on transient errors \
   (except for TimeoutException) before failing the task (default 5).
+neo4j.driver.log.level=Type: enum[ERROR, INFO, WARN, DEBUG, TRACE];\nDescription: Neo4j Driver Log Level (default INFO)
+
 
 ## Sink Properties
 neo4j.topic.cdc.sourceId=Type: String;\nDescription: The topic list (separated by semicolon) that manages CDC events with the `SourceId` strategy

--- a/kafka-connect-neo4j/src/main/resources/kafka-connect-neo4j.properties
+++ b/kafka-connect-neo4j/src/main/resources/kafka-connect-neo4j.properties
@@ -36,7 +36,7 @@ neo4j.retry.backoff.msecs=Type: Long;\nDescription: The time in milliseconds to 
   before a retry attempt is made (default 30000).
 neo4j.retry.max.attemps=Type: Int;\nDescription: The maximum number of times to retry on transient errors \
   (except for TimeoutException) before failing the task (default 5).
-neo4j.driver.log.level=Type: enum[ERROR, INFO, WARN, DEBUG, TRACE];\nDescription: Neo4j Driver Log Level (default INFO)
+neo4j.driver.log.level=Type: String;\nDescription: Neo4j Driver Log Level (default INFO)
 
 
 ## Sink Properties

--- a/kafka-connect-neo4j/src/test/kotlin/streams/kafka/connect/sink/Neo4jSinkTaskTest.kt
+++ b/kafka-connect-neo4j/src/test/kotlin/streams/kafka/connect/sink/Neo4jSinkTaskTest.kt
@@ -1367,13 +1367,13 @@ class Neo4jSinkTaskTest {
     }
 
     @Test
-    fun `should not fail running with invalid log level config`() {
+    fun `should not fail running with INFO log level`() {
         val topic = "neotopic"
         val props = mutableMapOf<String, String>()
         props[Neo4jConnectorConfig.SERVER_URI] = db.boltURI().toString()
         props["${Neo4jSinkConnectorConfig.TOPIC_CYPHER_PREFIX}$topic"] = "CREATE (n:Person {name: event.firstName, surname: event.lastName})"
         props[Neo4jConnectorConfig.AUTHENTICATION_TYPE] = AuthenticationType.NONE.toString()
-        props[Neo4jConnectorConfig.DRIVER_LOG_LEVEL] = "INVALID_LOG_LEVEL"
+        props[Neo4jConnectorConfig.DRIVER_LOG_LEVEL] = "INFO"
         props[SinkTask.TOPICS_CONFIG] = topic
         props[ErrorService.ErrorConfig.TOLERANCE] = "all"
         props[ErrorService.ErrorConfig.LOG] = true.toString()


### PR DESCRIPTION
## Fixes #488

Suggestion to change the log level of Neo4j driver

## Proposed Changes

A brief list of proposed changes in order to fix the issue:

- add log level to configBuilder in Neo4jConnectorConfig.kt
- add option to configure driver log level from connector props
- add incorrect input test