### PR TITLE
Update configuration.adoc

### DIFF
--- a/doc/docs/modules/ROOT/pages/configuration.adoc
+++ b/doc/docs/modules/ROOT/pages/configuration.adoc
@@ -293,8 +293,8 @@ you change properties related to the Sink, only it will be restarted.
 *What happens into the `Source` module*
 
 During the reload process the transaction event handler gets unplugged, this
-means that all transaction evens that happen during reload period are not
-caught by the Source, so they are *lost*.
+means that all transaction that even happen during reload period are not
+caught by the `Source`, so they are *lost*.
 
 *What happens into the `Sink` module*
 


### PR DESCRIPTION
Fixes a typo

One sentence summary of the change.

## Proposed Changes (Mandatory)

Typo on this page: https://neo4j.com/labs/kafka/4.0/configuration/
During the reload process the transaction event handler gets unplugged, this means that all transaction **evens** that happen during reload period are not caught by the Source, so they are lost.
