### PR TITLE
Fixes AsciiDoc issues reported by Antora/Asciidoctor

### DIFF
--- a/doc/docs/modules/ROOT/pages/configuration.adoc
+++ b/doc/docs/modules/ROOT/pages/configuration.adoc
@@ -280,7 +280,7 @@ You'll have this following output (it's related to *your* configuration 😄)
 
 |===
 
-====== What happens when we change a configuration properties from procedure
+===== What happens when we change a configuration properties from procedure
 
 When we change the configuration properties from `streams.configuration.set/remove`,
 under-the-hood `Sink` and `Source` modules are reloaded. So use it carefully

--- a/doc/docs/modules/ROOT/pages/consumer-configuration.adoc
+++ b/doc/docs/modules/ROOT/pages/consumer-configuration.adoc
@@ -3,7 +3,7 @@
 You can set the following Kafka configuration values in your `neo4j.conf`, here are the defaults.
 
 .neo4j.conf
-[source,subs="verbatim,attributes"]
+[source, subs=verbatim]
 ----
 kafka.bootstrap.servers=localhost:9092
 kafka.auto.offset.reset=earliest

--- a/doc/docs/modules/ROOT/pages/producer-configuration.adoc
+++ b/doc/docs/modules/ROOT/pages/producer-configuration.adoc
@@ -124,7 +124,7 @@ This means that if you have Neo4j with 3 db instances:
 and you want to enable the Source plugin on all instances,
 you can simply omit any configuration about enabling it, you just need to provide the routing configuration for each instance:
 
-[source]
+[source,subs=-attributes]
 ----
 streams.source.topic.nodes.testTopic=Test{testId}
 streams.source.topic.nodes.fooTopic.from.foo=Foo{fooId,fooName}
@@ -134,7 +134,7 @@ streams.source.topic.relationships.barTopic.from.bar=Bar{barId,barName}
 Otherwise if you want to enable the Source plugin only on `foo` and `bar` instances,
 you can do it in this way:
 
-[source]
+[source,subs=-attributes]
 ----
 streams.source.enabled=false
 streams.source.enabled.from.foo=true
@@ -148,7 +148,7 @@ streams.source.topic.relationships.barTopic.from.bar=Bar{barId,barName}
 ====
 As you can see, if you want to enable the Source plugin only on one or more specific db instances, you have to previously
 disable the Source plugin (`streams.source.enabled=false`) and then enable it only on the desired instances (i.e. `streams.source.enabled.from.foo=true`).
-Furthermore, please note that the `streams.source.topic.nodes.testTopic=Test{testId}` will not be considered because the Source plugin on the default database instance `neo4j` has been disabled.
+Furthermore, please note that the `+streams.source.topic.nodes.testTopic=Test{testId}+` will not be considered because the Source plugin on the default database instance `neo4j` has been disabled.
 ====
 
 So in general if you have:


### PR DESCRIPTION
```
[12:18:44.359] WARN (asciidoctor): section title out of sequence: expected level 4, got level 5
    file: doc/docs/modules/ROOT/pages/configuration.adoc:283
    source: https://github.com/neo4j-contrib/neo4j-streams (branch: 4.0 | start path: doc/docs)
[12:18:45.261] WARN (asciidoctor): skipping reference to missing attribute: testid
    file: doc/docs/modules/ROOT/pages/producer-configuration.adoc
    source: https://github.com/neo4j-contrib/neo4j-streams (branch: 4.0 | start path: doc/docs)
[12:18:45.401] WARN (asciidoctor): skipping reference to missing attribute: testid
    file: doc/docs/modules/ROOT/pages/producer.adoc
    source: https://github.com/neo4j-contrib/neo4j-streams (branch: 4.0 | start path: doc/docs)
[12:18:45.745] WARN (asciidoctor): skipping reference to missing attribute: environment
    file: doc/docs/modules/ROOT/pages/consumer-configuration.adoc
```

## Proposed Changes

A brief list of proposed changes in order to fix the issue:

  - Fix section title level in configuration.adoc
  - Remove subs attributes since `testid` and `environment` are not AsciiDoc attributes
