### PR TITLE
Add kafka-connect sink connector dropUnwind property

### DIFF
--- a/common/src/main/kotlin/streams/service/sink/strategy/CypherTemplateStrategy.kt
+++ b/common/src/main/kotlin/streams/service/sink/strategy/CypherTemplateStrategy.kt
@@ -3,8 +3,8 @@ package streams.service.sink.strategy
 import streams.service.StreamsSinkEntity
 import streams.utils.StreamsUtils
 
-class CypherTemplateStrategy(query: String): IngestionStrategy {
-    private val fullQuery = "${StreamsUtils.UNWIND} $query"
+class CypherTemplateStrategy(query: String, dropUnwind: Boolean = false): IngestionStrategy {
+    private val fullQuery = if (dropUnwind) query else "${StreamsUtils.UNWIND} $query"
     override fun mergeNodeEvents(events: Collection<StreamsSinkEntity>): List<QueryEvents> {
         return listOf(QueryEvents(fullQuery, events.mapNotNull { it.value as? Map<String, Any> }))
     }

--- a/doc/docs/modules/ROOT/pages/kafka-connect.adoc
+++ b/doc/docs/modules/ROOT/pages/kafka-connect.adoc
@@ -427,6 +427,7 @@ Following a summary of all the configuration parameters you can use for the Kafk
 | neo4j.topic.pattern.relationship.<TOPIC_NAME> | <relationship extraction pattern> | false |
 | neo4j.topic.cud | <list of topics separated by semicolon> | false |
 | neo4j.topic.cypher.<topic> | <valid Cypher query> | false |
+| neo4j.cypher.dropUnwind | boolean | false | If enabled connector will drop UNWIND part which prefixes cypher query under the hood. Useful for single query execution without events.
 |===
 
 .Kafka Connect Source configuration parameters

--- a/doc/package-lock.json
+++ b/doc/package-lock.json
@@ -172,6 +172,7 @@
         "@antora/document-converter": "~2 >=2.3.1 || ^3.0.0-alpha.1",
         "@antora/expand-path-helper": "~1.0",
         "@antora/playbook-builder": "~2 >=2.3.1 || ^3.0.0-alpha.1",
+        "@antora/ui-loader": "~2 >=2.3.1 || ^3.0.0-alpha.1",
         "cache-directory": "~2.0",
         "got": "~11.7",
         "node-gzip": "~1.1"

--- a/kafka-connect-neo4j/src/main/kotlin/streams/kafka/connect/sink/Neo4jSinkConnectorConfig.kt
+++ b/kafka-connect-neo4j/src/main/kotlin/streams/kafka/connect/sink/Neo4jSinkConnectorConfig.kt
@@ -21,6 +21,8 @@ class Neo4jSinkConnectorConfig(originals: Map<*, *>): Neo4jConnectorConfig(confi
 
     val parallelBatches: Boolean
 
+    val dropUnwind: Boolean
+
     val topics: Topics
 
     val strategyMap: Map<TopicType, Any>
@@ -33,6 +35,7 @@ class Neo4jSinkConnectorConfig(originals: Map<*, *>): Neo4jConnectorConfig(confi
         strategyMap = TopicUtils.toStrategyMap(topics, sourceIdStrategyConfig)
 
         parallelBatches = getBoolean(BATCH_PARALLELIZE)
+        dropUnwind = getBoolean(CYPHER_DROP_UNWIND)
         val kafkaPrefix = "kafka."
         kafkaBrokerProperties = originals
                 .filterKeys { it.startsWith(kafkaPrefix) }
@@ -61,6 +64,7 @@ class Neo4jSinkConnectorConfig(originals: Map<*, *>): Neo4jConnectorConfig(confi
     companion object {
 
         const val BATCH_PARALLELIZE = "neo4j.batch.parallelize"
+        const val CYPHER_DROP_UNWIND = "neo4j.cypher.dropUnwind"
 
         const val TOPIC_CYPHER_PREFIX = "neo4j.topic.cypher."
         const val TOPIC_CDC_SOURCE_ID = "neo4j.topic.cdc.sourceId"
@@ -89,6 +93,10 @@ class Neo4jSinkConnectorConfig(originals: Map<*, *>): Neo4jConnectorConfig(confi
                     .define(ConfigKeyBuilder.of(TOPIC_CDC_SCHEMA, ConfigDef.Type.STRING)
                             .documentation(PropertiesUtil.getProperty(TOPIC_CDC_SCHEMA)).importance(ConfigDef.Importance.HIGH)
                             .defaultValue("").group(ConfigGroup.TOPIC_CYPHER_MAPPING)
+                            .build())
+                    .define(ConfigKeyBuilder.of(CYPHER_DROP_UNWIND, ConfigDef.Type.BOOLEAN)
+                            .documentation(PropertiesUtil.getProperty(CYPHER_DROP_UNWIND)).importance(ConfigDef.Importance.LOW)
+                            .defaultValue(false).group(ConfigGroup.BATCH)
                             .build())
                     .define(ConfigKeyBuilder.of(BATCH_PARALLELIZE, ConfigDef.Type.BOOLEAN)
                             .documentation(PropertiesUtil.getProperty(BATCH_PARALLELIZE)).importance(ConfigDef.Importance.MEDIUM)

--- a/kafka-connect-neo4j/src/main/kotlin/streams/kafka/connect/sink/Neo4jStrategyStorage.kt
+++ b/kafka-connect-neo4j/src/main/kotlin/streams/kafka/connect/sink/Neo4jStrategyStorage.kt
@@ -28,7 +28,7 @@ class Neo4jStrategyStorage(val config: Neo4jSinkConnectorConfig): StreamsStrateg
         TopicType.CUD -> CUDIngestionStrategy()
         TopicType.PATTERN_NODE -> NodePatternIngestionStrategy(config.topics.nodePatternTopics.getValue(topic))
         TopicType.PATTERN_RELATIONSHIP -> RelationshipPatternIngestionStrategy(config.topics.relPatternTopics.getValue(topic))
-        TopicType.CYPHER -> CypherTemplateStrategy(config.topics.cypherTopics.getValue(topic))
+        TopicType.CYPHER -> CypherTemplateStrategy(config.topics.cypherTopics.getValue(topic), config.dropUnwind)
         null -> throw RuntimeException("Topic Type not Found")
     }
 }


### PR DESCRIPTION
Fixes  #550

A new `neo4j.cypher.dropUnwind` property should allow to skip UNWIND prefix from cypher template strategy queries.

## Proposed Changes (Mandatory)

Add `neo4j.cypher.dropUnwind` sink connector property

