### PR TITLE
Fix connector error parsing nested timestamps

### DIFF
--- a/kafka-connect-neo4j/src/main/kotlin/streams/kafka/connect/sink/converters/Neo4jValueConverter.kt
+++ b/kafka-connect-neo4j/src/main/kotlin/streams/kafka/connect/sink/converters/Neo4jValueConverter.kt
@@ -58,6 +58,6 @@ class Neo4jValueConverter: MapValueConverter<Value>() {
         val converted = convert(value)
             .mapValues { it.value?.asObject() }
             .toMutableMap() as MutableMap<Any?, Any?>
-        setMap(result, fieldName, null, converted)
+        setValue(result, fieldName, converted)
     }
 }

--- a/kafka-connect-neo4j/src/test/kotlin/streams/kafka/connect/sink/Neo4jSinkTaskTest.kt
+++ b/kafka-connect-neo4j/src/test/kotlin/streams/kafka/connect/sink/Neo4jSinkTaskTest.kt
@@ -190,8 +190,8 @@ class Neo4jSinkTaskTest {
         val secondTopic = "foo"
         val props = mutableMapOf<String, String>()
         props[Neo4jConnectorConfig.SERVER_URI] = neo4j.boltUrl
-        props["${Neo4jSinkConnectorConfig.TOPIC_CYPHER_PREFIX}$firstTopic"] = "CREATE (n:PersonExt {name: event.firstName, surname: event.lastName})"
-        props["${Neo4jSinkConnectorConfig.TOPIC_CYPHER_PREFIX}$secondTopic"] = "CREATE (n:Person {name: event.firstName})"
+        props["${Neo4jSinkConnectorConfig.TOPIC_CYPHER_PREFIX}$firstTopic"] = "CREATE (n:PersonExt {modified: event.place.modified})"
+        props["${Neo4jSinkConnectorConfig.TOPIC_CYPHER_PREFIX}$secondTopic"] = "CREATE (n:Person {modified: event.place.modified})"
         props[Neo4jConnectorConfig.AUTHENTICATION_TYPE] = AuthenticationType.NONE.toString()
         props[Neo4jConnectorConfig.BATCH_SIZE] = 2.toString()
         props[SinkTask.TOPICS_CONFIG] = "$firstTopic,$secondTopic"


### PR DESCRIPTION
Fixes #580 

Changed Neo4jValueConverter to call setValue instead of setMap after converting a struct

## Proposed Changes (Mandatory)

A brief list of proposed changes in order to fix the issue:

  - Call setValue instead of setMap after converting a struct. setMap attempts to convert the data again resulting in problems in the connect-utils AbstractConverter.
