### PR TITLE
Add missing CODEOWNERS and harden .github path

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+*       @neo4j-contrib/team-connectors
+
+/.github/   @ali-ince @fbiville @venikkin


### PR DESCRIPTION
The whole idea of "hardening" the .github path is to prevent large teams to have access to that path.

Instead, only a subset of that team must be allowed that.

In our case, we're a team of 3 at Neo4j, so listing us 3 should be fine, even if the team grows beyond that.
