### PR TITLE
Upgrade Neo4j images to Neo4j version 5.

### DIFF
--- a/kafka-connect-neo4j/config/sink-quickstart.properties
+++ b/kafka-connect-neo4j/config/sink-quickstart.properties
@@ -9,6 +9,6 @@ errors.log.enable=true
 errors.log.include.messages=true
 neo4j.server.uri=bolt://neo4j:7687
 neo4j.authentication.basic.username=neo4j
-neo4j.authentication.basic.password=connect
+neo4j.authentication.basic.password=kafkaconnect
 neo4j.encryption.enabled=false
 neo4j.topic.cypher.my-topic=MERGE (p:Person{name: event.name, surname: event.surname}) MERGE (f:Family{name: event.surname}) MERGE (p)-[:BELONGS_TO]->(f)

--- a/kafka-connect-neo4j/doc/contrib.sink.avro.neo4j.json
+++ b/kafka-connect-neo4j/doc/contrib.sink.avro.neo4j.json
@@ -10,7 +10,7 @@
     "errors.log.include.messages": true,
     "neo4j.server.uri": "bolt://neo4j:7687",
     "neo4j.authentication.basic.username": "neo4j",
-    "neo4j.authentication.basic.password": "connect",
+    "neo4j.authentication.basic.password": "kafkaconnect",
     "neo4j.encryption.enabled": false,
     "neo4j.topic.cypher.my-topic": "MERGE (p:Person{name: event.name, surname: event.surname, from: 'AVRO'}) MERGE (f:Family{name: event.surname}) MERGE (p)-[:BELONGS_TO]->(f)"
   }

--- a/kafka-connect-neo4j/doc/contrib.sink.string-json.neo4j.json
+++ b/kafka-connect-neo4j/doc/contrib.sink.string-json.neo4j.json
@@ -13,7 +13,7 @@
     "errors.log.include.messages": true,
     "neo4j.server.uri": "bolt://neo4j:7687",
     "neo4j.authentication.basic.username": "neo4j",
-    "neo4j.authentication.basic.password": "connect",
+    "neo4j.authentication.basic.password": "kafkaconnect",
     "neo4j.encryption.enabled": false,
     "neo4j.topic.cypher.my-topic": "MERGE (p:Person{name: event.name, surname: event.surname, from: 'JSON'}) MERGE (f:Family{name: event.surname}) MERGE (p)-[:BELONGS_TO]->(f)"
   }

--- a/kafka-connect-neo4j/doc/contrib.source.avro.neo4j.json
+++ b/kafka-connect-neo4j/doc/contrib.source.avro.neo4j.json
@@ -7,7 +7,7 @@
     "value.converter": "io.confluent.connect.avro.AvroConverter",
     "neo4j.server.uri": "bolt://neo4j:7687",
     "neo4j.authentication.basic.username": "neo4j",
-    "neo4j.authentication.basic.password": "connect",
+    "neo4j.authentication.basic.password": "kafkaconnect",
     "neo4j.encryption.enabled": false,
     "neo4j.streaming.poll.interval.msecs": 5000,
     "neo4j.streaming.property": "timestamp",

--- a/kafka-connect-neo4j/doc/contrib.source.string-json.neo4j.json
+++ b/kafka-connect-neo4j/doc/contrib.source.string-json.neo4j.json
@@ -7,7 +7,7 @@
     "value.converter": "org.apache.kafka.connect.json.JsonConverter",
     "neo4j.server.uri": "bolt://neo4j:7687",
     "neo4j.authentication.basic.username": "neo4j",
-    "neo4j.authentication.basic.password": "connect",
+    "neo4j.authentication.basic.password": "kafkaconnect",
     "neo4j.encryption.enabled": false,
     "neo4j.streaming.poll.interval.msecs": 5000,
     "neo4j.streaming.property": "timestamp",

--- a/kafka-connect-neo4j/doc/contrib.source.string.neo4j.json
+++ b/kafka-connect-neo4j/doc/contrib.source.string.neo4j.json
@@ -7,7 +7,7 @@
     "value.converter": "org.apache.kafka.connect.storage.StringConverter",
     "neo4j.server.uri": "bolt://neo4j:7687",
     "neo4j.authentication.basic.username": "neo4j",
-    "neo4j.authentication.basic.password": "connect",
+    "neo4j.authentication.basic.password": "kafkaconnect",
     "neo4j.encryption.enabled": false,
     "neo4j.streaming.poll.interval.msecs": 5000,
     "neo4j.streaming.property": "timestamp",

--- a/kafka-connect-neo4j/doc/docker-compose.yml
+++ b/kafka-connect-neo4j/doc/docker-compose.yml
@@ -2,15 +2,14 @@
 version: '2'
 services:
   neo4j:
-    image: neo4j:4.3-enterprise
+    image: neo4j:5-enterprise
     hostname: neo4j
     container_name: neo4j
     ports:
     - "7474:7474"
     - "7687:7687"
     environment:
-      NEO4J_kafka_bootstrap_servers: broker:9093
-      NEO4J_AUTH: neo4j/connect
+      NEO4J_AUTH: neo4j/kafkaconnect
       NEO4J_dbms_memory_heap_max__size: 8G
       NEO4J_ACCEPT_LICENSE_AGREEMENT: yes
 

--- a/kafka-connect-neo4j/docker/contrib.sink.avro.neo4j.json
+++ b/kafka-connect-neo4j/docker/contrib.sink.avro.neo4j.json
@@ -11,7 +11,7 @@
     "errors.log.include.messages": true,
     "neo4j.server.uri": "bolt://neo4j:7687",
     "neo4j.authentication.basic.username": "neo4j",
-    "neo4j.authentication.basic.password": "connect",
+    "neo4j.authentication.basic.password": "kafkaconnect",
     "neo4j.encryption.enabled": false,
     "neo4j.topic.cypher.my-topic": "MERGE (p:Person{name: event.name, surname: event.surname}) MERGE (f:Family{name: event.surname}) MERGE (p)-[:BELONGS_TO]->(f)"
   }

--- a/kafka-connect-neo4j/docker/contrib.sink.string-json.neo4j.json
+++ b/kafka-connect-neo4j/docker/contrib.sink.string-json.neo4j.json
@@ -14,7 +14,7 @@
     "errors.log.include.messages": true,
     "neo4j.server.uri": "bolt://neo4j:7687",
     "neo4j.authentication.basic.username": "neo4j",
-    "neo4j.authentication.basic.password": "connect",
+    "neo4j.authentication.basic.password": "kafkaconnect",
     "neo4j.encryption.enabled": false,
     "neo4j.topic.cypher.my-topic": "MERGE (p:Person{name: event.name, surname: event.surname}) MERGE (f:Family{name: event.surname}) MERGE (p)-[:BELONGS_TO]->(f)"
   }

--- a/kafka-connect-neo4j/docker/contrib.source.avro.neo4j.json
+++ b/kafka-connect-neo4j/docker/contrib.source.avro.neo4j.json
@@ -9,7 +9,7 @@
     "value.converter.schema.registry.url": "http://schema_registry:8081",
     "neo4j.server.uri": "bolt://neo4j:7687",
     "neo4j.authentication.basic.username": "neo4j",
-    "neo4j.authentication.basic.password": "connect",
+    "neo4j.authentication.basic.password": "kafkaconnect",
     "neo4j.encryption.enabled": false,
     "neo4j.streaming.poll.interval.msecs": 5000,
     "neo4j.streaming.property": "timestamp",

--- a/kafka-connect-neo4j/docker/contrib.source.string-json.neo4j.json
+++ b/kafka-connect-neo4j/docker/contrib.source.string-json.neo4j.json
@@ -7,7 +7,7 @@
     "value.converter": "org.apache.kafka.connect.json.JsonConverter",
     "neo4j.server.uri": "bolt://neo4j:7687",
     "neo4j.authentication.basic.username": "neo4j",
-    "neo4j.authentication.basic.password": "connect",
+    "neo4j.authentication.basic.password": "kafkaconnect",
     "neo4j.encryption.enabled": false,
     "neo4j.streaming.poll.interval.msecs": 5000,
     "neo4j.streaming.property": "timestamp",

--- a/kafka-connect-neo4j/docker/contrib.source.string.neo4j.json
+++ b/kafka-connect-neo4j/docker/contrib.source.string.neo4j.json
@@ -7,7 +7,7 @@
     "value.converter": "org.apache.kafka.connect.storage.StringConverter",
     "neo4j.server.uri": "bolt://neo4j:7687",
     "neo4j.authentication.basic.username": "neo4j",
-    "neo4j.authentication.basic.password": "connect",
+    "neo4j.authentication.basic.password": "kafkaconnect",
     "neo4j.encryption.enabled": false,
     "neo4j.streaming.poll.interval.msecs": 5000,
     "neo4j.streaming.property": "timestamp",

--- a/kafka-connect-neo4j/docker/docker-compose.yml
+++ b/kafka-connect-neo4j/docker/docker-compose.yml
@@ -3,15 +3,14 @@ version: '2'
 
 services:
   neo4j:
-    image: neo4j:4.3-enterprise
+    image: neo4j:5-enterprise
     hostname: neo4j
     container_name: neo4j
     ports:
       - "7474:7474"
       - "7687:7687"
     environment:
-      NEO4J_kafka_bootstrap_servers: broker:9093
-      NEO4J_AUTH: neo4j/connect
+      NEO4J_AUTH: neo4j/kafkaconnect
       NEO4J_dbms_memory_heap_max__size: 8G
       NEO4J_ACCEPT_LICENSE_AGREEMENT: 'yes'
 

--- a/kafka-connect-neo4j/docker/readme.adoc
+++ b/kafka-connect-neo4j/docker/readme.adoc
@@ -12,7 +12,7 @@ You can set the following configuration values via Confluent Connect UI, or via 
 |{environment}.server.uri|String|The Bolt URI (default bolt://localhost:7687)
 |{environment}.authentication.type|enum[NONE, BASIC, KERBEROS]| The authentication type (default BASIC)
 |{environment}.batch.size|Int|The max number of events processed by the Cypher query (default 1000)
-|{environment}.batch.timeout.msecs|Long|The execution timeout for the cypher query (default 30000)
+|{environment}.batch.timeout.msecs|Long|The execution timeout for the Cypher query (default 30000)
 |{environment}.authentication.basic.username|String| The authentication username
 |{environment}.authentication.basic.password|String| The authentication password
 |{environment}.authentication.basic.realm|String| The authentication realm
@@ -37,7 +37,7 @@ Start the compose file
 docker-compose up -d
 ----
 
-You can access your Neo4j instance under: http://localhost:7474, log in with `neo4j` as username and `connect` as password (see the docker-compose file to change it).
+You can access your Neo4j instance under: http://localhost:7474, log in with `neo4j` as username and `kafkaconnect` as password (see the docker-compose file to change it).
 
 ===== Plugin installation
 

--- a/kafka-connect-neo4j/src/main/resources/kafka-connect-neo4j.properties
+++ b/kafka-connect-neo4j/src/main/resources/kafka-connect-neo4j.properties
@@ -19,7 +19,7 @@ neo4j.server.uri=Type: String;\nDescription: The Bolt URI (default bolt://localh
 neo4j.authentication.type=Type: enum[NONE, BASIC, KERBEROS];\nDescription: The authentication type (default BASIC)
 neo4j.batch.size=Type: Int;\nDescription: The max number of events processed by the Cypher query for the Sink. \
   The max number of messages pushed for each poll cycle in case of the Source. (default 1000)
-neo4j.batch.timeout.msecs=Type: Long;\nDescription: The execution timeout for the cypher query (default: 0, that is without timeout)
+neo4j.batch.timeout.msecs=Type: Long;\nDescription: The execution timeout for the Cypher query (default: 0, that is without timeout)
 neo4j.authentication.basic.username=Type: String;\nDescription: The authentication username
 neo4j.authentication.basic.password=Type: String;\nDescription: The authentication password
 neo4j.authentication.basic.realm=Type: String;\nDescription: The authentication realm

--- a/test-support/src/main/kotlin/streams/Neo4jContainerExtension.kt
+++ b/test-support/src/main/kotlin/streams/Neo4jContainerExtension.kt
@@ -57,7 +57,7 @@ private class DatabasesWaitStrategy(private val auth: AuthToken): AbstractWaitSt
 }
 
 class Neo4jContainerExtension(dockerImage: String): Neo4jContainer<Neo4jContainerExtension>(dockerImage) {
-    constructor(): this("neo4j:5.1-enterprise")
+    constructor(): this("neo4j:5-enterprise")
     private val logger = LoggerFactory.getLogger(Neo4jContainerExtension::class.java)
     var driver: Driver? = null
     var session: Session? = null


### PR DESCRIPTION
Remove the `kafka.bootstrap.servers` property
because it would depend on the build in streams
support.
As a dependency of the upgrade, the password needs to be at least 8 characters long.