### PR TITLE
2D point serialization fix added for version 5.0

### DIFF
--- a/common/src/main/kotlin/streams/utils/JSONUtils.kt
+++ b/common/src/main/kotlin/streams/utils/JSONUtils.kt
@@ -38,8 +38,10 @@ import java.time.temporal.TemporalAccessor
 import kotlin.reflect.full.isSubclassOf
 
 abstract class StreamsPoint { abstract val crs: String }
-data class StreamsPointCartesian(override val crs: String, val x: Double, val y: Double, val z: Double? = null): StreamsPoint()
-data class StreamsPointWgs(override val crs: String, val latitude: Double, val longitude: Double, val height: Double? = null): StreamsPoint()
+data class StreamsPointCartesian2D(override val crs: String, val x: Double, val y: Double): StreamsPoint()
+data class StreamsPointCartesian3D(override val crs: String, val x: Double, val y: Double, val z: Double? = null): StreamsPoint()
+data class StreamsPointWgs2D(override val crs: String, val latitude: Double, val longitude: Double): StreamsPoint()
+data class StreamsPointWgs3D(override val crs: String, val latitude: Double, val longitude: Double, val height: Double? = null): StreamsPoint()
 
 fun PointValue.toStreamsPoint(): StreamsPoint {
     val point = this.asPoint()
@@ -49,10 +51,10 @@ fun PointValue.toStreamsPoint(): StreamsPoint {
 fun Point.toStreamsPoint(): StreamsPoint {
     val point = this
     return when (val crsType = point.srid()) {
-        7203 -> StreamsPointCartesian("cartesian", point.x(), point.y())
-        9157 -> StreamsPointCartesian("cartesian-3d", point.x(), point.y(), point.z())
-        4326 -> StreamsPointWgs("wgs-84", point.x(), point.y())
-        4979 -> StreamsPointWgs("wgs-84-3d", point.x(), point.y(), point.z())
+        7203 -> StreamsPointCartesian2D("cartesian", point.x(), point.y())
+        9157 -> StreamsPointCartesian3D("cartesian-3d", point.x(), point.y(), point.z())
+        4326 -> StreamsPointWgs2D("wgs-84", point.x(), point.y())
+        4979 -> StreamsPointWgs3D("wgs-84-3d", point.x(), point.y(), point.z())
         else -> throw IllegalArgumentException("Point type $crsType not supported")
     }
 }

--- a/common/src/test/kotlin/streams/utils/JSONUtilsTest.kt
+++ b/common/src/test/kotlin/streams/utils/JSONUtilsTest.kt
@@ -13,7 +13,6 @@ import streams.events.NodePayload
 import streams.events.OperationType
 import streams.events.Schema
 import streams.events.StreamsTransactionEvent
-import java.time.LocalTime
 import java.time.OffsetTime
 import java.time.ZoneOffset.UTC
 import java.time.ZonedDateTime
@@ -25,9 +24,9 @@ class JSONUtilsTest {
     @Test
     fun `should serialize driver Point Data Types`() {
         // Given
-        val expected = "{\"point2dCartesian\":{\"crs\":\"cartesian\",\"x\":1.0,\"y\":2.0,\"z\":null}," +
+        val expected = "{\"point2dCartesian\":{\"crs\":\"cartesian\",\"x\":1.0,\"y\":2.0}," +
                 "\"point3dCartesian\":{\"crs\":\"cartesian-3d\",\"x\":1.0,\"y\":2.0,\"z\":3.0}," +
-                "\"point2dWgs84\":{\"crs\":\"wgs-84\",\"latitude\":1.0,\"longitude\":2.0,\"height\":null}," +
+                "\"point2dWgs84\":{\"crs\":\"wgs-84\",\"latitude\":1.0,\"longitude\":2.0}," +
                 "\"point3dWgs84\":{\"crs\":\"wgs-84-3d\",\"latitude\":1.0,\"longitude\":2.0,\"height\":3.0}," +
                 "\"time\":\"14:01:01.000000001Z\",\"dateTime\":\"2017-12-17T17:14:35.123456789Z\"}"
 
@@ -87,6 +86,102 @@ class JSONUtilsTest {
         val fromString = JSONUtils.asStreamsTransactionEvent(cdcString)
         assertEquals(cdcData, fromMap)
         assertEquals(cdcData, fromString)
+    }
+
+    @Test
+    fun `should convert cdcMap wgs2D with height null to PointValue`() {
+        // given
+        val timestamp = System.currentTimeMillis()
+        val expectedPointValue = Values.point(4326, 12.78, 56.7)
+
+        //when
+        val cdcMap = mapOf<String, Any>(
+            "meta" to mapOf("timestamp" to timestamp,
+                "username" to "user",
+                "txId" to 1,
+                "txEventId" to 0,
+                "txEventsCount" to 1,
+                "operation" to OperationType.created),
+            "payload" to mapOf("id" to "0",
+                "before" to null,
+                "after" to NodeChange(properties = mapOf("location" to mapOf("crs" to "wgs-84", "longitude" to 12.78, "latitude" to 56.7, "height" to null)),
+                    labels = listOf("LabelCDC")),
+                "type" to EntityType.node),
+            "schema" to mapOf("properties" to mapOf("location" to "PointValue"))
+        )
+
+        //then
+        val actualEvent = JSONUtils.asStreamsTransactionEvent(cdcMap)
+        val actualPointValue = actualEvent.payload.after?.properties?.get("location")
+        assertEquals(expectedPointValue, actualPointValue)
+    }
+
+    @Test
+    fun `should convert cdcString wgs2D with height null to PointValue`() {
+        // given
+        val timestamp = System.currentTimeMillis()
+        val expectedPointValue = Values.point(4326, 12.78, 56.7)
+
+        //when
+        val cdcString = """{
+            |"meta":{"timestamp":$timestamp,"username":"user","txId":1,"txEventId":0,"txEventsCount":1,"operation":"created"},
+            |"payload":{"id":"0","before":null,"after":{"properties":{"location":{"crs":"wgs-84","longitude":12.78,"latitude":56.7,"height":null}},
+            |"labels":["LabelCDC"]},"type":"node"},
+            |"schema":{"properties":{"location":"PointValue"}}
+            |}""".trimMargin()
+
+        //then
+        val actualEvent = JSONUtils.asStreamsTransactionEvent(cdcString)
+        val actualPointValue = actualEvent.payload.after?.properties?.get("location")
+        assertEquals(expectedPointValue, actualPointValue)
+    }
+
+    @Test
+    fun `should convert cdcString cartesian2D with z null to PointValue`() {
+        // given
+        val timestamp = System.currentTimeMillis()
+        val expectedPointValue = Values.point(7203, 12.78, 56.7)
+
+        //when
+        val cdcString = """{
+            |"meta":{"timestamp":$timestamp,"username":"user","txId":1,"txEventId":0,"txEventsCount":1,"operation":"created"},
+            |"payload":{"id":"0","before":null,"after":{"properties":{"location":{"crs":"cartesian","x":12.78,"y":56.7,"z":null}},
+            |"labels":["LabelCDC"]},"type":"node"},
+            |"schema":{"properties":{"location":"PointValue"}}
+            |}""".trimMargin()
+
+        //then
+        val actualEvent = JSONUtils.asStreamsTransactionEvent(cdcString)
+        val actualPointValue = actualEvent.payload.after?.properties?.get("location")
+        assertEquals(expectedPointValue, actualPointValue)
+    }
+
+    @Test
+    fun `should convert cdcMap cartesian2D with z null to PointValue`() {
+        // given
+        val timestamp = System.currentTimeMillis()
+        val expectedPointValue = Values.point(7203, 12.78, 56.7)
+
+        //when
+        val cdcMap = mapOf<String, Any>(
+            "meta" to mapOf("timestamp" to timestamp,
+                "username" to "user",
+                "txId" to 1,
+                "txEventId" to 0,
+                "txEventsCount" to 1,
+                "operation" to OperationType.created),
+            "payload" to mapOf("id" to "0",
+                "before" to null,
+                "after" to NodeChange(properties = mapOf("location" to mapOf("crs" to "cartesian", "x" to 12.78, "y" to 56.7, "z" to null)),
+                    labels = listOf("LabelCDC")),
+                "type" to EntityType.node),
+            "schema" to mapOf("properties" to mapOf("location" to "PointValue"))
+        )
+
+        //then
+        val actualEvent = JSONUtils.asStreamsTransactionEvent(cdcMap)
+        val actualPointValue = actualEvent.payload.after?.properties?.get("location")
+        assertEquals(expectedPointValue, actualPointValue)
     }
 
     @Test


### PR DESCRIPTION
Different construction methods added for 2D and 3D point data types to get rid of null value generation in serialization.
