### PR TITLE
fix: latitude and longitude mapping issue

### DIFF
--- a/common/src/main/kotlin/streams/utils/JSONUtils.kt
+++ b/common/src/main/kotlin/streams/utils/JSONUtils.kt
@@ -40,8 +40,8 @@ import kotlin.reflect.full.isSubclassOf
 abstract class StreamsPoint { abstract val crs: String }
 data class StreamsPointCartesian2D(override val crs: String, val x: Double, val y: Double): StreamsPoint()
 data class StreamsPointCartesian3D(override val crs: String, val x: Double, val y: Double, val z: Double): StreamsPoint()
-data class StreamsPointWgs2D(override val crs: String, val latitude: Double, val longitude: Double): StreamsPoint()
-data class StreamsPointWgs3D(override val crs: String, val latitude: Double, val longitude: Double, val height: Double): StreamsPoint()
+data class StreamsPointWgs2D(override val crs: String, val longitude: Double, val latitude: Double): StreamsPoint()
+data class StreamsPointWgs3D(override val crs: String, val longitude: Double, val latitude: Double, val height: Double): StreamsPoint()
 
 fun Point.toStreamsPoint(): StreamsPoint {
     val crsType = this.crs.type

--- a/common/src/test/kotlin/streams/utils/JSONUtilsTest.kt
+++ b/common/src/test/kotlin/streams/utils/JSONUtilsTest.kt
@@ -28,8 +28,8 @@ class JSONUtilsTest {
         // Given
         val expected = "{\"point2dCartesian\":{\"crs\":\"cartesian\",\"x\":1.0,\"y\":2.0}," +
                 "\"point3dCartesian\":{\"crs\":\"cartesian-3d\",\"x\":1.0,\"y\":2.0,\"z\":3.0}," +
-                "\"point2dWgs84\":{\"crs\":\"wgs-84\",\"latitude\":1.0,\"longitude\":2.0}," +
-                "\"point3dWgs84\":{\"crs\":\"wgs-84-3d\",\"latitude\":1.0,\"longitude\":2.0,\"height\":3.0}," +
+                "\"point2dWgs84\":{\"crs\":\"wgs-84\",\"longitude\":1.0,\"latitude\":2.0}," +
+                "\"point3dWgs84\":{\"crs\":\"wgs-84-3d\",\"longitude\":1.0,\"latitude\":2.0,\"height\":3.0}," +
                 "\"time\":\"14:00:00Z\",\"dateTime\":\"2017-12-17T17:14:35.123456789Z\"}"
         val map = linkedMapOf<String, Any>("point2dCartesian" to pointValue(Cartesian, 1.0, 2.0),
                 "point3dCartesian" to pointValue(Cartesian_3D, 1.0, 2.0, 3.0),
@@ -50,8 +50,8 @@ class JSONUtilsTest {
         // Given
         val expected = "{\"point2dCartesian\":{\"crs\":\"cartesian\",\"x\":1.0,\"y\":2.0}," +
                 "\"point3dCartesian\":{\"crs\":\"cartesian-3d\",\"x\":1.0,\"y\":2.0,\"z\":3.0}," +
-                "\"point2dWgs84\":{\"crs\":\"wgs-84\",\"latitude\":1.0,\"longitude\":2.0}," +
-                "\"point3dWgs84\":{\"crs\":\"wgs-84-3d\",\"latitude\":1.0,\"longitude\":2.0,\"height\":3.0}," +
+                "\"point2dWgs84\":{\"crs\":\"wgs-84\",\"longitude\":1.0,\"latitude\":2.0}," +
+                "\"point3dWgs84\":{\"crs\":\"wgs-84-3d\",\"longitude\":1.0,\"latitude\":2.0,\"height\":3.0}," +
                 "\"time\":\"14:00:00Z\",\"dateTime\":\"2017-12-17T17:14:35.123456789Z\"}"
         val map = linkedMapOf<String, Any>("point2dCartesian" to pointValue(Cartesian, 1.0, 2.0),
                 "point3dCartesian" to Values.point(Cartesian_3D.code, 1.0, 2.0, 3.0),


### PR DESCRIPTION
Fixes #<Replace with the number of the issue, Mandatory>

According to neo4j [PointValue document](https://neo4j.com/docs/cypher-manual/4.4/values-and-types/spatial/#spatial-values-spatial-instants), x represent longitude and y represent latitude  

## Proposed Changes (Mandatory)

Change the mapping of latitude and longitude

  -
  -
  -
