### PR TITLE
fix: latitude and longitude mapping issue for version 5.0

### DIFF
--- a/common/src/main/kotlin/streams/utils/JSONUtils.kt
+++ b/common/src/main/kotlin/streams/utils/JSONUtils.kt
@@ -40,8 +40,8 @@ import kotlin.reflect.full.isSubclassOf
 abstract class StreamsPoint { abstract val crs: String }
 data class StreamsPointCartesian2D(override val crs: String, val x: Double, val y: Double): StreamsPoint()
 data class StreamsPointCartesian3D(override val crs: String, val x: Double, val y: Double, val z: Double? = null): StreamsPoint()
-data class StreamsPointWgs2D(override val crs: String, val latitude: Double, val longitude: Double): StreamsPoint()
-data class StreamsPointWgs3D(override val crs: String, val latitude: Double, val longitude: Double, val height: Double? = null): StreamsPoint()
+data class StreamsPointWgs2D(override val crs: String, val longitude: Double, val latitude: Double): StreamsPoint()
+data class StreamsPointWgs3D(override val crs: String, val longitude: Double, val latitude: Double, val height: Double? = null): StreamsPoint()
 
 fun PointValue.toStreamsPoint(): StreamsPoint {
     val point = this.asPoint()

--- a/common/src/test/kotlin/streams/utils/JSONUtilsTest.kt
+++ b/common/src/test/kotlin/streams/utils/JSONUtilsTest.kt
@@ -26,8 +26,8 @@ class JSONUtilsTest {
         // Given
         val expected = "{\"point2dCartesian\":{\"crs\":\"cartesian\",\"x\":1.0,\"y\":2.0}," +
                 "\"point3dCartesian\":{\"crs\":\"cartesian-3d\",\"x\":1.0,\"y\":2.0,\"z\":3.0}," +
-                "\"point2dWgs84\":{\"crs\":\"wgs-84\",\"latitude\":1.0,\"longitude\":2.0}," +
-                "\"point3dWgs84\":{\"crs\":\"wgs-84-3d\",\"latitude\":1.0,\"longitude\":2.0,\"height\":3.0}," +
+                "\"point2dWgs84\":{\"crs\":\"wgs-84\",\"longitude\":1.0,\"latitude\":2.0}," +
+                "\"point3dWgs84\":{\"crs\":\"wgs-84-3d\",\"longitude\":1.0,\"latitude\":2.0,\"height\":3.0}," +
                 "\"time\":\"14:01:01.000000001Z\",\"dateTime\":\"2017-12-17T17:14:35.123456789Z\"}"
 
         val map = linkedMapOf<String, Any>("point2dCartesian" to Values.point(Cartesian.code, 1.0, 2.0),


### PR DESCRIPTION
According to neo4j [PointValue document](https://neo4j.com/docs/cypher-manual/4.4/values-and-types/spatial/#spatial-values-spatial-instants), x represent longitude and y represent latitude

Change the mapping of latitude and longitude