### PR TITLE
feat: Add connector configuration migrator for 5.1

### DIFF
--- a/kafka-connect-neo4j/src/main/kotlin/streams/kafka/connect/common/ConfigurationMigrator.kt
+++ b/kafka-connect-neo4j/src/main/kotlin/streams/kafka/connect/common/ConfigurationMigrator.kt
@@ -1,0 +1,152 @@
+package streams.kafka.connect.common
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import streams.kafka.connect.common.Neo4jConnectorConfig.Companion.AUTHENTICATION_BASIC_PASSWORD
+import streams.kafka.connect.common.Neo4jConnectorConfig.Companion.AUTHENTICATION_BASIC_REALM
+import streams.kafka.connect.common.Neo4jConnectorConfig.Companion.AUTHENTICATION_BASIC_USERNAME
+import streams.kafka.connect.common.Neo4jConnectorConfig.Companion.AUTHENTICATION_KERBEROS_TICKET
+import streams.kafka.connect.common.Neo4jConnectorConfig.Companion.AUTHENTICATION_TYPE
+import streams.kafka.connect.common.Neo4jConnectorConfig.Companion.BATCH_SIZE
+import streams.kafka.connect.common.Neo4jConnectorConfig.Companion.BATCH_TIMEOUT_MSECS
+import streams.kafka.connect.common.Neo4jConnectorConfig.Companion.CONNECTION_LIVENESS_CHECK_TIMEOUT_MSECS
+import streams.kafka.connect.common.Neo4jConnectorConfig.Companion.CONNECTION_MAX_CONNECTION_ACQUISITION_TIMEOUT_MSECS
+import streams.kafka.connect.common.Neo4jConnectorConfig.Companion.CONNECTION_MAX_CONNECTION_LIFETIME_MSECS
+import streams.kafka.connect.common.Neo4jConnectorConfig.Companion.CONNECTION_POOL_MAX_SIZE
+import streams.kafka.connect.common.Neo4jConnectorConfig.Companion.DATABASE
+import streams.kafka.connect.common.Neo4jConnectorConfig.Companion.ENCRYPTION_CA_CERTIFICATE_PATH
+import streams.kafka.connect.common.Neo4jConnectorConfig.Companion.ENCRYPTION_ENABLED
+import streams.kafka.connect.common.Neo4jConnectorConfig.Companion.ENCRYPTION_TRUST_STRATEGY
+import streams.kafka.connect.common.Neo4jConnectorConfig.Companion.RETRY_BACKOFF_MSECS
+import streams.kafka.connect.common.Neo4jConnectorConfig.Companion.RETRY_MAX_ATTEMPTS
+import streams.kafka.connect.common.Neo4jConnectorConfig.Companion.SERVER_URI
+import streams.kafka.connect.sink.Neo4jSinkConnectorConfig
+import streams.kafka.connect.sink.Neo4jSinkConnectorConfig.Companion.BATCH_PARALLELIZE
+import streams.kafka.connect.sink.Neo4jSinkConnectorConfig.Companion.TOPIC_CDC_SCHEMA
+import streams.kafka.connect.sink.Neo4jSinkConnectorConfig.Companion.TOPIC_CDC_SOURCE_ID
+import streams.kafka.connect.sink.Neo4jSinkConnectorConfig.Companion.TOPIC_CDC_SOURCE_ID_ID_NAME
+import streams.kafka.connect.sink.Neo4jSinkConnectorConfig.Companion.TOPIC_CDC_SOURCE_ID_LABEL_NAME
+import streams.kafka.connect.sink.Neo4jSinkConnectorConfig.Companion.TOPIC_CUD
+import streams.kafka.connect.sink.Neo4jSinkConnectorConfig.Companion.TOPIC_PATTERN_MERGE_NODE_PROPERTIES_ENABLED
+import streams.kafka.connect.sink.Neo4jSinkConnectorConfig.Companion.TOPIC_PATTERN_MERGE_RELATIONSHIP_PROPERTIES_ENABLED
+import streams.kafka.connect.source.Neo4jSourceConnectorConfig.Companion.ENFORCE_SCHEMA
+import streams.kafka.connect.source.Neo4jSourceConnectorConfig.Companion.SOURCE_TYPE
+import streams.kafka.connect.source.Neo4jSourceConnectorConfig.Companion.SOURCE_TYPE_QUERY
+import streams.kafka.connect.source.Neo4jSourceConnectorConfig.Companion.STREAMING_FROM
+import streams.kafka.connect.source.Neo4jSourceConnectorConfig.Companion.STREAMING_POLL_INTERVAL
+import streams.kafka.connect.source.Neo4jSourceConnectorConfig.Companion.STREAMING_PROPERTY
+import streams.kafka.connect.source.Neo4jSourceConnectorConfig.Companion.TOPIC
+
+/**
+ * Configuration migrator
+ *
+ * @property settings
+ * @constructor Create empty Configuration migrator
+ */
+class ConfigurationMigrator(private val settings: Map<String, String>) {
+
+    private val log: Logger = LoggerFactory.getLogger(ConfigurationMigrator::class.java)
+
+    /**
+     * Property converter
+     *
+     * @property updatedConfigKey - v5.1 configuration key
+     * @property migrationHandler - Value migration handler
+     */
+    data class PropertyConverter(val updatedConfigKey: String, val migrationHandler: () -> String)
+
+    private val propertyConverterMap: Map<String, PropertyConverter> = mutableMapOf(
+        // Common
+        DATABASE to PropertyConverter("neo4j.database") { settings[DATABASE] as String },
+        SERVER_URI to PropertyConverter("neo4j.uri") { settings[SERVER_URI] as String },
+        AUTHENTICATION_TYPE to PropertyConverter("neo4j.authentication.type") { settings[AUTHENTICATION_TYPE] as String },
+        AUTHENTICATION_BASIC_USERNAME to PropertyConverter("neo4j.authentication.basic.username") {settings[AUTHENTICATION_BASIC_USERNAME] as String},
+        AUTHENTICATION_BASIC_PASSWORD to PropertyConverter("neo4j.authentication.basic.password") {settings[AUTHENTICATION_BASIC_PASSWORD] as String},
+        AUTHENTICATION_BASIC_REALM to PropertyConverter("neo4j.authentication.basic.realm") {settings[AUTHENTICATION_BASIC_REALM] as String},
+        AUTHENTICATION_KERBEROS_TICKET to PropertyConverter("neo4j.authentication.kerberos.ticket") {settings[AUTHENTICATION_KERBEROS_TICKET] as String},
+        BATCH_SIZE to PropertyConverter("neo4j.batch-size") {settings[BATCH_SIZE] as String},
+        ENCRYPTION_ENABLED to PropertyConverter("neo4j.security.encrypted") {settings[ENCRYPTION_ENABLED] as String},
+        ENCRYPTION_TRUST_STRATEGY to PropertyConverter("neo4j.security.trust-strategy") {settings[ENCRYPTION_TRUST_STRATEGY] as String},
+        ENCRYPTION_CA_CERTIFICATE_PATH to PropertyConverter("") {settings[ENCRYPTION_CA_CERTIFICATE_PATH] as String},
+        CONNECTION_MAX_CONNECTION_LIFETIME_MSECS to PropertyConverter("neo4j.connection-timeout") { convertMsecs(settings[CONNECTION_MAX_CONNECTION_LIFETIME_MSECS] as String) },
+        CONNECTION_MAX_CONNECTION_ACQUISITION_TIMEOUT_MSECS to PropertyConverter("neo4j.pool.connection-acquisition-timeout") { convertMsecs(settings[CONNECTION_MAX_CONNECTION_ACQUISITION_TIMEOUT_MSECS] as String) },
+        CONNECTION_LIVENESS_CHECK_TIMEOUT_MSECS to PropertyConverter("neo4j.pool.idle-time-before-connection-test") { convertMsecs(settings[CONNECTION_LIVENESS_CHECK_TIMEOUT_MSECS] as String) },
+        CONNECTION_POOL_MAX_SIZE to PropertyConverter("neo4j.pool.max-connection-pool-size") {settings[CONNECTION_POOL_MAX_SIZE] as String},
+        RETRY_BACKOFF_MSECS to PropertyConverter("neo4j.max-retry-time") { convertMsecs(settings[RETRY_BACKOFF_MSECS] as String) },
+        RETRY_MAX_ATTEMPTS to PropertyConverter("neo4j.max-retry-attempts") {settings[RETRY_MAX_ATTEMPTS] as String},
+        // Sink
+        TOPIC_CDC_SOURCE_ID to PropertyConverter("neo4j.cdc.source-id.topics") {settings[TOPIC_CDC_SOURCE_ID] as String},
+        TOPIC_CDC_SOURCE_ID_LABEL_NAME to PropertyConverter("neo4j.cdc.source-id.label-name") {settings[TOPIC_CDC_SOURCE_ID_LABEL_NAME] as String},
+        TOPIC_CDC_SOURCE_ID_ID_NAME to PropertyConverter("neo4j.cdc.source-id.property-name") {settings[TOPIC_CDC_SOURCE_ID_ID_NAME] as String},
+        TOPIC_CDC_SCHEMA to PropertyConverter("neo4j.cdc.schema.topics") {settings[TOPIC_CDC_SCHEMA] as String},
+        BATCH_PARALLELIZE to PropertyConverter("") {settings[BATCH_PARALLELIZE] as String},
+        TOPIC_CUD to PropertyConverter("neo4j.cud.topics") {settings[TOPIC_CUD] as String},
+        TOPIC_PATTERN_MERGE_NODE_PROPERTIES_ENABLED to PropertyConverter("neo4j.pattern.node.merge-properties") {settings[TOPIC_PATTERN_MERGE_NODE_PROPERTIES_ENABLED] as String},
+        TOPIC_PATTERN_MERGE_RELATIONSHIP_PROPERTIES_ENABLED to PropertyConverter("neo4j.pattern.relationship.merge-properties") {settings[TOPIC_PATTERN_MERGE_RELATIONSHIP_PROPERTIES_ENABLED] as String},
+        // Source
+        BATCH_TIMEOUT_MSECS to PropertyConverter("neo4j.batch-timeout") { convertMsecs(settings[BATCH_TIMEOUT_MSECS] as String) },
+        TOPIC to PropertyConverter("neo4j.query.topic") {settings[TOPIC] as String},
+        STREAMING_FROM to PropertyConverter("") {settings[STREAMING_FROM] as String},
+        SOURCE_TYPE to PropertyConverter("") {settings[SOURCE_TYPE] as String},
+        SOURCE_TYPE_QUERY to PropertyConverter("neo4j.query") {settings[SOURCE_TYPE_QUERY] as String},
+        STREAMING_PROPERTY to PropertyConverter("neo4j.query.streaming-property") {settings[STREAMING_PROPERTY] as String},
+        STREAMING_POLL_INTERVAL to PropertyConverter("neo4j.query.poll-interval") { convertMsecs(settings[STREAMING_POLL_INTERVAL] as String) },
+        ENFORCE_SCHEMA to PropertyConverter("") {settings[ENFORCE_SCHEMA] as String}
+    )
+
+    // Configuration properties that have user-defined keys
+    private val prefixConverterMap: Map<String, String> = mutableMapOf(
+        Neo4jSinkConnectorConfig.TOPIC_PATTERN_NODE_PREFIX to "neo4j.pattern.node.topic.",
+        Neo4jSinkConnectorConfig.TOPIC_PATTERN_RELATIONSHIP_PREFIX to "neo4j.pattern.relationship.topic.",
+        Neo4jSinkConnectorConfig.TOPIC_CYPHER_PREFIX to "neo4j.cypher.topic."
+    )
+
+    /**
+     * Migrate configuration keys from existing format to v5.1 connector format.
+     * Configuration properties containing msecs units are converted to new format.
+     *
+     * @return updated configuration key-value pairs
+     */
+    fun migrate(): Map<String, Any> {
+        val updatedConfig: MutableMap<String, String> = mutableMapOf()
+
+        settings.forEach { (originalKey, value) ->
+            val propConverter = propertyConverterMap[originalKey]
+            if (propConverter != null) {
+                val newKey = propConverter.updatedConfigKey
+                updatedConfig[newKey] = propConverter.migrationHandler()
+                log.debug("Migrating configuration {} to {}", originalKey, newKey)
+            } else {
+                // prefix match?
+                val prefixMatch = prefixConverterMap.keys.find { k -> originalKey.startsWith(k) }
+                prefixMatch?.let { prefix ->
+                    val replacement = prefixConverterMap[prefixMatch]
+                    replacement?.let { repl ->
+                        val newKey = originalKey.replace(prefix, repl)
+                        updatedConfig[newKey] = value
+                        log.debug("Migrating configuration prefix key {} to {}", originalKey, newKey)
+                    }
+                }
+            }
+        }
+
+        outputToLog(updatedConfig)
+
+        return updatedConfig
+    }
+
+    private fun outputToLog(config: Map<String, Any>) {
+        val mapper = ObjectMapper()
+        val json = mapper.writeValueAsString(config)
+        log.info("Migrated configuration to v5.1 connector format: {}", json)
+    }
+
+    companion object {
+        private fun convertMsecs(msecs: String): String {
+            return "${msecs}ms"
+        }
+    }
+
+}
+

--- a/kafka-connect-neo4j/src/main/kotlin/streams/kafka/connect/common/ConfigurationMigrator.kt
+++ b/kafka-connect-neo4j/src/main/kotlin/streams/kafka/connect/common/ConfigurationMigrator.kt
@@ -1,6 +1,5 @@
 package streams.kafka.connect.common
 
-import com.fasterxml.jackson.databind.ObjectMapper
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import streams.kafka.connect.common.Neo4jConnectorConfig.Companion.AUTHENTICATION_BASIC_PASSWORD
@@ -109,7 +108,7 @@ class ConfigurationMigrator(private val settings: Map<String, String>) {
      *
      * @return updated configuration key-value pairs
      */
-    fun migrate(): Map<String, Any> {
+    fun migrateToV51(): Map<String, Any> {
         val updatedConfig: MutableMap<String, String> = mutableMapOf()
 
         settings.forEach { (originalKey, value) ->

--- a/kafka-connect-neo4j/src/main/kotlin/streams/kafka/connect/common/ConfigurationMigrator.kt
+++ b/kafka-connect-neo4j/src/main/kotlin/streams/kafka/connect/common/ConfigurationMigrator.kt
@@ -135,15 +135,7 @@ class ConfigurationMigrator(private val settings: Map<String, String>) {
             }
         }
 
-        outputToLog(updatedConfig)
-
         return updatedConfig
-    }
-
-    private fun outputToLog(config: Map<String, Any>) {
-        val mapper = ObjectMapper()
-        val json = mapper.writeValueAsString(config)
-        log.info("Migrated configuration to v5.1 connector format: {}", json)
     }
 
     companion object {

--- a/kafka-connect-neo4j/src/main/kotlin/streams/kafka/connect/common/ConfigurationMigrator.kt
+++ b/kafka-connect-neo4j/src/main/kotlin/streams/kafka/connect/common/ConfigurationMigrator.kt
@@ -113,7 +113,7 @@ class ConfigurationMigrator(private val settings: Map<String, String>) {
 
         settings.forEach { (originalKey, value) ->
             val propConverter = propertyConverterMap[originalKey]
-            if (propConverter != null) {
+            if (propConverter != null && propConverter.updatedConfigKey.isNotEmpty()) {
                 val newKey = propConverter.updatedConfigKey
                 updatedConfig[newKey] = propConverter.migrationHandler()
                 log.debug("Migrating configuration {} to {}", originalKey, newKey)

--- a/kafka-connect-neo4j/src/main/kotlin/streams/kafka/connect/sink/Neo4jSinkConnector.kt
+++ b/kafka-connect-neo4j/src/main/kotlin/streams/kafka/connect/sink/Neo4jSinkConnector.kt
@@ -33,7 +33,7 @@ class Neo4jSinkConnector: SinkConnector() {
     }
 
     override fun stop() {
-        val migratedConfig = ConfigurationMigrator(settings).migrate()
+        val migratedConfig = ConfigurationMigrator(settings).migrateToV51()
         val mapper = ObjectMapper()
         val jsonConfig = mapper.writeValueAsString(migratedConfig)
         log.info("Migrated Sink configuration to v5.1 connector format: {}", jsonConfig)

--- a/kafka-connect-neo4j/src/main/kotlin/streams/kafka/connect/sink/Neo4jSinkConnector.kt
+++ b/kafka-connect-neo4j/src/main/kotlin/streams/kafka/connect/sink/Neo4jSinkConnector.kt
@@ -1,10 +1,14 @@
 package streams.kafka.connect.sink
 
-import com.github.jcustenborder.kafka.connect.utils.config.*
+import com.github.jcustenborder.kafka.connect.utils.config.Description
+import com.github.jcustenborder.kafka.connect.utils.config.DocumentationNote
+import com.github.jcustenborder.kafka.connect.utils.config.DocumentationTip
+import com.github.jcustenborder.kafka.connect.utils.config.TaskConfigs
+import com.github.jcustenborder.kafka.connect.utils.config.Title
 import org.apache.kafka.common.config.ConfigDef
 import org.apache.kafka.connect.connector.Task
 import org.apache.kafka.connect.sink.SinkConnector
-import org.slf4j.LoggerFactory
+import streams.kafka.connect.common.ConfigurationMigrator
 import streams.kafka.connect.utils.PropertiesUtil
 
 @Title("Neo4j Sink Connector")
@@ -23,7 +27,9 @@ class Neo4jSinkConnector: SinkConnector() {
         config = Neo4jSinkConnectorConfig(settings)
     }
 
-    override fun stop() {}
+    override fun stop() {
+        ConfigurationMigrator(settings).migrate()
+    }
 
     override fun version(): String {
         return PropertiesUtil.getVersion()

--- a/kafka-connect-neo4j/src/main/kotlin/streams/kafka/connect/source/Neo4jSourceConnector.kt
+++ b/kafka-connect-neo4j/src/main/kotlin/streams/kafka/connect/source/Neo4jSourceConnector.kt
@@ -1,13 +1,11 @@
 package streams.kafka.connect.source
 
-import com.github.jcustenborder.kafka.connect.utils.config.*
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.launch
+import com.github.jcustenborder.kafka.connect.utils.config.Description
+import com.github.jcustenborder.kafka.connect.utils.config.Title
 import org.apache.kafka.common.config.ConfigDef
 import org.apache.kafka.connect.connector.Task
 import org.apache.kafka.connect.source.SourceConnector
+import streams.kafka.connect.common.ConfigurationMigrator
 import streams.kafka.connect.utils.PropertiesUtil
 
 @Title("Neo4j Source Connector")
@@ -27,7 +25,9 @@ class Neo4jSourceConnector: SourceConnector() {
         config = Neo4jSourceConnectorConfig(settings)
     }
 
-    override fun stop() {}
+    override fun stop() {
+        ConfigurationMigrator(settings).migrate()
+    }
 
     override fun version(): String = PropertiesUtil.getVersion()
 

--- a/kafka-connect-neo4j/src/main/kotlin/streams/kafka/connect/source/Neo4jSourceConnector.kt
+++ b/kafka-connect-neo4j/src/main/kotlin/streams/kafka/connect/source/Neo4jSourceConnector.kt
@@ -5,7 +5,6 @@ import com.github.jcustenborder.kafka.connect.utils.config.Title
 import org.apache.kafka.common.config.ConfigDef
 import org.apache.kafka.connect.connector.Task
 import org.apache.kafka.connect.source.SourceConnector
-import streams.kafka.connect.common.ConfigurationMigrator
 import streams.kafka.connect.utils.PropertiesUtil
 
 @Title("Neo4j Source Connector")
@@ -25,9 +24,7 @@ class Neo4jSourceConnector: SourceConnector() {
         config = Neo4jSourceConnectorConfig(settings)
     }
 
-    override fun stop() {
-        ConfigurationMigrator(settings).migrate()
-    }
+    override fun stop() {}
 
     override fun version(): String = PropertiesUtil.getVersion()
 

--- a/kafka-connect-neo4j/src/main/kotlin/streams/kafka/connect/source/Neo4jSourceService.kt
+++ b/kafka-connect-neo4j/src/main/kotlin/streams/kafka/connect/source/Neo4jSourceService.kt
@@ -175,8 +175,12 @@ class Neo4jSourceService(private val config: Neo4jSourceConnectorConfig, offsetS
             log.info("Error while closing Driver instance:", it)
         }
 
-        val migratedConfig = ConfigurationMigrator(config.originals() as Map<String, String>).migrate()
-        // offset
+        val migratedConfig = ConfigurationMigrator(config.originals() as Map<String, String>).migrate().toMutableMap()
+
+        log.debug("Defaulting v5.1 migrated configuration offset to last checked timestamp: {}", lastCheck)
+        migratedConfig["neo4j.start-from"] = "USER_PROVIDED"
+        migratedConfig["neo4j.start-from.value"] = lastCheck
+
         val mapper = ObjectMapper()
         val jsonConfig = mapper.writeValueAsString(migratedConfig)
         log.info("Migrated Source configuration to v5.1 connector format: {}", jsonConfig)

--- a/kafka-connect-neo4j/src/main/kotlin/streams/kafka/connect/source/Neo4jSourceService.kt
+++ b/kafka-connect-neo4j/src/main/kotlin/streams/kafka/connect/source/Neo4jSourceService.kt
@@ -175,7 +175,7 @@ class Neo4jSourceService(private val config: Neo4jSourceConnectorConfig, offsetS
             log.info("Error while closing Driver instance:", it)
         }
 
-        val migratedConfig = ConfigurationMigrator(config.originals() as Map<String, String>).migrate().toMutableMap()
+        val migratedConfig = ConfigurationMigrator(config.originals() as Map<String, String>).migrateToV51().toMutableMap()
 
         log.debug("Defaulting v5.1 migrated configuration offset to last checked timestamp: {}", lastCheck)
         migratedConfig["neo4j.start-from"] = "USER_PROVIDED"

--- a/kafka-connect-neo4j/src/test/kotlin/streams/kafka/connect/common/ConfigurationMigratorTest.kt
+++ b/kafka-connect-neo4j/src/test/kotlin/streams/kafka/connect/common/ConfigurationMigratorTest.kt
@@ -43,7 +43,7 @@ class ConfigurationMigratorTest {
   @Test
   fun `should migrate time-based keys to new configuration format`() {
     // Given a configuration originally defined in milliseconds
-    var originals = mapOf(
+    val originals = mapOf(
       "neo4j.retry.backoff.msecs" to "1200",
       "neo4j.connection.max.lifetime.msecs" to "1000",
       "neo4j.batch.timeout.msecs" to "500",

--- a/kafka-connect-neo4j/src/test/kotlin/streams/kafka/connect/common/ConfigurationMigratorTest.kt
+++ b/kafka-connect-neo4j/src/test/kotlin/streams/kafka/connect/common/ConfigurationMigratorTest.kt
@@ -1,8 +1,7 @@
-package streams.kafka.connect.sink
+package streams.kafka.connect.common
 
 import org.junit.Assert.assertEquals
 import org.junit.Test
-import streams.kafka.connect.common.ConfigurationMigrator
 import streams.kafka.connect.source.SourceType
 
 class ConfigurationMigratorTest {

--- a/kafka-connect-neo4j/src/test/kotlin/streams/kafka/connect/common/ConfigurationMigratorTest.kt
+++ b/kafka-connect-neo4j/src/test/kotlin/streams/kafka/connect/common/ConfigurationMigratorTest.kt
@@ -1,8 +1,12 @@
 package streams.kafka.connect.common
 
+import com.fasterxml.jackson.core.type.TypeReference
+import com.fasterxml.jackson.databind.ObjectMapper
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import streams.kafka.connect.source.SourceType
+import java.io.File
+
 
 class ConfigurationMigratorTest {
 
@@ -37,7 +41,7 @@ class ConfigurationMigratorTest {
     val migratedConfig = ConfigurationMigrator(originals).migrate()
 
     // Then the existing key is not outputted
-    assertEquals("Migrated configuration should be empty", 0, migratedConfig.keys.size)
+    assertEquals("Migrated configuration should be empty", 0, migratedConfig.size)
   }
 
   @Test
@@ -82,4 +86,93 @@ class ConfigurationMigratorTest {
       "(:Bar{!barId,barName})",
     )
   }
+
+  @Test
+  fun `should migrate across unknown configuration options`() {
+    // Given a configuration with non-defined configuration options
+    val originals = mapOf(
+      "connector.class" to "streams.kafka.connect.source.Neo4jSourceConnector",
+      "key.converter" to "io.confluent.connect.avro.AvroConverter",
+      "arbitrary.config.key" to "arbitrary.value"
+    )
+
+    // When the configuration is migrated
+    val migratedConfig = ConfigurationMigrator(originals).migrate()
+
+    // Then those options should still be included
+    assertEquals(migratedConfig["connector.class"], "streams.kafka.connect.source.Neo4jSourceConnector")
+    assertEquals(migratedConfig["key.converter"], "io.confluent.connect.avro.AvroConverter")
+    assertEquals(migratedConfig["arbitrary.config.key"], "arbitrary.value")
+  }
+
+  @Test
+  fun `should migrate keys from full source quickstart configuration example`() {
+    // Given the configuration from the quickstart example
+    val quickstartSettings = loadConfiguration("src/test/resources/exampleConfigs/sourceExample.json")
+
+    // When the configuration is migrated
+    val migratedConfig = ConfigurationMigrator(quickstartSettings).migrate()
+
+    // Then the keys are updated correctly
+    assertEquals(12, migratedConfig.size)
+
+    assertEquals(migratedConfig["neo4j.query.topic"], "my-topic")
+    assertEquals(migratedConfig["connector.class"], "streams.kafka.connect.source.Neo4jSourceConnector")
+    assertEquals(migratedConfig["key.converter"], "io.confluent.connect.avro.AvroConverter")
+    assertEquals(migratedConfig["key.converter.schema.registry.url"], "http://schema-registry:8081")
+    assertEquals(migratedConfig["value.converter"], "io.confluent.connect.avro.AvroConverter")
+    assertEquals(migratedConfig["value.converter.schema.registry.url"], "http://schema-registry:8081")
+    assertEquals(migratedConfig["neo4j.uri"], "bolt://neo4j:7687")
+    assertEquals(migratedConfig["neo4j.authentication.basic.username"], "neo4j")
+    assertEquals(migratedConfig["neo4j.authentication.basic.password"], "password")
+    assertEquals(migratedConfig["neo4j.query.poll-interval"], "5000ms")
+    assertEquals(migratedConfig["neo4j.query.streaming-property"], "timestamp")
+    assertEquals(
+      migratedConfig["neo4j.query"],
+      "MATCH (ts:TestSource) WHERE ts.timestamp > \$lastCheck RETURN ts.name AS name, ts.surname AS surname, ts.timestamp AS timestamp"
+    )
+
+    assertEquals(migratedConfig["neo4j.enforce.schema"], null)
+    assertEquals(migratedConfig["neo4j.streaming.from"], null)
+  }
+
+  @Test
+  fun `should migrate keys from full sink quickstart configuration example`() {
+    // Given the configuration from the quickstart example
+    val quickstartSettings = loadConfiguration("src/test/resources/exampleConfigs/sinkExample.json")
+
+    // When the configuration is migrated
+    val migratedConfig = ConfigurationMigrator(quickstartSettings).migrate()
+
+    // Then the keys are updated correctly
+    assertEquals(15, migratedConfig.size)
+
+    assertEquals(migratedConfig["topics"], "my-topic")
+    assertEquals(migratedConfig["connector.class"], "streams.kafka.connect.sink.Neo4jSinkConnector")
+    assertEquals(migratedConfig["key.converter"], "org.apache.kafka.connect.json.JsonConverter")
+    assertEquals(migratedConfig["key.converter.schemas.enable"], "false")
+    assertEquals(migratedConfig["value.converter"], "org.apache.kafka.connect.json.JsonConverter")
+    assertEquals(migratedConfig["value.converter.schemas.enable"], "false")
+    assertEquals(migratedConfig["errors.retry.timeout"], "-1")
+    assertEquals(migratedConfig["errors.retry.delay.max.ms"], "1000")
+    assertEquals(migratedConfig["errors.tolerance"], "all")
+    assertEquals(migratedConfig["errors.log.enable"], "true")
+    assertEquals(migratedConfig["errors.log.include.messages"], "true")
+    assertEquals(migratedConfig["neo4j.uri"], "bolt://neo4j:7687")
+    assertEquals(migratedConfig["neo4j.authentication.basic.username"], "neo4j")
+    assertEquals(migratedConfig["neo4j.authentication.basic.password"], "password")
+    assertEquals(migratedConfig["neo4j.cypher.topic.my-topic"], "MERGE (p:Person{name: event.name, surname: event.surname}) MERGE (f:Family{name: event.surname}) MERGE (p)-[:BELONGS_TO]->(f)")
+  }
+
+  private fun loadConfiguration(path: String): Map<String, String> {
+    val file = File(path)
+    val json = file.readText()
+
+    val mapper = ObjectMapper()
+    val node = mapper.readTree(json)
+    val config = node.get("config")
+    val result: Map<String?, String?>? = mapper.convertValue(config, object : TypeReference<Map<String?, String?>?>() {})
+    return result as Map<String, String>
+  }
+
 }

--- a/kafka-connect-neo4j/src/test/kotlin/streams/kafka/connect/common/ConfigurationMigratorTest.kt
+++ b/kafka-connect-neo4j/src/test/kotlin/streams/kafka/connect/common/ConfigurationMigratorTest.kt
@@ -21,7 +21,7 @@ class ConfigurationMigratorTest {
       )
 
     // When the configuration is migrated
-    val migratedConfig = ConfigurationMigrator(originals).migrate()
+    val migratedConfig = ConfigurationMigrator(originals).migrateToV51()
 
     // Then the keys are updated to new key format containing the original value
     assertEquals(originals.size, migratedConfig.size)
@@ -39,7 +39,7 @@ class ConfigurationMigratorTest {
     )
 
     // When the configuration is migrated
-    val migratedConfig = ConfigurationMigrator(originals).migrate()
+    val migratedConfig = ConfigurationMigrator(originals).migrateToV51()
 
     // Then the existing key is not outputted
     assertEquals("Migrated configuration should be empty", 0, migratedConfig.size)
@@ -56,7 +56,7 @@ class ConfigurationMigratorTest {
     )
 
     // When the configuration is migrated
-    val migratedConfig = ConfigurationMigrator(originals).migrate()
+    val migratedConfig = ConfigurationMigrator(originals).migrateToV51()
 
     // Then the new configuration should be labelled with its units
     assertEquals(originals.size, migratedConfig.size)
@@ -76,7 +76,7 @@ class ConfigurationMigratorTest {
       )
 
     // When the configuration is migrated
-    val migratedConfig = ConfigurationMigrator(originals).migrate()
+    val migratedConfig = ConfigurationMigrator(originals).migrateToV51()
 
     // Then the keys are updated to new values still containing the user-defined key part
     assertEquals(originals.size, migratedConfig.size)
@@ -100,7 +100,7 @@ class ConfigurationMigratorTest {
     )
 
     // When the configuration is migrated
-    val migratedConfig = ConfigurationMigrator(originals).migrate()
+    val migratedConfig = ConfigurationMigrator(originals).migrateToV51()
 
     // Then those options should still be included
     assertEquals(originals.size, migratedConfig.size)
@@ -115,7 +115,7 @@ class ConfigurationMigratorTest {
     val quickstartSettings = loadConfiguration("src/test/resources/exampleConfigs/sourceExample.json")
 
     // When the configuration is migrated
-    val migratedConfig = ConfigurationMigrator(quickstartSettings).migrate()
+    val migratedConfig = ConfigurationMigrator(quickstartSettings).migrateToV51()
 
     // Then the keys are updated correctly
     assertEquals(12, migratedConfig.size)
@@ -146,7 +146,7 @@ class ConfigurationMigratorTest {
     val quickstartSettings = loadConfiguration("src/test/resources/exampleConfigs/sinkExample.json")
 
     // When the configuration is migrated
-    val migratedConfig = ConfigurationMigrator(quickstartSettings).migrate()
+    val migratedConfig = ConfigurationMigrator(quickstartSettings).migrateToV51()
 
     // Then the keys are updated correctly
     assertEquals(15, migratedConfig.size)

--- a/kafka-connect-neo4j/src/test/kotlin/streams/kafka/connect/common/ConfigurationMigratorTest.kt
+++ b/kafka-connect-neo4j/src/test/kotlin/streams/kafka/connect/common/ConfigurationMigratorTest.kt
@@ -24,6 +24,7 @@ class ConfigurationMigratorTest {
     val migratedConfig = ConfigurationMigrator(originals).migrate()
 
     // Then the keys are updated to new key format containing the original value
+    assertEquals(originals.size, migratedConfig.size)
     assertEquals(migratedConfig["neo4j.pattern.node.merge-properties"], "true")
     assertEquals(migratedConfig["neo4j.uri"], "neo4j+s://x.x.x.x")
     assertEquals(migratedConfig["neo4j.max-retry-attempts"], "1")
@@ -58,6 +59,7 @@ class ConfigurationMigratorTest {
     val migratedConfig = ConfigurationMigrator(originals).migrate()
 
     // Then the new configuration should be labelled with its units
+    assertEquals(originals.size, migratedConfig.size)
     assertEquals(migratedConfig["neo4j.max-retry-time"], "1200ms")
     assertEquals(migratedConfig["neo4j.connection-timeout"], "1000ms")
     assertEquals(migratedConfig["neo4j.batch-timeout"], "500ms")
@@ -77,6 +79,7 @@ class ConfigurationMigratorTest {
     val migratedConfig = ConfigurationMigrator(originals).migrate()
 
     // Then the keys are updated to new values still containing the user-defined key part
+    assertEquals(originals.size, migratedConfig.size)
     assertEquals(
       migratedConfig["neo4j.cypher.topic.foo"],
       "CREATE (p:Person{name: event.firstName})",
@@ -100,6 +103,7 @@ class ConfigurationMigratorTest {
     val migratedConfig = ConfigurationMigrator(originals).migrate()
 
     // Then those options should still be included
+    assertEquals(originals.size, migratedConfig.size)
     assertEquals(migratedConfig["connector.class"], "streams.kafka.connect.source.Neo4jSourceConnector")
     assertEquals(migratedConfig["key.converter"], "io.confluent.connect.avro.AvroConverter")
     assertEquals(migratedConfig["arbitrary.config.key"], "arbitrary.value")

--- a/kafka-connect-neo4j/src/test/kotlin/streams/kafka/connect/sink/ConfigurationMigratorTest.kt
+++ b/kafka-connect-neo4j/src/test/kotlin/streams/kafka/connect/sink/ConfigurationMigratorTest.kt
@@ -3,6 +3,10 @@ package streams.kafka.connect.sink
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import streams.kafka.connect.common.ConfigurationMigrator
+import streams.kafka.connect.common.Neo4jConnectorConfig.Companion.ENCRYPTION_CA_CERTIFICATE_PATH
+import streams.kafka.connect.source.Neo4jSourceConnectorConfig.Companion.ENFORCE_SCHEMA
+import streams.kafka.connect.source.Neo4jSourceConnectorConfig.Companion.SOURCE_TYPE
+import streams.kafka.connect.source.SourceType
 
 class ConfigurationMigratorTest {
 
@@ -27,7 +31,20 @@ class ConfigurationMigratorTest {
     )
   }
 
-  @Test fun `should not migrate keys with no matching configuration key`() {}
+  @Test fun `should not migrate keys with no matching configuration key`() {
+    // Given a configuration which has no equivalent in the updated connector
+    val originals = mapOf(
+      ENCRYPTION_CA_CERTIFICATE_PATH to "./cert.pem",
+      SOURCE_TYPE to SourceType.QUERY.toString(),
+      ENFORCE_SCHEMA to "true"
+    )
+
+    // When the configuration is migrated
+    val migratedConfig = ConfigurationMigrator(originals).migrate()
+
+    // Then the existing key is not outputted
+    assertEquals("Migrated configuration should be empty", 0, migratedConfig.keys.size)
+  }
 
   @Test
   fun `should migrate time-based keys to new configuration format`() {

--- a/kafka-connect-neo4j/src/test/kotlin/streams/kafka/connect/sink/ConfigurationMigratorTest.kt
+++ b/kafka-connect-neo4j/src/test/kotlin/streams/kafka/connect/sink/ConfigurationMigratorTest.kt
@@ -1,0 +1,62 @@
+package streams.kafka.connect.sink
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import streams.kafka.connect.common.ConfigurationMigrator
+
+class ConfigurationMigratorTest {
+
+  @Test
+  fun `should migrate keys to new configuration`() {
+    // Given a configuration containing normal keys
+    val originals =
+      mapOf(
+        "neo4j.topic.pattern.merge.node.properties.enabled" to "true",
+        "${Neo4jSinkConnectorConfig.TOPIC_CYPHER_PREFIX}foo" to
+          "CREATE (p:Person{name: event.firstName})",
+      )
+
+    // When the configuration is migrated
+    val migratedConfig = ConfigurationMigrator(originals).migrate()
+
+    // Then the keys are updated to new key format containing existing value
+    assertEquals(migratedConfig["neo4j.pattern.node.merge-properties"], "true")
+    assertEquals(
+      migratedConfig["neo4j.cypher.topic.foo"],
+      "CREATE (p:Person{name: event.firstName})",
+    )
+  }
+
+  @Test fun `should not migrate keys with no matching configuration key`() {}
+
+  @Test
+  fun `should migrate time-based keys to new configuration format`() {
+    // Given a configuration originally defined in milliseconds
+    var originals = mapOf("neo4j.retry.backoff.msecs" to "1200")
+
+    // When the configuration is migrated
+    val migratedConfig = ConfigurationMigrator(originals).migrate()
+
+    // Then the new configuration should be labelled with its units
+    assertEquals(migratedConfig["neo4j.max-retry-time"], "1200ms")
+  }
+
+  @Test
+  fun `should migrate prefix based keys to new configuration`() {
+    // Given a configuration containing prefix/user-defined keys
+    val originals =
+      mapOf(
+        "${Neo4jSinkConnectorConfig.TOPIC_CYPHER_PREFIX}foo" to
+          "CREATE (p:Person{name: event.firstName})"
+      )
+
+    // When the configuration is migrated
+    val migratedConfig = ConfigurationMigrator(originals).migrate()
+
+    // Then the keys are updated to new values still containing the user-defined key part
+    assertEquals(
+      migratedConfig["neo4j.cypher.topic.foo"],
+      "CREATE (p:Person{name: event.firstName})",
+    )
+  }
+}

--- a/kafka-connect-neo4j/src/test/kotlin/streams/kafka/connect/sink/ConfigurationMigratorTest.kt
+++ b/kafka-connect-neo4j/src/test/kotlin/streams/kafka/connect/sink/ConfigurationMigratorTest.kt
@@ -3,9 +3,6 @@ package streams.kafka.connect.sink
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import streams.kafka.connect.common.ConfigurationMigrator
-import streams.kafka.connect.common.Neo4jConnectorConfig.Companion.ENCRYPTION_CA_CERTIFICATE_PATH
-import streams.kafka.connect.source.Neo4jSourceConnectorConfig.Companion.ENFORCE_SCHEMA
-import streams.kafka.connect.source.Neo4jSourceConnectorConfig.Companion.SOURCE_TYPE
 import streams.kafka.connect.source.SourceType
 
 class ConfigurationMigratorTest {
@@ -16,27 +13,25 @@ class ConfigurationMigratorTest {
     val originals =
       mapOf(
         "neo4j.topic.pattern.merge.node.properties.enabled" to "true",
-        "${Neo4jSinkConnectorConfig.TOPIC_CYPHER_PREFIX}foo" to
-          "CREATE (p:Person{name: event.firstName})",
+        "neo4j.server.uri" to "neo4j+s://x.x.x.x",
+        "neo4j.retry.max.attemps" to "1"
       )
 
     // When the configuration is migrated
     val migratedConfig = ConfigurationMigrator(originals).migrate()
 
-    // Then the keys are updated to new key format containing existing value
+    // Then the keys are updated to new key format containing the original value
     assertEquals(migratedConfig["neo4j.pattern.node.merge-properties"], "true")
-    assertEquals(
-      migratedConfig["neo4j.cypher.topic.foo"],
-      "CREATE (p:Person{name: event.firstName})",
-    )
+    assertEquals(migratedConfig["neo4j.uri"], "neo4j+s://x.x.x.x")
+    assertEquals(migratedConfig["neo4j.max-retry-attempts"], "1")
   }
 
   @Test fun `should not migrate keys with no matching configuration key`() {
     // Given a configuration which has no equivalent in the updated connector
     val originals = mapOf(
-      ENCRYPTION_CA_CERTIFICATE_PATH to "./cert.pem",
-      SOURCE_TYPE to SourceType.QUERY.toString(),
-      ENFORCE_SCHEMA to "true"
+      "neo4j.encryption.ca.certificate.path" to "./cert.pem",
+      "neo4j.source.type" to SourceType.QUERY.toString(),
+      "neo4j.enforce.schema" to "true"
     )
 
     // When the configuration is migrated
@@ -49,13 +44,21 @@ class ConfigurationMigratorTest {
   @Test
   fun `should migrate time-based keys to new configuration format`() {
     // Given a configuration originally defined in milliseconds
-    var originals = mapOf("neo4j.retry.backoff.msecs" to "1200")
+    var originals = mapOf(
+      "neo4j.retry.backoff.msecs" to "1200",
+      "neo4j.connection.max.lifetime.msecs" to "1000",
+      "neo4j.batch.timeout.msecs" to "500",
+      "neo4j.streaming.poll.interval.msecs" to "800"
+    )
 
     // When the configuration is migrated
     val migratedConfig = ConfigurationMigrator(originals).migrate()
 
     // Then the new configuration should be labelled with its units
     assertEquals(migratedConfig["neo4j.max-retry-time"], "1200ms")
+    assertEquals(migratedConfig["neo4j.connection-timeout"], "1000ms")
+    assertEquals(migratedConfig["neo4j.batch-timeout"], "500ms")
+    assertEquals(migratedConfig["neo4j.query.poll-interval"], "800ms")
   }
 
   @Test
@@ -63,8 +66,8 @@ class ConfigurationMigratorTest {
     // Given a configuration containing prefix/user-defined keys
     val originals =
       mapOf(
-        "${Neo4jSinkConnectorConfig.TOPIC_CYPHER_PREFIX}foo" to
-          "CREATE (p:Person{name: event.firstName})"
+        "neo4j.topic.cypher.foo" to "CREATE (p:Person{name: event.firstName})",
+        "neo4j.topic.pattern.node.bar" to "(:Bar{!barId,barName})"
       )
 
     // When the configuration is migrated
@@ -74,6 +77,10 @@ class ConfigurationMigratorTest {
     assertEquals(
       migratedConfig["neo4j.cypher.topic.foo"],
       "CREATE (p:Person{name: event.firstName})",
+    )
+    assertEquals(
+      migratedConfig["neo4j.pattern.node.topic.bar"],
+      "(:Bar{!barId,barName})",
     )
   }
 }

--- a/kafka-connect-neo4j/src/test/resources/exampleConfigs/sinkExample.json
+++ b/kafka-connect-neo4j/src/test/resources/exampleConfigs/sinkExample.json
@@ -1,0 +1,20 @@
+{
+  "name": "Neo4jSinkConnectorJSONString",
+  "config": {
+    "topics": "my-topic",
+    "connector.class": "streams.kafka.connect.sink.Neo4jSinkConnector",
+    "key.converter": "org.apache.kafka.connect.json.JsonConverter",
+    "key.converter.schemas.enable": false,
+    "value.converter": "org.apache.kafka.connect.json.JsonConverter",
+    "value.converter.schemas.enable": false,
+    "errors.retry.timeout": "-1",
+    "errors.retry.delay.max.ms": "1000",
+    "errors.tolerance": "all",
+    "errors.log.enable": true,
+    "errors.log.include.messages": true,
+    "neo4j.server.uri": "bolt://neo4j:7687",
+    "neo4j.authentication.basic.username": "neo4j",
+    "neo4j.authentication.basic.password": "password",
+    "neo4j.topic.cypher.my-topic": "MERGE (p:Person{name: event.name, surname: event.surname}) MERGE (f:Family{name: event.surname}) MERGE (p)-[:BELONGS_TO]->(f)"
+  }
+}

--- a/kafka-connect-neo4j/src/test/resources/exampleConfigs/sourceExample.json
+++ b/kafka-connect-neo4j/src/test/resources/exampleConfigs/sourceExample.json
@@ -1,0 +1,19 @@
+{
+  "name": "Neo4jSourceConnectorAVRO",
+  "config": {
+    "topic": "my-topic",
+    "connector.class": "streams.kafka.connect.source.Neo4jSourceConnector",
+    "key.converter": "io.confluent.connect.avro.AvroConverter",
+    "key.converter.schema.registry.url": "http://schema-registry:8081",
+    "value.converter": "io.confluent.connect.avro.AvroConverter",
+    "value.converter.schema.registry.url": "http://schema-registry:8081",
+    "neo4j.server.uri": "bolt://neo4j:7687",
+    "neo4j.authentication.basic.username": "neo4j",
+    "neo4j.authentication.basic.password": "password",
+    "neo4j.streaming.poll.interval.msecs": 5000,
+    "neo4j.streaming.property": "timestamp",
+    "neo4j.streaming.from": "LAST_COMMITTED",
+    "neo4j.enforce.schema": true,
+    "neo4j.source.query": "MATCH (ts:TestSource) WHERE ts.timestamp > $lastCheck RETURN ts.name AS name, ts.surname AS surname, ts.timestamp AS timestamp"
+  }
+}


### PR DESCRIPTION
## Issue

On upgrading the connector to 5.1, there are breaking configuration changes.

## Proposed Changes

On connector shutdown, a migrated configuration using new 5.1 configuration keys are dumped to the log to be used after connector migration.


