### PR TITLE
fix: update configuration migration properties

### DIFF
--- a/kafka-connect-neo4j/src/main/kotlin/streams/kafka/connect/common/ConfigurationMigrator.kt
+++ b/kafka-connect-neo4j/src/main/kotlin/streams/kafka/connect/common/ConfigurationMigrator.kt
@@ -74,7 +74,7 @@ class ConfigurationMigrator(private val settings: Map<String, String>) {
         CONNECTION_LIVENESS_CHECK_TIMEOUT_MSECS to PropertyConverter("neo4j.pool.idle-time-before-connection-test") { convertMsecs(settings[CONNECTION_LIVENESS_CHECK_TIMEOUT_MSECS] as String) },
         CONNECTION_POOL_MAX_SIZE to PropertyConverter("neo4j.pool.max-connection-pool-size") {settings[CONNECTION_POOL_MAX_SIZE] as String},
         RETRY_BACKOFF_MSECS to PropertyConverter("neo4j.max-retry-time") { convertMsecs(settings[RETRY_BACKOFF_MSECS] as String) },
-        RETRY_MAX_ATTEMPTS to PropertyConverter("neo4j.max-retry-attempts") {settings[RETRY_MAX_ATTEMPTS] as String},
+        RETRY_MAX_ATTEMPTS to PropertyConverter("") {settings[RETRY_MAX_ATTEMPTS] as String},
         // Sink
         TOPIC_CDC_SOURCE_ID to PropertyConverter("neo4j.cdc.source-id.topics") {settings[TOPIC_CDC_SOURCE_ID] as String},
         TOPIC_CDC_SOURCE_ID_LABEL_NAME to PropertyConverter("neo4j.cdc.source-id.label-name") {settings[TOPIC_CDC_SOURCE_ID_LABEL_NAME] as String},

--- a/kafka-connect-neo4j/src/main/kotlin/streams/kafka/connect/sink/Neo4jSinkConnector.kt
+++ b/kafka-connect-neo4j/src/main/kotlin/streams/kafka/connect/sink/Neo4jSinkConnector.kt
@@ -36,7 +36,11 @@ class Neo4jSinkConnector: SinkConnector() {
         val migratedConfig = ConfigurationMigrator(settings).migrateToV51()
         val mapper = ObjectMapper()
         val jsonConfig = mapper.writeValueAsString(migratedConfig)
-        log.info("Migrated Neo4j Sink Connector '{}' configuration to v5.1 connector format: {}", settings["name"], jsonConfig)
+        log.info(
+            "The migrated settings for 5.1 version of Neo4j Sink Connector '{}' is: `{}`",
+            settings["name"],
+            jsonConfig
+        )
     }
 
     override fun version(): String {

--- a/kafka-connect-neo4j/src/main/kotlin/streams/kafka/connect/sink/Neo4jSinkConnector.kt
+++ b/kafka-connect-neo4j/src/main/kotlin/streams/kafka/connect/sink/Neo4jSinkConnector.kt
@@ -36,7 +36,7 @@ class Neo4jSinkConnector: SinkConnector() {
         val migratedConfig = ConfigurationMigrator(settings).migrateToV51()
         val mapper = ObjectMapper()
         val jsonConfig = mapper.writeValueAsString(migratedConfig)
-        log.info("Migrated Sink configuration to v5.1 connector format: {}", jsonConfig)
+        log.info("Migrated Neo4j Sink Connector '{}' configuration to v5.1 connector format: {}", settings["name"], jsonConfig)
     }
 
     override fun version(): String {

--- a/kafka-connect-neo4j/src/main/kotlin/streams/kafka/connect/sink/Neo4jSinkConnector.kt
+++ b/kafka-connect-neo4j/src/main/kotlin/streams/kafka/connect/sink/Neo4jSinkConnector.kt
@@ -35,7 +35,7 @@ class Neo4jSinkConnector: SinkConnector() {
     override fun stop() {
         val migratedConfig = ConfigurationMigrator(settings).migrateToV51()
         val mapper = ObjectMapper()
-        val jsonConfig = mapper.writeValueAsString(migratedConfig)
+        val jsonConfig = mapper.writerWithDefaultPrettyPrinter().writeValueAsString(migratedConfig)
         log.info(
             "The migrated settings for 5.1 version of Neo4j Sink Connector '{}' is: `{}`",
             settings["name"],

--- a/kafka-connect-neo4j/src/main/kotlin/streams/kafka/connect/source/Neo4jSourceService.kt
+++ b/kafka-connect-neo4j/src/main/kotlin/streams/kafka/connect/source/Neo4jSourceService.kt
@@ -175,7 +175,8 @@ class Neo4jSourceService(private val config: Neo4jSourceConnectorConfig, offsetS
             log.info("Error while closing Driver instance:", it)
         }
 
-        val migratedConfig = ConfigurationMigrator(config.originals() as Map<String, String>).migrateToV51().toMutableMap()
+        val originalConfig = config.originals() as Map<String, String>
+        val migratedConfig = ConfigurationMigrator(originalConfig).migrateToV51().toMutableMap()
 
         log.debug("Defaulting v5.1 migrated configuration offset to last checked timestamp: {}", lastCheck)
         migratedConfig["neo4j.start-from"] = "USER_PROVIDED"
@@ -183,7 +184,7 @@ class Neo4jSourceService(private val config: Neo4jSourceConnectorConfig, offsetS
 
         val mapper = ObjectMapper()
         val jsonConfig = mapper.writeValueAsString(migratedConfig)
-        log.info("Migrated Source configuration to v5.1 connector format: {}", jsonConfig)
+        log.info("Migrated Neo4j Source Connector '{}' configuration to v5.1 connector format: {}", originalConfig["name"], jsonConfig)
 
         log.info("Neo4j Source Service closed successfully")
     }

--- a/kafka-connect-neo4j/src/main/kotlin/streams/kafka/connect/source/Neo4jSourceService.kt
+++ b/kafka-connect-neo4j/src/main/kotlin/streams/kafka/connect/source/Neo4jSourceService.kt
@@ -184,7 +184,11 @@ class Neo4jSourceService(private val config: Neo4jSourceConnectorConfig, offsetS
 
         val mapper = ObjectMapper()
         val jsonConfig = mapper.writeValueAsString(migratedConfig)
-        log.info("Migrated Neo4j Source Connector '{}' configuration to v5.1 connector format: {}", originalConfig["name"], jsonConfig)
+        log.info(
+            "The migrated settings for 5.1 version of Neo4j Source Connector '{}' is: `{}`",
+            originalConfig["name"],
+            jsonConfig
+        )
 
         log.info("Neo4j Source Service closed successfully")
     }

--- a/kafka-connect-neo4j/src/main/kotlin/streams/kafka/connect/source/Neo4jSourceService.kt
+++ b/kafka-connect-neo4j/src/main/kotlin/streams/kafka/connect/source/Neo4jSourceService.kt
@@ -183,7 +183,7 @@ class Neo4jSourceService(private val config: Neo4jSourceConnectorConfig, offsetS
         migratedConfig["neo4j.start-from.value"] = lastCheck
 
         val mapper = ObjectMapper()
-        val jsonConfig = mapper.writeValueAsString(migratedConfig)
+        val jsonConfig = mapper.writerWithDefaultPrettyPrinter().writeValueAsString(migratedConfig)
         log.info(
             "The migrated settings for 5.1 version of Neo4j Source Connector '{}' is: `{}`",
             originalConfig["name"],

--- a/kafka-connect-neo4j/src/test/kotlin/streams/kafka/connect/common/ConfigurationMigratorTest.kt
+++ b/kafka-connect-neo4j/src/test/kotlin/streams/kafka/connect/common/ConfigurationMigratorTest.kt
@@ -17,7 +17,7 @@ class ConfigurationMigratorTest {
       mapOf(
         "neo4j.topic.pattern.merge.node.properties.enabled" to "true",
         "neo4j.server.uri" to "neo4j+s://x.x.x.x",
-        "neo4j.retry.max.attemps" to "1"
+        "neo4j.encryption.enabled" to "false"
       )
 
     // When the configuration is migrated
@@ -27,7 +27,7 @@ class ConfigurationMigratorTest {
     assertEquals(originals.size, migratedConfig.size)
     assertEquals(migratedConfig["neo4j.pattern.node.merge-properties"], "true")
     assertEquals(migratedConfig["neo4j.uri"], "neo4j+s://x.x.x.x")
-    assertEquals(migratedConfig["neo4j.max-retry-attempts"], "1")
+    assertEquals(migratedConfig["neo4j.security.encrypted"], "false")
   }
 
   @Test fun `should not migrate keys with no matching configuration key`() {
@@ -35,7 +35,8 @@ class ConfigurationMigratorTest {
     val originals = mapOf(
       "neo4j.encryption.ca.certificate.path" to "./cert.pem",
       "neo4j.source.type" to SourceType.QUERY.toString(),
-      "neo4j.enforce.schema" to "true"
+      "neo4j.enforce.schema" to "true",
+      "neo4j.retry.max.attemps" to "1"
     )
 
     // When the configuration is migrated
@@ -104,7 +105,7 @@ class ConfigurationMigratorTest {
 
     // Then those options should still be included
     assertEquals(originals.size, migratedConfig.size)
-    assertEquals(migratedConfig["connector.class"], "streams.kafka.connect.source.Neo4jSourceConnector")
+    assertEquals(migratedConfig["connector.class"], "org.neo4j.connectors.kafka.source.Neo4jConnector")
     assertEquals(migratedConfig["key.converter"], "io.confluent.connect.avro.AvroConverter")
     assertEquals(migratedConfig["arbitrary.config.key"], "arbitrary.value")
   }
@@ -121,7 +122,7 @@ class ConfigurationMigratorTest {
     assertEquals(12, migratedConfig.size)
 
     assertEquals(migratedConfig["neo4j.query.topic"], "my-topic")
-    assertEquals(migratedConfig["connector.class"], "streams.kafka.connect.source.Neo4jSourceConnector")
+    assertEquals(migratedConfig["connector.class"], "org.neo4j.connectors.kafka.source.Neo4jConnector")
     assertEquals(migratedConfig["key.converter"], "io.confluent.connect.avro.AvroConverter")
     assertEquals(migratedConfig["key.converter.schema.registry.url"], "http://schema-registry:8081")
     assertEquals(migratedConfig["value.converter"], "io.confluent.connect.avro.AvroConverter")
@@ -152,7 +153,7 @@ class ConfigurationMigratorTest {
     assertEquals(15, migratedConfig.size)
 
     assertEquals(migratedConfig["topics"], "my-topic")
-    assertEquals(migratedConfig["connector.class"], "streams.kafka.connect.sink.Neo4jSinkConnector")
+    assertEquals(migratedConfig["connector.class"], "org.neo4j.connectors.kafka.sink.Neo4jConnector")
     assertEquals(migratedConfig["key.converter"], "org.apache.kafka.connect.json.JsonConverter")
     assertEquals(migratedConfig["key.converter.schemas.enable"], "false")
     assertEquals(migratedConfig["value.converter"], "org.apache.kafka.connect.json.JsonConverter")


### PR DESCRIPTION
Fixes configuration migration for missed properties and removed properties.


## Proposed Changes (Mandatory)

A brief list of proposed changes in order to fix the issue:

  - Remove `neo4j.retry.max.attemps` configuration option as it has been removed in the 5.1 release of the connector
  - Add configuration migration for `connector.class` to updated class package for 5.1 connector
  - Update tests

## Example

<img width="1316" alt="image" src="https://github.com/user-attachments/assets/6fe9d1de-2148-4b84-a60b-144fe9c322e0">

