### PR TITLE
fix: obfuscate password in configuration migration log

### DIFF
--- a/kafka-connect-neo4j/src/main/kotlin/streams/kafka/connect/common/ConfigurationMigrator.kt
+++ b/kafka-connect-neo4j/src/main/kotlin/streams/kafka/connect/common/ConfigurationMigrator.kt
@@ -66,7 +66,7 @@ class ConfigurationMigrator(private val settings: Map<String, String>) {
         AUTHENTICATION_BASIC_USERNAME to PropertyConverter("neo4j.authentication.basic.username") {settings[AUTHENTICATION_BASIC_USERNAME] as String},
         AUTHENTICATION_BASIC_PASSWORD to PropertyConverter("neo4j.authentication.basic.password") {""},
         AUTHENTICATION_BASIC_REALM to PropertyConverter("neo4j.authentication.basic.realm") {settings[AUTHENTICATION_BASIC_REALM] as String},
-        AUTHENTICATION_KERBEROS_TICKET to PropertyConverter("neo4j.authentication.kerberos.ticket") {settings[AUTHENTICATION_KERBEROS_TICKET] as String},
+        AUTHENTICATION_KERBEROS_TICKET to PropertyConverter("neo4j.authentication.kerberos.ticket") {""},
         BATCH_SIZE to PropertyConverter("neo4j.batch-size") {settings[BATCH_SIZE] as String},
         ENCRYPTION_ENABLED to PropertyConverter("neo4j.security.encrypted") {settings[ENCRYPTION_ENABLED] as String},
         ENCRYPTION_TRUST_STRATEGY to PropertyConverter("neo4j.security.trust-strategy") {settings[ENCRYPTION_TRUST_STRATEGY] as String},

--- a/kafka-connect-neo4j/src/main/kotlin/streams/kafka/connect/common/ConfigurationMigrator.kt
+++ b/kafka-connect-neo4j/src/main/kotlin/streams/kafka/connect/common/ConfigurationMigrator.kt
@@ -64,7 +64,7 @@ class ConfigurationMigrator(private val settings: Map<String, String>) {
         SERVER_URI to PropertyConverter("neo4j.uri") { settings[SERVER_URI] as String },
         AUTHENTICATION_TYPE to PropertyConverter("neo4j.authentication.type") { settings[AUTHENTICATION_TYPE] as String },
         AUTHENTICATION_BASIC_USERNAME to PropertyConverter("neo4j.authentication.basic.username") {settings[AUTHENTICATION_BASIC_USERNAME] as String},
-        AUTHENTICATION_BASIC_PASSWORD to PropertyConverter("neo4j.authentication.basic.password") {settings[AUTHENTICATION_BASIC_PASSWORD] as String},
+        AUTHENTICATION_BASIC_PASSWORD to PropertyConverter("neo4j.authentication.basic.password") {""},
         AUTHENTICATION_BASIC_REALM to PropertyConverter("neo4j.authentication.basic.realm") {settings[AUTHENTICATION_BASIC_REALM] as String},
         AUTHENTICATION_KERBEROS_TICKET to PropertyConverter("neo4j.authentication.kerberos.ticket") {settings[AUTHENTICATION_KERBEROS_TICKET] as String},
         BATCH_SIZE to PropertyConverter("neo4j.batch-size") {settings[BATCH_SIZE] as String},

--- a/kafka-connect-neo4j/src/test/kotlin/streams/kafka/connect/common/ConfigurationMigratorTest.kt
+++ b/kafka-connect-neo4j/src/test/kotlin/streams/kafka/connect/common/ConfigurationMigratorTest.kt
@@ -169,6 +169,23 @@ class ConfigurationMigratorTest {
     assertEquals(migratedConfig["neo4j.cypher.topic.my-topic"], "MERGE (p:Person{name: event.name, surname: event.surname}) MERGE (f:Family{name: event.surname}) MERGE (p)-[:BELONGS_TO]->(f)")
   }
 
+  @Test
+  fun `should leave sensitive configuration values blank`() {
+    // Given a configuration which contains sensitive values
+    val config = mapOf(
+      "neo4j.authentication.basic.password" to "password",
+      "neo4j.authentication.kerberos.ticket" to "kerberos"
+    )
+
+    // When the configuration is migrated
+    val migratedConfig = ConfigurationMigrator(config).migrateToV51()
+
+    // Then the keys persist but the values are blank
+    assertEquals(2, migratedConfig.size)
+    assertEquals(migratedConfig["neo4j.authentication.basic.password"], "")
+    assertEquals(migratedConfig["neo4j.authentication.kerberos.ticket"], "")
+  }
+
   private fun loadConfiguration(path: String): Map<String, String> {
     val file = File(path)
     val json = file.readText()

--- a/kafka-connect-neo4j/src/test/kotlin/streams/kafka/connect/common/ConfigurationMigratorTest.kt
+++ b/kafka-connect-neo4j/src/test/kotlin/streams/kafka/connect/common/ConfigurationMigratorTest.kt
@@ -129,7 +129,7 @@ class ConfigurationMigratorTest {
     assertEquals(migratedConfig["value.converter.schema.registry.url"], "http://schema-registry:8081")
     assertEquals(migratedConfig["neo4j.uri"], "bolt://neo4j:7687")
     assertEquals(migratedConfig["neo4j.authentication.basic.username"], "neo4j")
-    assertEquals(migratedConfig["neo4j.authentication.basic.password"], "password")
+    assertEquals(migratedConfig["neo4j.authentication.basic.password"], "")
     assertEquals(migratedConfig["neo4j.query.poll-interval"], "5000ms")
     assertEquals(migratedConfig["neo4j.query.streaming-property"], "timestamp")
     assertEquals(
@@ -165,7 +165,7 @@ class ConfigurationMigratorTest {
     assertEquals(migratedConfig["errors.log.include.messages"], "true")
     assertEquals(migratedConfig["neo4j.uri"], "bolt://neo4j:7687")
     assertEquals(migratedConfig["neo4j.authentication.basic.username"], "neo4j")
-    assertEquals(migratedConfig["neo4j.authentication.basic.password"], "password")
+    assertEquals(migratedConfig["neo4j.authentication.basic.password"], "")
     assertEquals(migratedConfig["neo4j.cypher.topic.my-topic"], "MERGE (p:Person{name: event.name, surname: event.surname}) MERGE (f:Family{name: event.surname}) MERGE (p)-[:BELONGS_TO]->(f)")
   }
 


### PR DESCRIPTION
Fixes printing password to log during configurtion migration

## Proposed Changes (Mandatory)

A brief list of proposed changes in order to fix the issue:

  - Do not migrate `neo4j.authentication.basic.password` property value. Maintain the key but replace the value with an empty string