### PR TITLE
fix: add kafka connect properties for configuration migration

### DIFF
--- a/kafka-connect-neo4j/src/main/kotlin/streams/kafka/connect/common/ConfigurationMigrator.kt
+++ b/kafka-connect-neo4j/src/main/kotlin/streams/kafka/connect/common/ConfigurationMigrator.kt
@@ -138,8 +138,8 @@ class ConfigurationMigrator(private val settings: Map<String, String>) {
                         log.debug("Migrating configuration prefix key {} to {}", originalKey, newKey)
                     }
                 }
-            } else {
-                // Configuration option not declared should be copied across
+            } else if (KafkaConnectConfig.options.any { k -> originalKey.startsWith(k) }) {
+                // Migrate all Kafka Connect configuration options
                 updatedConfig[originalKey] = value
             }
         }

--- a/kafka-connect-neo4j/src/main/kotlin/streams/kafka/connect/common/KafkaConnectConfig.kt
+++ b/kafka-connect-neo4j/src/main/kotlin/streams/kafka/connect/common/KafkaConnectConfig.kt
@@ -1,0 +1,35 @@
+package streams.kafka.connect.common
+
+object KafkaConnectConfig {
+
+  val options = setOf(
+    // common
+    "name",
+    "connector.class",
+    "tasks.max",
+    "key.converter",
+    "value.converter",
+    "header.converter",
+    "config.action.reload",
+    "transforms",
+    "predicates",
+    "errors.retry.timeout",
+    "errors.retry.delay.max.ms",
+    "errors.tolerance",
+    "errors.log.enable",
+    "errors.log.include.messages",
+    // sink
+    "topics",
+    "topic.regex",
+    "errors.deadletterqueue.topic.name",
+    "errors.deadletterqueue.topic.replication.factor",
+    "errors.deadletterqueue.context.headers.enable",
+    // source
+    "topic.creation.groups",
+    "exactly.once.support",
+    "transaction.boundary",
+    "transaction.boundary.interval.ms",
+    "offsets.storage.topic"
+  )
+
+}


### PR DESCRIPTION
Fixes issue where extraneous configuration options were printed in configuration migration log

## Proposed Changes (Mandatory)

A brief list of proposed changes in order to fix the issue:

  - Remove else branch where unknown properties were still migrated to new configuration version
  - Create `KafkaConnectConfig` containing kafka connect specific configuration options which should be migrated
  - Update tests
