### PR TITLE
test: fix flakiness of the tests

### DIFF
--- a/kafka-connect-neo4j/src/test/kotlin/streams/kafka/connect/source/Neo4jSourceTaskTest.kt
+++ b/kafka-connect-neo4j/src/test/kotlin/streams/kafka/connect/source/Neo4jSourceTaskTest.kt
@@ -246,6 +246,7 @@ class Neo4jSourceTaskTest {
                                 |       key2: "value2"
                                 |   } AS map,
                                 |   n AS node
+                                |ORDER BY n.timestamp   
                             """.trimMargin(), mapOf("timestamp" to clock.instant().toEpochMilli() + it)
                 )
                 val next = result.next()
@@ -324,6 +325,7 @@ class Neo4jSourceTaskTest {
                 |       key2: "value2"
                 |   } AS map,
                 |   n AS node
+                |ORDER BY n.timestamp
             """.trimMargin()
 
     @Test(expected = ConnectException::class)


### PR DESCRIPTION
This PR fixes flaky tests for Neo4jSourceTask by adding deterministic ordering to the query.
