### PR TITLE
feat: switch to caniuse and add cypher version selection

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -30,6 +30,10 @@
             <artifactId>kotlinx-coroutines-core</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.neo4j</groupId>
+            <artifactId>caniuse-core</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
             <scope>provided</scope>
@@ -52,6 +56,11 @@
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
             <artifactId>kotlin-test-junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/common/src/main/kotlin/streams/service/sink/strategy/CypherTemplateStrategy.kt
+++ b/common/src/main/kotlin/streams/service/sink/strategy/CypherTemplateStrategy.kt
@@ -1,10 +1,15 @@
 package streams.service.sink.strategy
 
+import org.neo4j.caniuse.CanIUse.canIUse
+import org.neo4j.caniuse.Cypher
+import org.neo4j.caniuse.Neo4j
 import streams.service.StreamsSinkEntity
 import streams.utils.StreamsUtils
 
-class CypherTemplateStrategy(query: String): IngestionStrategy {
-    private val fullQuery = "${StreamsUtils.UNWIND} $query"
+class CypherTemplateStrategy(neo4j: Neo4j, query: String) : IngestionStrategy {
+    private val cypherPrefix = if (canIUse(Cypher.explicitCypher5Selection()).withNeo4j(neo4j)) "CYPHER 5 " else ""
+    private val fullQuery = "${cypherPrefix}${StreamsUtils.UNWIND} $query"
+
     override fun mergeNodeEvents(events: Collection<StreamsSinkEntity>): List<QueryEvents> {
         return listOf(QueryEvents(fullQuery, events.mapNotNull { it.value as? Map<String, Any> }))
     }

--- a/common/src/main/kotlin/streams/service/sink/strategy/SourceIdIngestionStrategy.kt
+++ b/common/src/main/kotlin/streams/service/sink/strategy/SourceIdIngestionStrategy.kt
@@ -1,5 +1,8 @@
 package streams.service.sink.strategy
 
+import org.neo4j.caniuse.CanIUse.canIUse
+import org.neo4j.caniuse.Cypher
+import org.neo4j.caniuse.Neo4j
 import streams.events.*
 import streams.extensions.quote
 import streams.service.StreamsSinkEntity
@@ -13,98 +16,108 @@ data class SourceIdIngestionStrategyConfig(val labelName: String = "SourceEvent"
     }
 }
 
-class SourceIdIngestionStrategy(config: SourceIdIngestionStrategyConfig = SourceIdIngestionStrategyConfig()): IngestionStrategy {
+class SourceIdIngestionStrategy(
+    neo4j: Neo4j,
+    config: SourceIdIngestionStrategyConfig = SourceIdIngestionStrategyConfig()
+) : IngestionStrategy {
+    private val cypherPrefix = if (canIUse(Cypher.explicitCypher5Selection()).withNeo4j(neo4j)) "CYPHER 5 " else ""
 
     private val quotedLabelName = config.labelName.quote()
     private val quotedIdName = config.idName.quote()
 
     override fun mergeRelationshipEvents(events: Collection<StreamsSinkEntity>): List<QueryEvents> {
         return events
-                .mapNotNull { SchemaUtils.toStreamsTransactionEvent(it) { it.payload.type == EntityType.relationship && it.meta.operation != OperationType.deleted } }
-                .map { data ->
-                    val payload = data.payload as RelationshipPayload
-                    val changeEvt = when (data.meta.operation) {
-                        OperationType.deleted -> {
-                            data.payload.before as RelationshipChange
-                        }
-                        else -> data.payload.after as RelationshipChange
+            .mapNotNull { SchemaUtils.toStreamsTransactionEvent(it) { it.payload.type == EntityType.relationship && it.meta.operation != OperationType.deleted } }
+            .map { data ->
+                val payload = data.payload as RelationshipPayload
+                val changeEvt = when (data.meta.operation) {
+                    OperationType.deleted -> {
+                        data.payload.before as RelationshipChange
                     }
-                    payload.label to mapOf("id" to payload.id,
-                            "start" to payload.start.id, "end" to payload.end.id, "properties" to changeEvt.properties)
+
+                    else -> data.payload.after as RelationshipChange
                 }
-                .groupBy({ it.first }, { it.second })
-                .map {
-                    val query = """
-                        |${StreamsUtils.UNWIND}
+                payload.label to mapOf(
+                    "id" to payload.id,
+                    "start" to payload.start.id, "end" to payload.end.id, "properties" to changeEvt.properties
+                )
+            }
+            .groupBy({ it.first }, { it.second })
+            .map {
+                val query = """
+                        |${cypherPrefix}${StreamsUtils.UNWIND}
                         |MERGE (start:$quotedLabelName{$quotedIdName: event.start})
                         |MERGE (end:$quotedLabelName{$quotedIdName: event.end})
                         |MERGE (start)-[r:${it.key.quote()}{$quotedIdName: event.id}]->(end)
                         |SET r = event.properties
                         |SET r.$quotedIdName = event.id
                     """.trimMargin()
-                    QueryEvents(query, it.value)
-                }
+                QueryEvents(query, it.value)
+            }
     }
 
     override fun deleteRelationshipEvents(events: Collection<StreamsSinkEntity>): List<QueryEvents> {
         return events
-                .mapNotNull { SchemaUtils.toStreamsTransactionEvent(it) { it.payload.type == EntityType.relationship && it.meta.operation == OperationType.deleted } }
-                .map { data ->
-                    val payload = data.payload as RelationshipPayload
-                    payload.label to mapOf("id" to data.payload.id)
-                }
-                .groupBy({ it.first }, { it.second })
-                .map {
-                    val query = "${StreamsUtils.UNWIND} MATCH ()-[r:${it.key.quote()}{$quotedIdName: event.id}]-() DELETE r"
-                    QueryEvents(query, it.value)
-                }
+            .mapNotNull { SchemaUtils.toStreamsTransactionEvent(it) { it.payload.type == EntityType.relationship && it.meta.operation == OperationType.deleted } }
+            .map { data ->
+                val payload = data.payload as RelationshipPayload
+                payload.label to mapOf("id" to data.payload.id)
+            }
+            .groupBy({ it.first }, { it.second })
+            .map {
+                val query = "${cypherPrefix}${StreamsUtils.UNWIND} MATCH ()-[r:${it.key.quote()}{$quotedIdName: event.id}]-() DELETE r"
+                QueryEvents(query, it.value)
+            }
     }
 
     override fun deleteNodeEvents(events: Collection<StreamsSinkEntity>): List<QueryEvents> {
         val data = events
-                .mapNotNull { SchemaUtils.toStreamsTransactionEvent(it) { it.payload.type == EntityType.node && it.meta.operation == OperationType.deleted } }
-                .map { mapOf("id" to it.payload.id) }
+            .mapNotNull { SchemaUtils.toStreamsTransactionEvent(it) { it.payload.type == EntityType.node && it.meta.operation == OperationType.deleted } }
+            .map { mapOf("id" to it.payload.id) }
         if (data.isNullOrEmpty()) {
             return emptyList()
         }
-        val query = "${StreamsUtils.UNWIND} MATCH (n:$quotedLabelName{$quotedIdName: event.id}) DETACH DELETE n"
+        val query = "${cypherPrefix}${StreamsUtils.UNWIND} MATCH (n:$quotedLabelName{$quotedIdName: event.id}) DETACH DELETE n"
         return listOf(QueryEvents(query, data))
     }
 
     override fun mergeNodeEvents(events: Collection<StreamsSinkEntity>): List<QueryEvents> {
         return events
-                .mapNotNull { SchemaUtils.toStreamsTransactionEvent(it) { it.payload.type == EntityType.node && it.meta.operation != OperationType.deleted } }
-                .map { data ->
-                    val changeEvtAfter = data.payload.after as NodeChange
-                    val labelsAfter = changeEvtAfter.labels ?: emptyList()
-                    val labelsBefore = if (data.payload.before != null) {
-                        val changeEvtBefore = data.payload.before as NodeChange
-                        changeEvtBefore.labels ?: emptyList()
-                    } else {
-                        emptyList()
-                    }
-                    val labelsToAdd = (labelsAfter - labelsBefore)
-                            .toSet()
-                    val labelsToDelete = (labelsBefore - labelsAfter)
-                            .toSet()
-                    NodeMergeMetadata(labelsToAdd = labelsToAdd, labelsToDelete = labelsToDelete) to mapOf("id" to data.payload.id, "properties" to changeEvtAfter.properties)
+            .mapNotNull { SchemaUtils.toStreamsTransactionEvent(it) { it.payload.type == EntityType.node && it.meta.operation != OperationType.deleted } }
+            .map { data ->
+                val changeEvtAfter = data.payload.after as NodeChange
+                val labelsAfter = changeEvtAfter.labels ?: emptyList()
+                val labelsBefore = if (data.payload.before != null) {
+                    val changeEvtBefore = data.payload.before as NodeChange
+                    changeEvtBefore.labels ?: emptyList()
+                } else {
+                    emptyList()
                 }
-                .groupBy({ it.first }, { it.second })
-                .map {
-                    var query = """
-                        |${StreamsUtils.UNWIND}
+                val labelsToAdd = (labelsAfter - labelsBefore)
+                    .toSet()
+                val labelsToDelete = (labelsBefore - labelsAfter)
+                    .toSet()
+                NodeMergeMetadata(
+                    labelsToAdd = labelsToAdd,
+                    labelsToDelete = labelsToDelete
+                ) to mapOf("id" to data.payload.id, "properties" to changeEvtAfter.properties)
+            }
+            .groupBy({ it.first }, { it.second })
+            .map {
+                var query = """
+                        |${cypherPrefix}${StreamsUtils.UNWIND}
                         |MERGE (n:$quotedLabelName{$quotedIdName: event.id})
                         |SET n = event.properties
                         |SET n.$quotedIdName = event.id
                     """.trimMargin()
-                    if (it.key.labelsToDelete.isNotEmpty()) {
-                        query += "\nREMOVE n${getLabelsAsString(it.key.labelsToDelete)}"
-                    }
-                    if (it.key.labelsToAdd.isNotEmpty()) {
-                        query += "\nSET n${getLabelsAsString(it.key.labelsToAdd)}"
-                    }
-                    QueryEvents(query, it.value)
+                if (it.key.labelsToDelete.isNotEmpty()) {
+                    query += "\nREMOVE n${getLabelsAsString(it.key.labelsToDelete)}"
                 }
+                if (it.key.labelsToAdd.isNotEmpty()) {
+                    query += "\nSET n${getLabelsAsString(it.key.labelsToAdd)}"
+                }
+                QueryEvents(query, it.value)
+            }
     }
 
 }

--- a/common/src/main/kotlin/streams/utils/StreamsUtils.kt
+++ b/common/src/main/kotlin/streams/utils/StreamsUtils.kt
@@ -2,17 +2,23 @@ package streams.utils
 
 object StreamsUtils {
 
-    @JvmStatic val UNWIND: String = "UNWIND \$events AS event"
+    @JvmStatic
+    val UNWIND: String = "UNWIND \$events AS event"
 
-    @JvmStatic val WITH_EVENT_FROM: String = "WITH event, from"
+    @JvmStatic
+    val WITH_EVENT_FROM: String = "WITH event, from"
 
-    @JvmStatic val STREAMS_CONFIG_PREFIX = "streams."
+    @JvmStatic
+    val STREAMS_CONFIG_PREFIX = "streams."
 
-    @JvmStatic val STREAMS_SINK_TOPIC_PREFIX = "sink.topic.cypher."
+    @JvmStatic
+    val STREAMS_SINK_TOPIC_PREFIX = "sink.topic.cypher."
 
-    @JvmStatic val LEADER = "LEADER"
+    @JvmStatic
+    val LEADER = "LEADER"
 
-    @JvmStatic val SYSTEM_DATABASE_NAME = "system"
+    @JvmStatic
+    val SYSTEM_DATABASE_NAME = "system"
 
     fun <T> ignoreExceptions(action: () -> T, vararg toIgnore: Class<out Throwable>): T? {
         return try {
@@ -29,7 +35,7 @@ object StreamsUtils {
         }
     }
 
-    fun closeSafetely(closeable: AutoCloseable, onError: (Throwable) -> Unit = {}) = try {
+    fun closeSafely(closeable: AutoCloseable, onError: (Throwable) -> Unit = {}) = try {
         closeable.close()
     } catch (e: Throwable) {
         onError(e)

--- a/common/src/test/kotlin/streams/service/sink/strategy/Neo4j.kt
+++ b/common/src/test/kotlin/streams/service/sink/strategy/Neo4j.kt
@@ -1,0 +1,55 @@
+package streams.service.sink.strategy
+
+import org.junit.jupiter.api.extension.ExtensionContext
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.ArgumentsProvider
+import org.neo4j.caniuse.Neo4j
+import org.neo4j.caniuse.Neo4jDeploymentType
+import org.neo4j.caniuse.Neo4jEdition
+import org.neo4j.caniuse.Neo4jVersion
+import java.util.stream.Stream
+
+internal val Neo4jV4Aura = Neo4j(Neo4jVersion(4, 4, 0), Neo4jEdition.ENTERPRISE, Neo4jDeploymentType.AURA)
+internal val Neo4jV4OnPrem = Neo4j(Neo4jVersion(4, 4, 41), Neo4jEdition.ENTERPRISE, Neo4jDeploymentType.SELF_MANAGED)
+internal val Neo4jV4Community = Neo4j(Neo4jVersion(4, 4, 41), Neo4jEdition.COMMUNITY, Neo4jDeploymentType.SELF_MANAGED)
+internal val Neo4jV519Aura = Neo4j(Neo4jVersion(5, 19, 0), Neo4jEdition.ENTERPRISE, Neo4jDeploymentType.AURA)
+internal val Neo4jV519OnPrem = Neo4j(Neo4jVersion(5, 19, 0), Neo4jEdition.ENTERPRISE, Neo4jDeploymentType.SELF_MANAGED)
+internal val Neo4jV519Community =
+    Neo4j(Neo4jVersion(5, 19, 0), Neo4jEdition.COMMUNITY, Neo4jDeploymentType.SELF_MANAGED)
+internal val Neo4jV5LTSAura = Neo4j(Neo4jVersion(5, 26, 1), Neo4jEdition.ENTERPRISE, Neo4jDeploymentType.AURA)
+internal val Neo4jV5LTSOnPrem = Neo4j(Neo4jVersion(5, 26, 1), Neo4jEdition.ENTERPRISE, Neo4jDeploymentType.SELF_MANAGED)
+internal val Neo4jV5LTSCommunity =
+    Neo4j(Neo4jVersion(5, 26, 1), Neo4jEdition.COMMUNITY, Neo4jDeploymentType.SELF_MANAGED)
+internal val Neo4jV2025Aura = Neo4j(Neo4jVersion(2025, 1, 0), Neo4jEdition.ENTERPRISE, Neo4jDeploymentType.AURA)
+internal val Neo4jV2025OnPrem =
+    Neo4j(Neo4jVersion(2025, 1, 0), Neo4jEdition.ENTERPRISE, Neo4jDeploymentType.SELF_MANAGED)
+internal val Neo4jV2025Community =
+    Neo4j(Neo4jVersion(2025, 1, 0), Neo4jEdition.COMMUNITY, Neo4jDeploymentType.SELF_MANAGED)
+internal val Neo4jVLatestAura = Neo4j(Neo4jVersion.LATEST, Neo4jEdition.ENTERPRISE, Neo4jDeploymentType.AURA)
+internal val Neo4jVLatestOnPrem =
+    Neo4j(Neo4jVersion.LATEST, Neo4jEdition.ENTERPRISE, Neo4jDeploymentType.SELF_MANAGED)
+internal val Neo4jVLatestCommunity =
+    Neo4j(Neo4jVersion.LATEST, Neo4jEdition.COMMUNITY, Neo4jDeploymentType.SELF_MANAGED)
+
+class SupportedVersionsProvider : ArgumentsProvider {
+    override fun provideArguments(context: ExtensionContext?): Stream<out Arguments?>? {
+        return Stream.of(
+            Arguments.of(Neo4jV4Aura, ""),
+            Arguments.of(Neo4jV4OnPrem, ""),
+            Arguments.of(Neo4jV4Community, ""),
+            Arguments.of(Neo4jV519Aura, ""),
+            Arguments.of(Neo4jV519OnPrem, ""),
+            Arguments.of(Neo4jV519Community, ""),
+            Arguments.of(Neo4jV5LTSAura, "CYPHER 5 "),
+            Arguments.of(Neo4jV5LTSOnPrem, "CYPHER 5 "),
+            Arguments.of(Neo4jV5LTSCommunity, "CYPHER 5 "),
+            Arguments.of(Neo4jV2025Aura, "CYPHER 5 "),
+            Arguments.of(Neo4jV2025OnPrem, "CYPHER 5 "),
+            Arguments.of(Neo4jV2025Community, "CYPHER 5 "),
+            Arguments.of(Neo4jVLatestAura, "CYPHER 5 "),
+            Arguments.of(Neo4jVLatestOnPrem, "CYPHER 5 "),
+            Arguments.of(Neo4jVLatestCommunity, "CYPHER 5 ")
+        )
+    }
+
+}

--- a/common/src/test/kotlin/streams/service/sink/strategy/NodePatternIngestionStrategyTest.kt
+++ b/common/src/test/kotlin/streams/service/sink/strategy/NodePatternIngestionStrategyTest.kt
@@ -1,17 +1,20 @@
 package streams.service.sink.strategy
 
-import org.junit.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ArgumentsSource
+import org.neo4j.caniuse.Neo4j
 import streams.service.StreamsSinkEntity
 import streams.utils.StreamsUtils
 import kotlin.test.assertEquals
 
 class NodePatternIngestionStrategyTest {
 
-    @Test
-    fun `should get all properties`() {
+    @ParameterizedTest
+    @ArgumentsSource(SupportedVersionsProvider::class)
+    fun `should get all properties`(neo4j: Neo4j, expectedPrefix: String) {
         // given
         val config = NodePatternConfiguration.parse("(:LabelA:LabelB{!id})", true)
-        val strategy = NodePatternIngestionStrategy(config)
+        val strategy = NodePatternIngestionStrategy(neo4j, config)
         val data = mapOf("id" to 1, "foo" to "foo", "bar" to "bar", "foobar" to "foobar")
 
         // when
@@ -20,7 +23,7 @@ class NodePatternIngestionStrategyTest {
 
         // then
         assertEquals("""
-                |${StreamsUtils.UNWIND}
+                |${expectedPrefix}${StreamsUtils.UNWIND}
                 |MERGE (n:LabelA:LabelB{id: event.keys.id})
                 |SET n += event.properties
                 |SET n += event.keys
@@ -34,11 +37,12 @@ class NodePatternIngestionStrategyTest {
         assertEquals(emptyList(), strategy.mergeRelationshipEvents(events))
     }
 
-    @Test
-    fun `should get nested properties`() {
+    @ParameterizedTest
+    @ArgumentsSource(SupportedVersionsProvider::class)
+    fun `should get nested properties`(neo4j: Neo4j, expectedPrefix: String) {
         // given
         val config = NodePatternConfiguration.parse("(:LabelA:LabelB{!id, foo.bar})", false)
-        val strategy = NodePatternIngestionStrategy(config)
+        val strategy = NodePatternIngestionStrategy(neo4j, config)
         val data = mapOf("id" to 1, "foo" to mapOf("bar" to "bar", "foobar" to "foobar"))
 
         // when
@@ -48,7 +52,7 @@ class NodePatternIngestionStrategyTest {
         // then
         assertEquals(1, queryEvents.size)
         assertEquals("""
-                |${StreamsUtils.UNWIND}
+                |${expectedPrefix}${StreamsUtils.UNWIND}
                 |MERGE (n:LabelA:LabelB{id: event.keys.id})
                 |SET n = event.properties
                 |SET n += event.keys
@@ -62,11 +66,12 @@ class NodePatternIngestionStrategyTest {
         assertEquals(emptyList(), strategy.mergeRelationshipEvents(events))
     }
 
-    @Test
-    fun `should exclude nested properties`() {
+    @ParameterizedTest
+    @ArgumentsSource(SupportedVersionsProvider::class)
+    fun `should exclude nested properties`(neo4j: Neo4j, expectedPrefix: String) {
         // given
         val config = NodePatternConfiguration.parse("(:LabelA:LabelB{!id, -foo})", false)
-        val strategy = NodePatternIngestionStrategy(config)
+        val strategy = NodePatternIngestionStrategy(neo4j, config)
         val map = mapOf("id" to 1, "foo" to mapOf("bar" to "bar", "foobar" to "foobar"), "prop" to 100)
 
         // when
@@ -76,7 +81,7 @@ class NodePatternIngestionStrategyTest {
         // then
         assertEquals(1, queryEvents.size)
         assertEquals("""
-                |${StreamsUtils.UNWIND}
+                |${expectedPrefix}${StreamsUtils.UNWIND}
                 |MERGE (n:LabelA:LabelB{id: event.keys.id})
                 |SET n = event.properties
                 |SET n += event.keys
@@ -90,11 +95,12 @@ class NodePatternIngestionStrategyTest {
         assertEquals(emptyList(), strategy.mergeRelationshipEvents(events))
     }
 
-    @Test
-    fun `should include nested properties`() {
+    @ParameterizedTest
+    @ArgumentsSource(SupportedVersionsProvider::class)
+    fun `should include nested properties`(neo4j: Neo4j, expectedPrefix: String) {
         // given
         val config = NodePatternConfiguration.parse("(:LabelA:LabelB{!id, foo})", true)
-        val strategy = NodePatternIngestionStrategy(config)
+        val strategy = NodePatternIngestionStrategy(neo4j, config)
         val data = mapOf("id" to 1, "foo" to mapOf("bar" to "bar", "foobar" to "foobar"), "prop" to 100)
 
         // when
@@ -104,7 +110,7 @@ class NodePatternIngestionStrategyTest {
         // then
         assertEquals(1, queryEvents.size)
         assertEquals("""
-                |${StreamsUtils.UNWIND}
+                |${expectedPrefix}${StreamsUtils.UNWIND}
                 |MERGE (n:LabelA:LabelB{id: event.keys.id})
                 |SET n += event.properties
                 |SET n += event.keys
@@ -118,11 +124,12 @@ class NodePatternIngestionStrategyTest {
         assertEquals(emptyList(), strategy.mergeRelationshipEvents(events))
     }
 
-    @Test
-    fun `should exclude the properties`() {
+    @ParameterizedTest
+    @ArgumentsSource(SupportedVersionsProvider::class)
+    fun `should exclude the properties`(neo4j: Neo4j, expectedPrefix: String) {
         // given
         val config = NodePatternConfiguration.parse("(:LabelA:LabelB{!id,-foo,-bar})", false)
-        val strategy = NodePatternIngestionStrategy(config)
+        val strategy = NodePatternIngestionStrategy(neo4j, config)
         val data = mapOf("id" to 1, "foo" to "foo", "bar" to "bar", "foobar" to "foobar")
 
         // when
@@ -132,7 +139,7 @@ class NodePatternIngestionStrategyTest {
         // then
         assertEquals(1, queryEvents.size)
         assertEquals("""
-                |${StreamsUtils.UNWIND}
+                |${expectedPrefix}${StreamsUtils.UNWIND}
                 |MERGE (n:LabelA:LabelB{id: event.keys.id})
                 |SET n = event.properties
                 |SET n += event.keys
@@ -143,11 +150,12 @@ class NodePatternIngestionStrategyTest {
         assertEquals(emptyList(), strategy.mergeRelationshipEvents(events))
     }
 
-    @Test
-    fun `should include the properties`() {
+    @ParameterizedTest
+    @ArgumentsSource(SupportedVersionsProvider::class)
+    fun `should include the properties`(neo4j: Neo4j, expectedPrefix: String) {
         // given
         val config = NodePatternConfiguration.parse("(:LabelA:LabelB{!id,foo,bar})", false)
-        val strategy = NodePatternIngestionStrategy(config)
+        val strategy = NodePatternIngestionStrategy(neo4j, config)
         val data = mapOf("id" to 1, "foo" to "foo", "bar" to "bar", "foobar" to "foobar")
 
         // when
@@ -156,7 +164,7 @@ class NodePatternIngestionStrategyTest {
 
         // then
         assertEquals("""
-                |${StreamsUtils.UNWIND}
+                |${expectedPrefix}${StreamsUtils.UNWIND}
                 |MERGE (n:LabelA:LabelB{id: event.keys.id})
                 |SET n = event.properties
                 |SET n += event.keys
@@ -167,11 +175,12 @@ class NodePatternIngestionStrategyTest {
         assertEquals(emptyList(), strategy.mergeRelationshipEvents(events))
     }
 
-    @Test
-    fun `should delete the node`() {
+    @ParameterizedTest
+    @ArgumentsSource(SupportedVersionsProvider::class)
+    fun `should delete the node`(neo4j: Neo4j, expectedPrefix: String) {
         // given
         val config = NodePatternConfiguration.parse("(:LabelA:LabelB{!id})", true)
-        val strategy = NodePatternIngestionStrategy(config)
+        val strategy = NodePatternIngestionStrategy(neo4j, config)
         val data = mapOf("id" to 1, "foo" to "foo", "bar" to "bar", "foobar" to "foobar")
 
         // when
@@ -180,7 +189,7 @@ class NodePatternIngestionStrategyTest {
 
         // then
         assertEquals("""
-                |${StreamsUtils.UNWIND}
+                |${expectedPrefix}${StreamsUtils.UNWIND}
                 |MATCH (n:LabelA:LabelB{id: event.keys.id})
                 |DETACH DELETE n
             """.trimMargin(), queryEvents[0].query)

--- a/common/src/test/kotlin/streams/service/sink/strategy/RelationshipPatternIngestionStrategyTest.kt
+++ b/common/src/test/kotlin/streams/service/sink/strategy/RelationshipPatternIngestionStrategyTest.kt
@@ -1,20 +1,23 @@
 package streams.service.sink.strategy
 
-import org.junit.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ArgumentsSource
+import org.neo4j.caniuse.Neo4j
 import streams.service.StreamsSinkEntity
 import streams.utils.StreamsUtils
 import kotlin.test.assertEquals
 
 class RelationshipPatternIngestionStrategyTest {
 
-    @Test
-    fun `should get all properties`() {
+    @ParameterizedTest
+    @ArgumentsSource(SupportedVersionsProvider::class)
+    fun `should get all properties`(neo4j: Neo4j, expectedPrefix: String) {
         // given
         val startPattern = "LabelA{!idStart}"
         val endPattern = "LabelB{!idEnd}"
         val pattern = "(:$startPattern)-[:REL_TYPE]->(:$endPattern)"
         val config = RelationshipPatternConfiguration.parse(pattern, mergeNodeProps = false, mergeRelProps = true)
-        val strategy = RelationshipPatternIngestionStrategy(config)
+        val strategy = RelationshipPatternIngestionStrategy(neo4j, config)
         val data = mapOf("idStart" to 1, "idEnd" to 2,
                 "foo" to "foo",
                 "bar" to "bar")
@@ -26,7 +29,7 @@ class RelationshipPatternIngestionStrategyTest {
         // then
         assertEquals(1, queryEvents.size)
         assertEquals("""
-            |${StreamsUtils.UNWIND}
+            |${expectedPrefix}${StreamsUtils.UNWIND}
             |MERGE (start:LabelA{idStart: event.start.keys.idStart})
             |SET start += event.start.properties
             |SET start += event.start.keys
@@ -44,14 +47,15 @@ class RelationshipPatternIngestionStrategyTest {
         assertEquals(emptyList(), strategy.mergeNodeEvents(events))
     }
 
-    @Test
-    fun `should get all properties - simple`() {
+    @ParameterizedTest
+    @ArgumentsSource(SupportedVersionsProvider::class)
+    fun `should get all properties - simple`(neo4j: Neo4j, expectedPrefix: String) {
         // given
         val startPattern = "LabelA{!idStart}"
         val endPattern = "LabelB{!idEnd}"
         val pattern = "$startPattern REL_TYPE $endPattern"
         val config = RelationshipPatternConfiguration.parse(pattern, mergeNodeProps = false, mergeRelProps = false)
-        val strategy = RelationshipPatternIngestionStrategy(config)
+        val strategy = RelationshipPatternIngestionStrategy(neo4j, config)
         val data = mapOf("idStart" to 1, "idEnd" to 2,
                 "foo" to "foo",
                 "bar" to "bar")
@@ -63,7 +67,7 @@ class RelationshipPatternIngestionStrategyTest {
         // then
         assertEquals(1, queryEvents.size)
         assertEquals("""
-            |${StreamsUtils.UNWIND}
+            |${expectedPrefix}${StreamsUtils.UNWIND}
             |MERGE (start:LabelA{idStart: event.start.keys.idStart})
             |SET start = event.start.properties
             |SET start += event.start.keys
@@ -81,14 +85,15 @@ class RelationshipPatternIngestionStrategyTest {
         assertEquals(emptyList(), strategy.mergeNodeEvents(events))
     }
 
-    @Test
-    fun `should get all properties with reverse start-end`() {
+    @ParameterizedTest
+    @ArgumentsSource(SupportedVersionsProvider::class)
+    fun `should get all properties with reverse start-end`(neo4j: Neo4j, expectedPrefix: String) {
         // given
         val startPattern = "LabelA{!idStart}"
         val endPattern = "LabelB{!idEnd}"
         val pattern = "(:$endPattern)<-[:REL_TYPE]-(:$startPattern)"
         val config = RelationshipPatternConfiguration.parse(pattern, mergeNodeProps = false, mergeRelProps = false)
-        val strategy = RelationshipPatternIngestionStrategy(config)
+        val strategy = RelationshipPatternIngestionStrategy(neo4j, config)
         val data = mapOf("idStart" to 1, "idEnd" to 2,
                 "foo" to "foo",
                 "bar" to "bar")
@@ -100,7 +105,7 @@ class RelationshipPatternIngestionStrategyTest {
         // then
         assertEquals(1, queryEvents.size)
         assertEquals("""
-            |${StreamsUtils.UNWIND}
+            |${expectedPrefix}${StreamsUtils.UNWIND}
             |MERGE (start:LabelA{idStart: event.start.keys.idStart})
             |SET start = event.start.properties
             |SET start += event.start.keys
@@ -118,14 +123,15 @@ class RelationshipPatternIngestionStrategyTest {
         assertEquals(emptyList(), strategy.mergeNodeEvents(events))
     }
 
-    @Test
-    fun `should get nested properties`() {
+    @ParameterizedTest
+    @ArgumentsSource(SupportedVersionsProvider::class)
+    fun `should get nested properties`(neo4j: Neo4j, expectedPrefix: String) {
         // given
         val startPattern = "LabelA{!idStart, foo.mapFoo}"
         val endPattern = "LabelB{!idEnd, bar.mapBar}"
         val pattern = "(:$startPattern)-[:REL_TYPE]->(:$endPattern)"
         val config = RelationshipPatternConfiguration.parse(pattern, mergeNodeProps = false, mergeRelProps = true)
-        val strategy = RelationshipPatternIngestionStrategy(config)
+        val strategy = RelationshipPatternIngestionStrategy(neo4j, config)
         val data = mapOf("idStart" to 1, "idEnd" to 2,
                 "foo" to mapOf("mapFoo" to "mapFoo"),
                 "bar" to mapOf("mapBar" to "mapBar"),
@@ -139,7 +145,7 @@ class RelationshipPatternIngestionStrategyTest {
         // then
         assertEquals(1, queryEvents.size)
         assertEquals("""
-            |${StreamsUtils.UNWIND}
+            |${expectedPrefix}${StreamsUtils.UNWIND}
             |MERGE (start:LabelA{idStart: event.start.keys.idStart})
             |SET start += event.start.properties
             |SET start += event.start.keys
@@ -159,14 +165,15 @@ class RelationshipPatternIngestionStrategyTest {
         assertEquals(emptyList(), strategy.mergeNodeEvents(events))
     }
 
-    @Test
-    fun `should delete the relationship`() {
+    @ParameterizedTest
+    @ArgumentsSource(SupportedVersionsProvider::class)
+    fun `should delete the relationship`(neo4j: Neo4j, expectedPrefix: String) {
         // given
         val startPattern = "LabelA{!idStart}"
         val endPattern = "LabelB{!idEnd}"
         val pattern = "(:$startPattern)-[:REL_TYPE]->(:$endPattern)"
         val config = RelationshipPatternConfiguration.parse(pattern, mergeNodeProps = false, mergeRelProps = false)
-        val strategy = RelationshipPatternIngestionStrategy(config)
+        val strategy = RelationshipPatternIngestionStrategy(neo4j, config)
         val data = mapOf("idStart" to 1, "idEnd" to 2,
                 "foo" to "foo",
                 "bar" to "bar")
@@ -178,7 +185,7 @@ class RelationshipPatternIngestionStrategyTest {
         // then
         assertEquals(1, queryEvents.size)
         assertEquals("""
-            |${StreamsUtils.UNWIND}
+            |${expectedPrefix}${StreamsUtils.UNWIND}
             |MATCH (start:LabelA{idStart: event.start.keys.idStart})
             |MATCH (end:LabelB{idEnd: event.end.keys.idEnd})
             |MATCH (start)-[r:REL_TYPE]->(end)

--- a/kafka-connect-neo4j/doc/docker-compose.yml
+++ b/kafka-connect-neo4j/doc/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       NEO4J_server_memory_heap_max__size: "4G"
 
   zookeeper:
-    image: confluentinc/cp-zookeeper:7.3.0
+    image: confluentinc/cp-zookeeper:7.8.1
     hostname: zookeeper
     container_name: zookeeper
     ports:
@@ -23,7 +23,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   broker:
-    image: confluentinc/cp-server:7.3.0
+    image: confluentinc/cp-server:7.8.1
     hostname: broker
     container_name: broker
     depends_on:
@@ -52,7 +52,7 @@ services:
       CONFLUENT_SUPPORT_CUSTOMER_ID: 'anonymous'
 
   schema-registry:
-    image: confluentinc/cp-schema-registry:7.3.0
+    image: confluentinc/cp-schema-registry:7.8.1
     hostname: schema-registry
     container_name: schema-registry
     depends_on:
@@ -65,7 +65,7 @@ services:
       SCHEMA_REGISTRY_LISTENERS: http://0.0.0.0:8081
 
   connect:
-    image: confluentinc/cp-server-connect:7.3.0
+    image: confluentinc/cp-server-connect:7.8.1
     hostname: connect
     container_name: connect
     depends_on:
@@ -90,7 +90,7 @@ services:
       CONNECT_VALUE_CONVERTER: io.confluent.connect.avro.AvroConverter
       CONNECT_VALUE_CONVERTER_SCHEMA_REGISTRY_URL: http://schema-registry:8081
       # CLASSPATH required due to CC-2422
-      CLASSPATH: /usr/share/java/monitoring-interceptors/monitoring-interceptors-7.3.0.jar
+      CLASSPATH: /usr/share/java/monitoring-interceptors/monitoring-interceptors-7.8.1.jar
       CONNECT_PRODUCER_INTERCEPTOR_CLASSES: "io.confluent.monitoring.clients.interceptor.MonitoringProducerInterceptor"
       CONNECT_CONSUMER_INTERCEPTOR_CLASSES: "io.confluent.monitoring.clients.interceptor.MonitoringConsumerInterceptor"
       CONNECT_PLUGIN_PATH: "/usr/share/java,/usr/share/confluent-hub-components,/tmp/connect-plugins"
@@ -102,7 +102,7 @@ services:
       /etc/confluent/docker/run
 
   control-center:
-    image: confluentinc/cp-enterprise-control-center:7.3.0
+    image: confluentinc/cp-enterprise-control-center:7.8.1
     hostname: control-center
     container_name: control-center
     depends_on:
@@ -114,8 +114,6 @@ services:
     environment:
       CONTROL_CENTER_BOOTSTRAP_SERVERS: 'broker:29092'
       CONTROL_CENTER_CONNECT_CONNECT-DEFAULT_CLUSTER: 'connect:8083'
-      CONTROL_CENTER_KSQL_KSQLDB1_URL: "http://ksqldb-server:8088"
-      CONTROL_CENTER_KSQL_KSQLDB1_ADVERTISED_URL: "http://localhost:8088"
       CONTROL_CENTER_SCHEMA_REGISTRY_URL: "http://schema-registry:8081"
       CONTROL_CENTER_REPLICATION_FACTOR: 1
       CONTROL_CENTER_INTERNAL_TOPICS_PARTITIONS: 1

--- a/kafka-connect-neo4j/docker/docker-compose.yml
+++ b/kafka-connect-neo4j/docker/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       NEO4J_server_memory_heap_max__size: "4G"
 
   zookeeper:
-    image: confluentinc/cp-zookeeper:7.3.0
+    image: confluentinc/cp-zookeeper:7.8.1
     hostname: zookeeper
     container_name: zookeeper
     ports:
@@ -23,7 +23,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   broker:
-    image: confluentinc/cp-server:7.3.0
+    image: confluentinc/cp-server:7.8.1
     hostname: broker
     container_name: broker
     depends_on:
@@ -52,7 +52,7 @@ services:
       CONFLUENT_SUPPORT_CUSTOMER_ID: 'anonymous'
 
   schema-registry:
-    image: confluentinc/cp-schema-registry:7.3.0
+    image: confluentinc/cp-schema-registry:7.8.1
     hostname: schema-registry
     container_name: schema-registry
     depends_on:
@@ -65,7 +65,7 @@ services:
       SCHEMA_REGISTRY_LISTENERS: http://0.0.0.0:8081
 
   connect:
-    image: confluentinc/cp-server-connect:7.3.0
+    image: confluentinc/cp-server-connect:7.8.1
     hostname: connect
     container_name: connect
     depends_on:
@@ -90,19 +90,19 @@ services:
       CONNECT_VALUE_CONVERTER: io.confluent.connect.avro.AvroConverter
       CONNECT_VALUE_CONVERTER_SCHEMA_REGISTRY_URL: http://schema-registry:8081
       # CLASSPATH required due to CC-2422
-      CLASSPATH: /usr/share/java/monitoring-interceptors/monitoring-interceptors-7.3.0.jar
+      CLASSPATH: /usr/share/java/monitoring-interceptors/monitoring-interceptors-7.8.1.jar
       CONNECT_PRODUCER_INTERCEPTOR_CLASSES: "io.confluent.monitoring.clients.interceptor.MonitoringProducerInterceptor"
       CONNECT_CONSUMER_INTERCEPTOR_CLASSES: "io.confluent.monitoring.clients.interceptor.MonitoringConsumerInterceptor"
       CONNECT_PLUGIN_PATH: "/usr/share/java,/usr/share/confluent-hub-components,/tmp/connect-plugins"
       CONNECT_LOG4J_LOGGERS: org.apache.zookeeper=ERROR,org.I0Itec.zkclient=ERROR,org.reflections=ERROR
     command:
-#      - bash
-#      - -c
-#      - |
-        /etc/confluent/docker/run
+      #      - bash
+      #      - -c
+      #      - |
+      /etc/confluent/docker/run
 
   control-center:
-    image: confluentinc/cp-enterprise-control-center:7.3.0
+    image: confluentinc/cp-enterprise-control-center:7.8.1
     hostname: control-center
     container_name: control-center
     depends_on:
@@ -114,8 +114,6 @@ services:
     environment:
       CONTROL_CENTER_BOOTSTRAP_SERVERS: 'broker:29092'
       CONTROL_CENTER_CONNECT_CONNECT-DEFAULT_CLUSTER: 'connect:8083'
-      CONTROL_CENTER_KSQL_KSQLDB1_URL: "http://ksqldb-server:8088"
-      CONTROL_CENTER_KSQL_KSQLDB1_ADVERTISED_URL: "http://localhost:8088"
       CONTROL_CENTER_SCHEMA_REGISTRY_URL: "http://schema-registry:8081"
       CONTROL_CENTER_REPLICATION_FACTOR: 1
       CONTROL_CENTER_INTERNAL_TOPICS_PARTITIONS: 1

--- a/kafka-connect-neo4j/pom.xml
+++ b/kafka-connect-neo4j/pom.xml
@@ -31,6 +31,14 @@
         </dependency>
         <dependency>
             <groupId>org.neo4j</groupId>
+            <artifactId>caniuse-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.neo4j</groupId>
+            <artifactId>caniuse-neo4j-detection</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.neo4j</groupId>
             <artifactId>neo4j-streams-common</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/kafka-connect-neo4j/src/main/kotlin/streams/kafka/connect/utils/Topics.kt
+++ b/kafka-connect-neo4j/src/main/kotlin/streams/kafka/connect/utils/Topics.kt
@@ -1,48 +1,58 @@
 package streams.service
 
+import org.neo4j.caniuse.Neo4j
 import streams.kafka.connect.sink.Neo4jSinkConnectorConfig
 import streams.service.sink.strategy.*
 import java.util.Locale
 import kotlin.reflect.jvm.javaType
 
 private fun TopicType.replaceKeyBy(replacePrefix: Pair<String, String>) = if (replacePrefix.first.isNullOrBlank())
-        this.key
-    else
-        this.key.replace(replacePrefix.first, replacePrefix.second)
+    this.key
+else
+    this.key.replace(replacePrefix.first, replacePrefix.second)
 
-data class Topics(val cypherTopics: Map<String, String> = emptyMap(),
-                  val cdcSourceIdTopics: Pair<Set<String>, SourceIdIngestionStrategyConfig> = (emptySet<String>() to SourceIdIngestionStrategyConfig()),
-                  val cdcSchemaTopics: Set<String> = emptySet(),
-                  val cudTopics: Set<String> = emptySet(),
-                  val nodePatternTopics: Map<String, NodePatternConfiguration> = emptyMap(),
-                  val relPatternTopics: Map<String, RelationshipPatternConfiguration> = emptyMap(),
-                  val invalid: List<String> = emptyList()) {
+data class Topics(
+    val cypherTopics: Map<String, String> = emptyMap(),
+    val cdcSourceIdTopics: Pair<Set<String>, SourceIdIngestionStrategyConfig> = (emptySet<String>() to SourceIdIngestionStrategyConfig()),
+    val cdcSchemaTopics: Set<String> = emptySet(),
+    val cudTopics: Set<String> = emptySet(),
+    val nodePatternTopics: Map<String, NodePatternConfiguration> = emptyMap(),
+    val relPatternTopics: Map<String, RelationshipPatternConfiguration> = emptyMap(),
+    val invalid: List<String> = emptyList()
+) {
 
     fun allTopics(): List<String> = this.asMap()
-            .map {
-                when (it.key.group) {
-                    TopicTypeGroup.CDC, TopicTypeGroup.CUD -> if (it.key != TopicType.CDC_SOURCE_ID) {
-                        (it.value as Set<String>).toList()
-                    } else {
-                        (it.value as Pair<Set<String>, SourceIdIngestionStrategyConfig>).first
-                    }
-                    else -> (it.value as Map<String, Any>).keys.toList()
+        .map {
+            when (it.key.group) {
+                TopicTypeGroup.CDC, TopicTypeGroup.CUD -> if (it.key != TopicType.CDC_SOURCE_ID) {
+                    (it.value as Set<String>).toList()
+                } else {
+                    (it.value as Pair<Set<String>, SourceIdIngestionStrategyConfig>).first
                 }
-            }
-            .flatten()
 
-    fun asMap(): Map<TopicType, Any> = mapOf(TopicType.CYPHER to cypherTopics, TopicType.CUD to cudTopics,
-            TopicType.CDC_SCHEMA to cdcSchemaTopics, TopicType.CDC_SOURCE_ID to cdcSourceIdTopics,
-            TopicType.PATTERN_NODE to nodePatternTopics, TopicType.PATTERN_RELATIONSHIP to relPatternTopics)
+                else -> (it.value as Map<String, Any>).keys.toList()
+            }
+        }
+        .flatten()
+
+    fun asMap(): Map<TopicType, Any> = mapOf(
+        TopicType.CYPHER to cypherTopics, TopicType.CUD to cudTopics,
+        TopicType.CDC_SCHEMA to cdcSchemaTopics, TopicType.CDC_SOURCE_ID to cdcSourceIdTopics,
+        TopicType.PATTERN_NODE to nodePatternTopics, TopicType.PATTERN_RELATIONSHIP to relPatternTopics
+    )
 
     companion object {
-        fun from(map: Map<String, Any?>,
-                 replacePrefix: Pair<String, String> = ("" to ""),
-                 dbName: String = "",
-                 invalidTopics: List<String> = emptyList()): Topics {
+        fun from(
+            map: Map<String, Any?>,
+            replacePrefix: Pair<String, String> = ("" to ""),
+            dbName: String = "",
+            invalidTopics: List<String> = emptyList()
+        ): Topics {
             val config = map
-                    .filterKeys { if (dbName.isNotBlank()) it.lowercase(Locale.ROOT).endsWith(".to.$dbName") else !it.contains(".to.") }
-                    .mapKeys { if (dbName.isNotBlank()) it.key.replace(".to.$dbName", "", true) else it.key }
+                .filterKeys {
+                    if (dbName.isNotBlank()) it.lowercase(Locale.ROOT).endsWith(".to.$dbName") else !it.contains(".to.")
+                }
+                .mapKeys { if (dbName.isNotBlank()) it.key.replace(".to.$dbName", "", true) else it.key }
             val cypherTopicPrefix = TopicType.CYPHER.replaceKeyBy(replacePrefix)
             val sourceIdKey = TopicType.CDC_SOURCE_ID.replaceKeyBy(replacePrefix)
             val schemaKey = TopicType.CDC_SCHEMA.replaceKeyBy(replacePrefix)
@@ -57,33 +67,52 @@ data class Topics(val cypherTopics: Map<String, String> = emptyMap(),
                 .toString()
                 .toBoolean()
             val nodePatternTopics = TopicUtils
-                    .filterByPrefix(config, nodePatterKey, invalidTopics)
-                    .mapValues { NodePatternConfiguration.parse(it.value,mergeNodeProperties) }
+                .filterByPrefix(config, nodePatterKey, invalidTopics)
+                .mapValues { NodePatternConfiguration.parse(it.value, mergeNodeProperties) }
             val relPatternTopics = TopicUtils
-                    .filterByPrefix(config, relPatterKey, invalidTopics)
-                    .mapValues { RelationshipPatternConfiguration.parse(it.value, mergeNodeProperties, mergeRelProperties) }
+                .filterByPrefix(config, relPatterKey, invalidTopics)
+                .mapValues { RelationshipPatternConfiguration.parse(it.value, mergeNodeProperties, mergeRelProperties) }
             val cdcSourceIdTopics = TopicUtils.splitTopics(config[sourceIdKey] as? String, invalidTopics)
             val cdcSchemaTopics = TopicUtils.splitTopics(config[schemaKey] as? String, invalidTopics)
             val cudTopics = TopicUtils.splitTopics(config[cudKey] as? String, invalidTopics)
             val sourceIdStrategyConfig = SourceIdIngestionStrategyConfig(
-                map.getOrDefault(Neo4jSinkConnectorConfig.TOPIC_CDC_SOURCE_ID_LABEL_NAME, SourceIdIngestionStrategyConfig.DEFAULT.labelName).toString(),
-                map.getOrDefault(Neo4jSinkConnectorConfig.TOPIC_CDC_SOURCE_ID_ID_NAME, SourceIdIngestionStrategyConfig.DEFAULT.idName).toString())
-            return Topics(cypherTopics, (cdcSourceIdTopics to sourceIdStrategyConfig), cdcSchemaTopics, cudTopics, nodePatternTopics, relPatternTopics)
+                map.getOrDefault(
+                    Neo4jSinkConnectorConfig.TOPIC_CDC_SOURCE_ID_LABEL_NAME,
+                    SourceIdIngestionStrategyConfig.DEFAULT.labelName
+                ).toString(),
+                map.getOrDefault(
+                    Neo4jSinkConnectorConfig.TOPIC_CDC_SOURCE_ID_ID_NAME,
+                    SourceIdIngestionStrategyConfig.DEFAULT.idName
+                ).toString()
+            )
+            return Topics(
+                cypherTopics,
+                (cdcSourceIdTopics to sourceIdStrategyConfig),
+                cdcSchemaTopics,
+                cudTopics,
+                nodePatternTopics,
+                relPatternTopics
+            )
         }
     }
 }
 
 object TopicUtils {
 
-    @JvmStatic val TOPIC_SEPARATOR = ";"
+    @JvmStatic
+    val TOPIC_SEPARATOR = ";"
 
-    fun filterByPrefix(config: Map<*, *>, prefix: String, invalidTopics: List<String> = emptyList()): Map<String, String> {
+    fun filterByPrefix(
+        config: Map<*, *>,
+        prefix: String,
+        invalidTopics: List<String> = emptyList()
+    ): Map<String, String> {
         val fullPrefix = "$prefix."
         return config
-                .filterKeys { it.toString().startsWith(fullPrefix) }
-                .mapKeys { it.key.toString().replace(fullPrefix, "") }
-                .filterKeys { !invalidTopics.contains(it) }
-                .mapValues { it.value.toString() }
+            .filterKeys { it.toString().startsWith(fullPrefix) }
+            .mapKeys { it.key.toString().replace(fullPrefix, "") }
+            .filterKeys { !invalidTopics.contains(it) }
+            .mapValues { it.value.toString() }
     }
 
     fun splitTopics(cdcMergeTopicsString: String?, invalidTopics: List<String> = emptyList()): Set<String> {
@@ -91,45 +120,48 @@ object TopicUtils {
             emptySet()
         } else {
             cdcMergeTopicsString.split(TOPIC_SEPARATOR)
-                    .filter { !invalidTopics.contains(it) }
-                    .toSet()
+                .filter { !invalidTopics.contains(it) }
+                .toSet()
         }
     }
 
-    inline fun <reified T: Throwable> validate(topics: Topics) {
+    inline fun <reified T : Throwable> validate(topics: Topics) {
         val exceptionStringConstructor = T::class.constructors
-                .first { it.parameters.size == 1 && it.parameters[0].type.javaType == String::class.java }!!
+            .first { it.parameters.size == 1 && it.parameters[0].type.javaType == String::class.java }!!
         val crossDefinedTopics = topics.allTopics()
-                .groupBy({ it }, { 1 })
-                .filterValues { it.sum() > 1 }
-                .keys
+            .groupBy({ it }, { 1 })
+            .filterValues { it.sum() > 1 }
+            .keys
         if (crossDefinedTopics.isNotEmpty()) {
             throw exceptionStringConstructor
-                    .call("The following topics are cross defined: $crossDefinedTopics")
+                .call("The following topics are cross defined: $crossDefinedTopics")
         }
     }
 
-    fun toStrategyMap(topics: Topics): Map<TopicType, Any> {
+    fun toStrategyMap(topics: Topics, neo4j: Neo4j): Map<TopicType, Any> {
         return topics.asMap()
-                .filterKeys { it != TopicType.CYPHER }
-                .mapValues { (type, config) ->
-                    when (type) {
-                        TopicType.CDC_SOURCE_ID -> {
-                            val (topics, sourceIdStrategyConfig) = (config as Pair<Set<String>, SourceIdIngestionStrategyConfig>)
-                            SourceIdIngestionStrategy(sourceIdStrategyConfig)
-                        }
-                        TopicType.CDC_SCHEMA -> SchemaIngestionStrategy()
-                        TopicType.CUD -> CUDIngestionStrategy()
-                        TopicType.PATTERN_NODE -> {
-                            val map = config as Map<String, NodePatternConfiguration>
-                            map.mapValues { NodePatternIngestionStrategy(it.value) }
-                        }
-                        TopicType.PATTERN_RELATIONSHIP -> {
-                            val map = config as Map<String, RelationshipPatternConfiguration>
-                            map.mapValues { RelationshipPatternIngestionStrategy(it.value) }
-                        }
-                        else -> throw RuntimeException("Unsupported topic type $type")
+            .filterKeys { it != TopicType.CYPHER }
+            .mapValues { (type, config) ->
+                when (type) {
+                    TopicType.CDC_SOURCE_ID -> {
+                        val (topics, sourceIdStrategyConfig) = (config as Pair<Set<String>, SourceIdIngestionStrategyConfig>)
+                        SourceIdIngestionStrategy(neo4j, sourceIdStrategyConfig)
                     }
+
+                    TopicType.CDC_SCHEMA -> SchemaIngestionStrategy(neo4j)
+                    TopicType.CUD -> CUDIngestionStrategy(neo4j)
+                    TopicType.PATTERN_NODE -> {
+                        val map = config as Map<String, NodePatternConfiguration>
+                        map.mapValues { NodePatternIngestionStrategy(neo4j, it.value) }
+                    }
+
+                    TopicType.PATTERN_RELATIONSHIP -> {
+                        val map = config as Map<String, RelationshipPatternConfiguration>
+                        map.mapValues { RelationshipPatternIngestionStrategy(neo4j, it.value) }
+                    }
+
+                    else -> throw RuntimeException("Unsupported topic type $type")
                 }
+            }
     }
 }

--- a/kafka-connect-neo4j/src/test/kotlin/streams/kafka/connect/sink/Neo4jSinkTaskTest.kt
+++ b/kafka-connect-neo4j/src/test/kotlin/streams/kafka/connect/sink/Neo4jSinkTaskTest.kt
@@ -60,9 +60,9 @@ class Neo4jSinkTaskTest {
         @AfterClass
         @JvmStatic
         fun tearDownContainer() {
-            driver.let { StreamsUtils.closeSafetely(it) }
-            session.let { StreamsUtils.closeSafetely(it) }
-            StreamsUtils.closeSafetely(neo4j)
+            driver.let { StreamsUtils.closeSafely(it) }
+            session.let { StreamsUtils.closeSafely(it) }
+            StreamsUtils.closeSafely(neo4j)
         }
     }
 

--- a/kafka-connect-neo4j/src/test/kotlin/streams/kafka/connect/source/Neo4jSourceTaskTest.kt
+++ b/kafka-connect-neo4j/src/test/kotlin/streams/kafka/connect/source/Neo4jSourceTaskTest.kt
@@ -46,9 +46,9 @@ class Neo4jSourceTaskTest {
         @AfterClass
         @JvmStatic
         fun tearDownContainer() {
-            driver.let { StreamsUtils.closeSafetely(it) }
-            session.let { StreamsUtils.closeSafetely(it) }
-            StreamsUtils.closeSafetely(neo4j)
+            driver.let { StreamsUtils.closeSafely(it) }
+            session.let { StreamsUtils.closeSafely(it) }
+            StreamsUtils.closeSafely(neo4j)
         }
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,7 @@
     <properties>
         <annotations.version>26.0.2</annotations.version>
         <awaitility.version>4.2.2</awaitility.version>
+        <caniuse-core.version>1.0.0</caniuse-core.version>
         <commons-compress.version>1.27.1</commons-compress.version>
         <commons-lang3.version>3.17.0</commons-lang3.version>
         <connect-utils.version>1.0.3</connect-utils.version>
@@ -105,6 +106,13 @@
                 <scope>import</scope>
             </dependency>
             <dependency>
+                <groupId>org.junit</groupId>
+                <artifactId>junit-bom</artifactId>
+                <version>${junit-jupiter.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-bom</artifactId>
                 <version>${mockito.version}</version>
@@ -162,6 +170,16 @@
                 <groupId>org.jetbrains</groupId>
                 <artifactId>annotations</artifactId>
                 <version>${annotations.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.neo4j</groupId>
+                <artifactId>caniuse-core</artifactId>
+                <version>${caniuse-core.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.neo4j</groupId>
+                <artifactId>caniuse-neo4j-detection</artifactId>
+                <version>${caniuse-core.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.neo4j.driver</groupId>


### PR DESCRIPTION
This PR switches to caniuse library and starts prefixing generated cypher statements with `CYPHER 5` on supported versions.