### PR TITLE
build: upgrade kafka library

### DIFF
--- a/common/src/test/kotlin/streams/service/sink/errors/KafkaErrorServiceTest.kt
+++ b/common/src/test/kotlin/streams/service/sink/errors/KafkaErrorServiceTest.kt
@@ -5,7 +5,7 @@ import org.apache.kafka.clients.producer.MockProducer
 import org.apache.kafka.clients.producer.ProducerRecord
 import org.apache.kafka.clients.producer.internals.FutureRecordMetadata
 import org.apache.kafka.common.record.RecordBatch
-import org.apache.kafka.common.utils.SystemTime
+import org.apache.kafka.common.utils.Time
 import org.junit.Test
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito
@@ -24,7 +24,7 @@ class KafkaErrorServiceTest {
         val counter = AtomicInteger(0)
         Mockito.`when`(producer.send(ArgumentMatchers.any<ProducerRecord<ByteArray, ByteArray>>())).then {
             counter.incrementAndGet()
-            FutureRecordMetadata(null, 0, RecordBatch.NO_TIMESTAMP, 0, 0, SystemTime())
+            FutureRecordMetadata(null, 0, RecordBatch.NO_TIMESTAMP, 0, 0, Time.SYSTEM)
         }
         val dlqService = KafkaErrorService(producer, ErrorService.ErrorConfig(fail=false,dlqTopic = "dlqTopic"), { s, e -> })
         dlqService.report(listOf(dlqData()))

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
         <junit-jupiter.version>5.13.1</junit-jupiter.version>
         <junit.version>4.13.2</junit.version>
         <kafka-connect-maven-plugin.version>0.12.0</kafka-connect-maven-plugin.version>
-        <kafka.version>3.8.1</kafka.version>
+        <kafka.version>3.9.1</kafka.version>
         <kotlin.compiler.incremental>true</kotlin.compiler.incremental>
         <kotlin.coroutines.version>1.10.2</kotlin.coroutines.version>
         <kotlin.version>2.1.21</kotlin.version>


### PR DESCRIPTION
This PR upgrades kafka-clients library to 3.9.1.