### PR TITLE
ci: add semgrep check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,10 @@ jobs:
         neo4j-image: [ "neo4j:4.4", "neo4j:4.4-enterprise", "neo4j:5", "neo4j:5-enterprise", "neo4j:2025", "neo4j:2025-enterprise" ]
     name: Build and test with ${{ matrix.neo4j-image }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8   # v6.0.1
 
       - name: Set up Java
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@f2beeb24e141e01a676f977032f5a29d81c9e27e # v5.1.0
         with:
           distribution: temurin
           java-version: 11

--- a/.github/workflows/semgrep-check.yml
+++ b/.github/workflows/semgrep-check.yml
@@ -1,0 +1,57 @@
+name: Semgrep Check
+
+on:
+  workflow_dispatch:
+  pull_request:
+  schedule:
+    - cron: "0 7 * * *"
+
+jobs:
+  build-dependency-tree:
+    name: Build dependency tree
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8   # v6.0.1
+
+      - name: Set up Java
+        uses: actions/setup-java@f2beeb24e141e01a676f977032f5a29d81c9e27e # v5.1.0
+        with:
+          distribution: temurin
+          java-version: 11
+          cache: 'maven'
+
+      - name: Cleanup previous dependency tree files
+        run: find . -type f -name 'maven_dep_tree.txt' -exec rm {} +
+
+      - name: Build dependency tree
+        run: ./mvnw dependency:tree -DoutputFile=maven_dep_tree.txt
+
+      - name: Create Zip file
+        run: find . -type f -name 'maven_dep_tree.txt' -exec zip -r maven-dependency-trees.zip {} +
+
+      - name: Upload dependency zip file
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        with:
+          name: maven-dependency-trees
+          path: maven-dependency-trees.zip
+
+  semgrep-check:
+    name: Run Semgrep scan
+    runs-on: ubuntu-latest
+    needs: build-dependency-tree
+    env:
+      SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
+    container:
+      image: semgrep/semgrep:1.146.0
+    steps:
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8   # v6.0.1
+
+      - name: Download Maven dependency tree artifact
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          name: maven-dependency-trees
+      - name: Semgrep scan
+        run: |
+          unzip -o maven-dependency-trees.zip
+          semgrep ci --no-git-ignore         


### PR DESCRIPTION
This PR adds a Semgrep check to CI pipeline.

Key changes:

* Introduce a separate workflow to build maven dependency tree and perform Semgrep scan. Scan results are integrated with Semgrep UI and available in the scan history.
* Scans are performed on each pull request, every day at 7am UTC against main branch and could be triggered manually.
Note: --no-git-ignore file apparently required to both discover language rules and scan tree files correctly.
* Bumped all GitHub actions
* Switched to git SHA instead of tags for action versions. Going to enable Require actions to be pinned to a full-length commit SHA when merged.